### PR TITLE
Add Trace Appearance dialog and per-trace styling for 1D plots

### DIFF
--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -1,7 +1,9 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pyqtgraph as pg
 from PyQt6 import QtCore
+from PyQt6 import QtGui
 from PyQt6 import QtWidgets as qtw
 
 from ._subplots import subplot1d
@@ -38,6 +40,24 @@ else:
 
 
 class Plot1DTraceMixin(_Plot1DTraceBase):
+    @dataclass
+    class _TraceStyle:
+        line_enabled: bool = True
+        line_color: str = "#1f77b4"
+        line_width: float = 2.0
+        line_style: str = "Solid"
+        dots_enabled: bool = False
+        dots_color: str = "#1f77b4"
+        dots_size: float = 6.0
+        markers_enabled: bool = False
+        markers_color: str = "#1f77b4"
+        markers_symbol: str = "o"
+        markers_size: float = 10.0
+        x_axis: str = "Bottom"
+        y_axis: str = "Left"
+        visible: bool = True
+        order: int = 0
+
     """Trace controls and secondary-axis handling for 1D plot windows."""
 
     def _register_main_line(self) -> None:
@@ -47,6 +67,23 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         """
         if hasattr(self, "lines"):
             self.lines[self.label] = self.line
+        if not hasattr(self, "_trace_styles"):
+            self._trace_styles = {}
+        self._trace_styles.setdefault(self.label, self._TraceStyle())
+
+    def initMenu(self) -> None:
+        super().initMenu()
+        view_menu = None
+        for action in self.menuBar().actions():
+            if action.text().replace("&", "") == "View":
+                view_menu = action.menu()
+                break
+        if view_menu is None:
+            return
+        view_menu.addSeparator()
+        trace_action = qtw.QAction("Trace Appearance…", self)
+        trace_action.triggered.connect(self.open_trace_appearance_dialog)
+        view_menu.addAction(trace_action)
 
 
     def initAxes(self) -> None:
@@ -64,6 +101,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         self._register_main_line()
         self.option_boxes = []
         self.box_count = 1
+        self._trace_appearance_dialog = None
         
         # Produce scrollable widget to allow viewing of as many lines as needed
         self.lineScroll = qtw.QScrollArea()
@@ -92,6 +130,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             )
         self.box_layout.addWidget(main_line)
         main_line.adjustSize()
+        self._apply_trace_style(self.label, self.line)
         
         # Force to top
         self.box_layout.addStretch()
@@ -286,6 +325,10 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         # Set display
         subplot.set_color(selected_box.color_box.color())
         subplot.set_side(selected_box.axis_side.currentText().lower())
+        style = self._trace_styles.setdefault(label, self._TraceStyle(order=len(self._trace_styles)))
+        style.line_color = selected_box.color_box.color().name()
+        style.y_axis = "Right" if selected_box.axis_side.currentText().lower() == "right" else "Left"
+        self._apply_trace_style(label, subplot)
         
     
     @QtCore.pyqtSlot(bool)
@@ -323,6 +366,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         # Remove line from viewbox
         line = self.lines[label]
         self.lines.pop(label)
+        self._trace_styles.pop(label, None)
         # Fetch correct viewbox to remove from
         vb = self.plot if side.lower() == "left" else self.right_vb
         vb.removeItem(line)
@@ -357,12 +401,166 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             
         """
         self.right_vb.setGeometry(self.vb.sceneBoundingRect())
-        
-        # Find which event 
-        if ev.__class__.__name__ == "QGraphicsSceneWheelEvent":
-            self.right_vb.wheelEvent(ev)
-        elif ev.__class__.__name__ == "MouseDragEvent":
-            self.right_vb.mouseDragEvent(ev)
+        if ev is not None:
+            if ev.__class__.__name__ == "QGraphicsSceneWheelEvent":
+                self.right_vb.wheelEvent(ev)
+            elif ev.__class__.__name__ == "MouseDragEvent":
+                self.right_vb.mouseDragEvent(ev)
 
         # Prevents lines from moving outside the axes.
         self.right_vb.setGeometry(self.vb.sceneBoundingRect())
+
+    def open_trace_appearance_dialog(self) -> None:
+        if self._trace_appearance_dialog is None:
+            self._trace_appearance_dialog = _TraceAppearanceDialog(self)
+        self._trace_appearance_dialog.refresh_rows()
+        self._trace_appearance_dialog.show()
+        self._trace_appearance_dialog.raise_()
+        self._trace_appearance_dialog.activateWindow()
+
+    def _trace_measurement_name(self, label: str, line: Any) -> str:
+        if label == self.label:
+            return self.param.name
+        from_win = getattr(line, "from_win", None)
+        param = getattr(from_win, "param", None)
+        return getattr(param, "name", str(label))
+
+    def _apply_trace_style(self, label: str, line: Any) -> None:
+        style = self._trace_styles.setdefault(label, self._TraceStyle(order=len(self._trace_styles)))
+        pen_style_map = {
+            "Solid": QtCore.Qt.PenStyle.SolidLine,
+            "Dash": QtCore.Qt.PenStyle.DashLine,
+            "Dot": QtCore.Qt.PenStyle.DotLine,
+            "Dash Dot": QtCore.Qt.PenStyle.DashDotLine,
+        }
+        if style.line_enabled:
+            pen = pg.mkPen(
+                color=QtGui.QColor(style.line_color),
+                width=style.line_width,
+                style=pen_style_map.get(style.line_style, QtCore.Qt.PenStyle.SolidLine),
+            )
+        else:
+            pen = None
+        line.setPen(pen)
+        line.setSymbolPen(pg.mkPen(style.markers_color if style.markers_enabled else style.dots_color))
+        line.setSymbolBrush(
+            pg.mkBrush(style.markers_color if style.markers_enabled else style.dots_color)
+        )
+        line.setSymbolSize(style.markers_size if style.markers_enabled else style.dots_size)
+        line.setSymbol(style.markers_symbol if style.markers_enabled else ("o" if style.dots_enabled else None))
+        line.setVisible(style.visible)
+
+        target_side = "right" if style.y_axis == "Right" else "left"
+        current_side = getattr(line, "side", "left")
+        if hasattr(line, "set_side") and current_side != target_side:
+            line.set_side(target_side)
+
+        z = style.order
+        set_z = getattr(line, "setZValue", None)
+        if callable(set_z):
+            set_z(z)
+
+
+class _TraceAppearanceDialog(qtw.QDialog):
+    def __init__(self, owner: Plot1DTraceMixin):
+        super().__init__(owner)
+        self.owner = owner
+        self.setWindowTitle("Trace Appearance")
+        self.resize(980, 460)
+        self._building = False
+        main = qtw.QHBoxLayout(self)
+        self.table = qtw.QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels(["ID", "Preview", "Measurement", "Axis", "Order"])
+        self.table.setSelectionBehavior(qtw.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(qtw.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.table.verticalHeader().setVisible(False)
+        self.table.itemSelectionChanged.connect(self._sync_controls_from_selection)
+        main.addWidget(self.table, 5)
+        panel = qtw.QWidget()
+        form = qtw.QFormLayout(panel)
+        self.line_enable = qtw.QCheckBox("Line")
+        self.line_color = qtw.QComboBox(); self.line_color.addItems(["#1f77b4", "#d62728", "#2ca02c", "#9467bd", "#000000"])
+        self.line_width = qtw.QDoubleSpinBox(); self.line_width.setRange(0.5, 15); self.line_width.setValue(2)
+        self.line_style = qtw.QComboBox(); self.line_style.addItems(["Solid", "Dash", "Dot", "Dash Dot"])
+        self.dots_enable = qtw.QCheckBox("Dots")
+        self.dots_color = qtw.QComboBox(); self.dots_color.addItems(self.line_color.itemText(i) for i in range(self.line_color.count()))
+        self.dots_size = qtw.QDoubleSpinBox(); self.dots_size.setRange(1, 20)
+        self.marker_enable = qtw.QCheckBox("Markers")
+        self.marker_color = qtw.QComboBox(); self.marker_color.addItems(self.line_color.itemText(i) for i in range(self.line_color.count()))
+        self.marker_symbol = qtw.QComboBox(); self.marker_symbol.addItems(["o", "s", "t", "d", "+", "x"])
+        self.marker_size = qtw.QDoubleSpinBox(); self.marker_size.setRange(1, 30); self.marker_size.setValue(10)
+        self.x_axis = qtw.QComboBox(); self.x_axis.addItems(["Bottom"])
+        self.y_axis = qtw.QComboBox(); self.y_axis.addItems(["Left", "Right"])
+        self.visible = qtw.QCheckBox("Visible")
+        self.visible.setChecked(True)
+        self.order = qtw.QSpinBox(); self.order.setRange(-999, 999)
+        form.addRow(self.line_enable); form.addRow("Line color", self.line_color); form.addRow("Line thickness", self.line_width); form.addRow("Line style", self.line_style)
+        form.addRow(self.dots_enable); form.addRow("Dots color", self.dots_color); form.addRow("Dots size", self.dots_size)
+        form.addRow(self.marker_enable); form.addRow("Marker color", self.marker_color); form.addRow("Marker symbol", self.marker_symbol); form.addRow("Marker size", self.marker_size)
+        form.addRow("Horizontal axis", self.x_axis); form.addRow("Vertical axis", self.y_axis); form.addRow(self.visible); form.addRow("Plot order", self.order)
+        main.addWidget(panel, 4)
+        for widget, signal in [
+            (self.line_enable, self.line_enable.toggled), (self.line_color, self.line_color.currentTextChanged),
+            (self.line_width, self.line_width.valueChanged), (self.line_style, self.line_style.currentTextChanged),
+            (self.dots_enable, self.dots_enable.toggled), (self.dots_color, self.dots_color.currentTextChanged),
+            (self.dots_size, self.dots_size.valueChanged), (self.marker_enable, self.marker_enable.toggled),
+            (self.marker_color, self.marker_color.currentTextChanged), (self.marker_symbol, self.marker_symbol.currentTextChanged),
+            (self.marker_size, self.marker_size.valueChanged), (self.x_axis, self.x_axis.currentTextChanged),
+            (self.y_axis, self.y_axis.currentTextChanged), (self.visible, self.visible.toggled), (self.order, self.order.valueChanged),
+        ]:
+            signal.connect(self._apply_selection)
+
+    def refresh_rows(self):
+        selected = set(self._selected_labels())
+        self.table.setRowCount(0)
+        for row, (label, line) in enumerate(self.owner.lines.items()):
+            self.table.insertRow(row)
+            trace_id = label.split()[0].replace("ID:", "") if label.startswith("ID:") else str(row + 1)
+            preview = "✕"
+            measurement = self.owner._trace_measurement_name(label, line)
+            style = self.owner._trace_styles.setdefault(label, self.owner._TraceStyle(order=row))
+            axis_text = style.y_axis
+            for col, value in enumerate([trace_id, preview, measurement, axis_text, str(style.order)]):
+                self.table.setItem(row, col, qtw.QTableWidgetItem(value))
+            self.table.item(row, 1).setForeground(QtGui.QBrush(QtGui.QColor("#d62728")))
+            self.table.item(row, 1).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            self.table.item(row, 1).setFlags(self.table.item(row, 1).flags() | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
+            self.table.item(row, 0).setData(QtCore.Qt.ItemDataRole.UserRole, label)
+            if label in selected:
+                self.table.selectRow(row)
+        self.table.resizeColumnsToContents()
+        if self.table.rowCount() and not selected:
+            self.table.selectRow(0)
+
+    def _selected_labels(self) -> list[str]:
+        labels = []
+        for idx in self.table.selectionModel().selectedRows():
+            item = self.table.item(idx.row(), 0)
+            labels.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
+        return labels
+
+    def _sync_controls_from_selection(self):
+        labels = self._selected_labels()
+        if not labels:
+            return
+        style = self.owner._trace_styles[labels[0]]
+        self._building = True
+        self.line_enable.setChecked(style.line_enabled); self.line_color.setCurrentText(style.line_color); self.line_width.setValue(style.line_width); self.line_style.setCurrentText(style.line_style)
+        self.dots_enable.setChecked(style.dots_enabled); self.dots_color.setCurrentText(style.dots_color); self.dots_size.setValue(style.dots_size)
+        self.marker_enable.setChecked(style.markers_enabled); self.marker_color.setCurrentText(style.markers_color); self.marker_symbol.setCurrentText(style.markers_symbol); self.marker_size.setValue(style.markers_size)
+        self.x_axis.setCurrentText(style.x_axis); self.y_axis.setCurrentText(style.y_axis); self.visible.setChecked(style.visible); self.order.setValue(style.order)
+        self._building = False
+
+    def _apply_selection(self, *_args):
+        if self._building:
+            return
+        for label in self._selected_labels():
+            style = self.owner._trace_styles.setdefault(label, self.owner._TraceStyle())
+            style.line_enabled = self.line_enable.isChecked(); style.line_color = self.line_color.currentText(); style.line_width = self.line_width.value(); style.line_style = self.line_style.currentText()
+            style.dots_enabled = self.dots_enable.isChecked(); style.dots_color = self.dots_color.currentText(); style.dots_size = self.dots_size.value()
+            style.markers_enabled = self.marker_enable.isChecked(); style.markers_color = self.marker_color.currentText(); style.markers_symbol = self.marker_symbol.currentText(); style.markers_size = self.marker_size.value()
+            style.x_axis = self.x_axis.currentText(); style.y_axis = self.y_axis.currentText(); style.visible = self.visible.isChecked(); style.order = self.order.value()
+            line = self.owner.lines.get(label)
+            if line is not None:
+                self.owner._apply_trace_style(label, line)
+        self.refresh_rows()

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pyqtgraph as pg
-from PyQt6 import QtCore
-from PyQt6 import QtGui
+from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from ._subplots import subplot1d
@@ -505,7 +504,7 @@ class _TraceAppearanceDialog(qtw.QDialog):
         form.addRow(self.marker_enable); form.addRow("Marker color", self.marker_color); form.addRow("Marker symbol", self.marker_symbol); form.addRow("Marker size", self.marker_size)
         form.addRow("Horizontal axis", self.x_axis); form.addRow("Vertical axis", self.y_axis); form.addRow(self.visible); form.addRow("Plot order", self.order)
         main.addWidget(panel, 4)
-        for widget, signal in [
+        for _widget, signal in [
             (self.line_enable, self.line_enable.toggled), (self.line_color, self.line_color.currentTextChanged),
             (self.line_width, self.line_width.valueChanged), (self.line_style, self.line_style.currentTextChanged),
             (self.dots_enable, self.dots_enable.toggled), (self.dots_color, self.dots_color.currentTextChanged),

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
@@ -65,30 +65,46 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     _trace_styles: dict[str, _TraceStyle]
     _trace_appearance_dialog: "_TraceAppearanceDialog | None"
 
+    def _ensure_trace_styles(self) -> dict[str, _TraceStyle]:
+        styles = self.__dict__.get("_trace_styles")
+        if not isinstance(styles, dict):
+            styles = {}
+            self.__dict__["_trace_styles"] = styles
+        return cast(dict[str, Plot1DTraceMixin._TraceStyle], styles)
+
     def _register_main_line(self) -> None:
         """
         Keeps the main pyqtgraph line in the trace registry.
 
         """
-        if hasattr(self, "lines"):
-            self.lines[self.label] = self.line
-        if not hasattr(self, "_trace_styles"):
-            self._trace_styles = {}
-        self._trace_styles.setdefault(self.label, self._TraceStyle())
+        line = self.__dict__.get("line")
+        if "lines" in self.__dict__ and line is not None:
+            self.lines[self.label] = line
+        self._ensure_trace_styles().setdefault(self.label, self._TraceStyle())
 
     def initMenu(self) -> None:
         super().initMenu()
         view_menu = None
-        for action in self.menuBar().actions():
+        menu_bar = self.menuBar()
+        if menu_bar is None:
+            return
+        for action in menu_bar.actions():
             if action.text().replace("&", "") == "View":
                 view_menu = action.menu()
                 break
         if view_menu is None:
             return
         view_menu.addSeparator()
-        trace_action = qtw.QAction("Trace Appearance…", self)
+        trace_action = QtGui.QAction("Trace Appearance…", self)
         trace_action.triggered.connect(self.open_trace_appearance_dialog)
         view_menu.addAction(trace_action)
+
+    def _set_main_line_color(self, color: Any) -> None:
+        style = self._ensure_trace_styles().setdefault(self.label, self._TraceStyle())
+        style.line_color = color.name() if hasattr(color, "name") else str(color)
+        line = self.__dict__.get("line")
+        if line is not None:
+            self._apply_trace_style(self.label, line)
 
 
     def initAxes(self) -> None:
@@ -330,7 +346,8 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         # Set display
         subplot.set_color(selected_box.color_box.color())
         subplot.set_side(selected_box.axis_side.currentText().lower())
-        style = self._trace_styles.setdefault(label, self._TraceStyle(order=len(self._trace_styles)))
+        styles = self._ensure_trace_styles()
+        style = styles.setdefault(label, self._TraceStyle(order=len(styles)))
         style.line_color = selected_box.color_box.color().name()
         style.y_axis = "Right" if selected_box.axis_side.currentText().lower() == "right" else "Left"
         self._apply_trace_style(label, subplot)
@@ -431,7 +448,10 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         return getattr(param, "name", str(label))
 
     def _apply_trace_style(self, label: str, line: Any) -> None:
-        style = self._trace_styles.setdefault(label, self._TraceStyle(order=len(self._trace_styles)))
+        styles = self._ensure_trace_styles()
+        style = styles.setdefault(label, self._TraceStyle(order=len(styles)))
+        if line is None:
+            return
         pen_style_map = {
             "Solid": QtCore.Qt.PenStyle.SolidLine,
             "Dash": QtCore.Qt.PenStyle.DashLine,
@@ -476,22 +496,29 @@ class _TraceAppearanceDialog(qtw.QDialog):
         main = qtw.QHBoxLayout(self)
         self.table = qtw.QTableWidget(0, 5)
         self.table.setHorizontalHeaderLabels(["ID", "Preview", "Measurement", "Axis", "Order"])
+        self.table.setEditTriggers(qtw.QAbstractItemView.EditTrigger.NoEditTriggers)
         self.table.setSelectionBehavior(qtw.QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.setSelectionMode(qtw.QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.table.verticalHeader().setVisible(False)
+        horizontal_header = self.table.horizontalHeader()
+        if horizontal_header is not None:
+            horizontal_header.setSectionResizeMode(2, qtw.QHeaderView.ResizeMode.Stretch)
+        vertical_header = self.table.verticalHeader()
+        if vertical_header is not None:
+            vertical_header.setVisible(False)
         self.table.itemSelectionChanged.connect(self._sync_controls_from_selection)
         main.addWidget(self.table, 5)
         panel = qtw.QWidget()
         form = qtw.QFormLayout(panel)
+        colors = ["#1f77b4", "#d62728", "#2ca02c", "#9467bd", "#000000"]
         self.line_enable = qtw.QCheckBox("Line")
-        self.line_color = qtw.QComboBox(); self.line_color.addItems(["#1f77b4", "#d62728", "#2ca02c", "#9467bd", "#000000"])
+        self.line_color = qtw.QComboBox(); self._add_color_items(self.line_color, colors)
         self.line_width = qtw.QDoubleSpinBox(); self.line_width.setRange(0.5, 15); self.line_width.setValue(2)
         self.line_style = qtw.QComboBox(); self.line_style.addItems(["Solid", "Dash", "Dot", "Dash Dot"])
         self.dots_enable = qtw.QCheckBox("Dots")
-        self.dots_color = qtw.QComboBox(); self.dots_color.addItems(self.line_color.itemText(i) for i in range(self.line_color.count()))
+        self.dots_color = qtw.QComboBox(); self._add_color_items(self.dots_color, colors)
         self.dots_size = qtw.QDoubleSpinBox(); self.dots_size.setRange(1, 20)
         self.marker_enable = qtw.QCheckBox("Markers")
-        self.marker_color = qtw.QComboBox(); self.marker_color.addItems(self.line_color.itemText(i) for i in range(self.line_color.count()))
+        self.marker_color = qtw.QComboBox(); self._add_color_items(self.marker_color, colors)
         self.marker_symbol = qtw.QComboBox(); self.marker_symbol.addItems(["o", "s", "t", "d", "+", "x"])
         self.marker_size = qtw.QDoubleSpinBox(); self.marker_size.setRange(1, 30); self.marker_size.setValue(10)
         self.x_axis = qtw.QComboBox(); self.x_axis.addItems(["Bottom"])
@@ -515,6 +542,31 @@ class _TraceAppearanceDialog(qtw.QDialog):
         ]:
             signal.connect(self._apply_selection)
 
+    def _add_color_items(self, combo: qtw.QComboBox, colors: list[str]) -> None:
+        for color in colors:
+            combo.addItem(self._color_icon(color), color)
+
+    def _color_icon(self, color: str) -> QtGui.QIcon:
+        pixmap = QtGui.QPixmap(28, 14)
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        painter = QtGui.QPainter(pixmap)
+        painter.setPen(QtGui.QPen(QtGui.QColor("#444444")))
+        painter.setBrush(QtGui.QBrush(QtGui.QColor(color)))
+        painter.drawRoundedRect(1, 1, 26, 12, 2, 2)
+        painter.end()
+        return QtGui.QIcon(pixmap)
+
+    def _trace_icon(self, style: Plot1DTraceMixin._TraceStyle) -> QtGui.QIcon:
+        pixmap = QtGui.QPixmap(42, 20)
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        painter = QtGui.QPainter(pixmap)
+        pen = QtGui.QPen(QtGui.QColor(style.line_color))
+        pen.setWidthF(style.line_width)
+        painter.setPen(pen)
+        painter.drawLine(4, 10, 38, 10)
+        painter.end()
+        return QtGui.QIcon(pixmap)
+
     def refresh_rows(self):
         selected = set(self._selected_labels())
         self.table.setRowCount(0)
@@ -526,11 +578,19 @@ class _TraceAppearanceDialog(qtw.QDialog):
             style = self.owner._trace_styles.setdefault(label, self.owner._TraceStyle(order=row))
             axis_text = style.y_axis
             for col, value in enumerate([trace_id, preview, measurement, axis_text, str(style.order)]):
-                self.table.setItem(row, col, qtw.QTableWidgetItem(value))
-            self.table.item(row, 1).setForeground(QtGui.QBrush(QtGui.QColor("#d62728")))
-            self.table.item(row, 1).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-            self.table.item(row, 1).setFlags(self.table.item(row, 1).flags() | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
-            self.table.item(row, 0).setData(QtCore.Qt.ItemDataRole.UserRole, label)
+                item = qtw.QTableWidgetItem(value)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+                self.table.setItem(row, col, item)
+            self.table.setRowHeight(row, 44)
+            preview_item = self.table.item(row, 1)
+            if preview_item is not None:
+                preview_item.setText("")
+                preview_item.setIcon(self._trace_icon(style))
+                preview_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                preview_item.setFlags(preview_item.flags() | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
+            label_item = self.table.item(row, 0)
+            if label_item is not None:
+                label_item.setData(QtCore.Qt.ItemDataRole.UserRole, label)
             if label in selected:
                 self.table.selectRow(row)
         self.table.resizeColumnsToContents()
@@ -538,10 +598,14 @@ class _TraceAppearanceDialog(qtw.QDialog):
             self.table.selectRow(0)
 
     def _selected_labels(self) -> list[str]:
-        labels = []
-        for idx in self.table.selectionModel().selectedRows():
+        labels: list[str] = []
+        selection_model = self.table.selectionModel()
+        if selection_model is None:
+            return labels
+        for idx in selection_model.selectedRows():
             item = self.table.item(idx.row(), 0)
-            labels.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
+            if item is not None:
+                labels.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
         return labels
 
     def _sync_controls_from_selection(self):


### PR DESCRIPTION
### Motivation
- Provide a centralized UI to customize visual properties of traces (line, dots, markers, axis, order, visibility) in 1D plot windows.
- Persist per-trace appearance state so programmatic updates and new UI controls remain in sync with existing trace objects.
- Improve user control over secondary-axis traces and ordering without changing existing plot APIs.

### Description
- Introduces a `@dataclass` `_TraceStyle` and a `self._trace_styles` registry to store per-trace appearance settings and ordering.
- Adds `_apply_trace_style`, `_trace_measurement_name`, `open_trace_appearance_dialog` and integrates style application into `initAxes`, `_add_line`/`_add_axis` flow and `remove_line` cleanup to keep visuals consistent.
- Adds a `Trace Appearance…` menu item and a new `_TraceAppearanceDialog` Qt dialog that exposes controls for line/dot/marker colors, sizes, styles, axis, visibility and plot order and applies changes to selected traces.
- Minor robustness fixes: avoid handling a None event in `updateViews` and ensure styles are created/updated when lines are registered.

### Testing
- Ran a basic import smoke test by importing the modified module and instantiating the dialog and main mixin components without rendering, which completed successfully.
- Executed the project's automated unit test suite with `pytest`, and the suite completed successfully without regressions related to these changes.
- No new automated tests were added for the dialog UI in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5e173168832394c272ef92460cb8)