### PR TITLE
Fix heatmap geometry handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy>=2.3.1",
     "pandas>=2.3.0",
     "PyQt6>=6.8.0",
-    "pyqtgraph>=0.13.7",
+    "pyqtgraph>=0.14.0",
     "qcodes>=0.53.0",
 ]
 
@@ -108,6 +108,7 @@ files = [
     "src/qplot/diagnostics.py",
     "src/qplot/tools/__init__.py",
     "src/qplot/tools/general.py",
+    "src/qplot/tools/heatmap_geometry.py",
     "src/qplot/tools/operation_registry.py",
     "src/qplot/tools/plot_tools.py",
     "src/qplot/tools/worker.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,5 @@ files = [
 ]
 ignore_missing_imports = true
 no_implicit_optional = true
-python_version = "3.11"
 sqlite_cache = false
 warn_unused_ignores = true

--- a/src/qplot/tools/heatmap_geometry.py
+++ b/src/qplot/tools/heatmap_geometry.py
@@ -1,0 +1,347 @@
+"""Coordinate geometry for rectilinear heatmaps.
+
+This module deliberately has no Qt dependencies.  It defines the coordinate
+contract shared by heatmap rendering and interactions: axis values are pixel
+centres, while the derived edges are pixel boundaries.
+"""
+
+import math
+import operator
+from bisect import bisect_left, bisect_right
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+_DEFAULT_SINGLETON_SPAN = 1.0
+_DEFAULT_UNIFORM_REL_TOL = 1e-9
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class AxisGeometry:
+    """Immutable geometry for one strictly increasing heatmap axis.
+
+    Descending axes are rejected rather than silently reordered because axis
+    indices must remain aligned with the corresponding dimension of the data
+    grid.  A caller that receives descending data must reverse both together.
+
+    Parameters
+    ----------
+    centres:
+        Finite, strictly increasing cell-centre coordinates.
+    singleton_span:
+        Width assigned to an axis containing one centre.  Callers can supply a
+        known neighbouring step; otherwise one coordinate unit is used.
+    uniform_rel_tol, uniform_abs_tol:
+        Tolerances used only when classifying an axis as uniform.
+    """
+
+    centres: tuple[float, ...]
+    edges: tuple[float, ...]
+    is_uniform: bool
+
+    def __init__(
+            self,
+            centres: Iterable[float],
+            *,
+            singleton_span: float = _DEFAULT_SINGLETON_SPAN,
+            uniform_rel_tol: float = _DEFAULT_UNIFORM_REL_TOL,
+            uniform_abs_tol: float = 0.0,
+            ) -> None:
+        values = tuple(float(value) for value in centres)
+        span = float(singleton_span)
+        rel_tol = float(uniform_rel_tol)
+        abs_tol = float(uniform_abs_tol)
+
+        if not values:
+            raise ValueError("A heatmap axis requires at least one centre.")
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("Heatmap axis centres must all be finite.")
+        if not math.isfinite(span) or span <= 0.0:
+            raise ValueError("singleton_span must be positive and finite.")
+        if not math.isfinite(rel_tol) or rel_tol < 0.0:
+            raise ValueError("uniform_rel_tol must be non-negative and finite.")
+        if not math.isfinite(abs_tol) or abs_tol < 0.0:
+            raise ValueError("uniform_abs_tol must be non-negative and finite.")
+
+        deltas = tuple(
+            right - left
+            for left, right in zip(values[:-1], values[1:], strict=True)
+        )
+        if deltas and all(delta < 0.0 for delta in deltas):
+            raise ValueError(
+                "descending heatmap axes are not supported; reverse both the "
+                "axis centres and the corresponding data dimension."
+            )
+        if any(delta <= 0.0 for delta in deltas):
+            raise ValueError("Heatmap axis centres must be strictly increasing.")
+
+        derived_edges: tuple[float, ...]
+        if len(values) == 1:
+            half_span = span / 2.0
+            derived_edges = (values[0] - half_span, values[0] + half_span)
+        else:
+            interior_edges = tuple(
+                left / 2.0 + right / 2.0
+                for left, right in zip(values[:-1], values[1:], strict=True)
+            )
+            derived_edges = (
+                values[0] - (interior_edges[0] - values[0]),
+                *interior_edges,
+                values[-1] + (values[-1] - interior_edges[-1]),
+            )
+
+        if not all(math.isfinite(edge) for edge in derived_edges):
+            raise ValueError("Derived heatmap axis edges must all be finite.")
+        if any(
+                right <= left
+                for left, right in zip(
+                    derived_edges[:-1],
+                    derived_edges[1:],
+                    strict=True,
+                    )
+                ):
+            raise ValueError(
+                "Heatmap cell edges collapse at floating-point precision."
+                )
+
+        uniform = len(deltas) <= 1 or all(
+            math.isclose(
+                delta,
+                deltas[0],
+                rel_tol=rel_tol,
+                abs_tol=abs_tol,
+            )
+            for delta in deltas[1:]
+        )
+
+        object.__setattr__(self, "centres", values)
+        object.__setattr__(self, "edges", derived_edges)
+        object.__setattr__(self, "is_uniform", uniform)
+
+    @property
+    def count(self) -> int:
+        """Number of cells along this axis."""
+
+        return len(self.centres)
+
+    @property
+    def bounds(self) -> tuple[float, float]:
+        """Inclusive outer coordinate bounds of the axis."""
+
+        return self.edges[0], self.edges[-1]
+
+    @property
+    def span(self) -> float:
+        """Positive distance between the outer axis edges."""
+
+        return self.edges[-1] - self.edges[0]
+
+    def centre(self, index: int) -> float:
+        """Return the recorded centre coordinate of one cell."""
+
+        return self.centres[self._checked_index(index)]
+
+    def cell_bounds(self, index: int) -> tuple[float, float]:
+        """Return the lower and upper boundary of one cell."""
+
+        checked_index = self._checked_index(index)
+        return self.edges[checked_index], self.edges[checked_index + 1]
+
+    def index_at(self, value: float, *, clamp: bool = False) -> int | None:
+        """Return the cell containing ``value``.
+
+        An interior boundary belongs to the cell on its right.  Both outer
+        boundaries are included.  Out-of-bounds coordinates return ``None``
+        unless ``clamp`` is true, in which case the nearest outer cell is used.
+        Non-finite coordinates always return ``None``.
+        """
+
+        coordinate = float(value)
+        if not math.isfinite(coordinate):
+            return None
+
+        lower, upper = self.bounds
+        if coordinate < lower:
+            return 0 if clamp else None
+        if coordinate > upper:
+            return self.count - 1 if clamp else None
+        if coordinate == upper:
+            return self.count - 1
+
+        return bisect_right(self.edges, coordinate) - 1
+
+    def snap_interval(self, low: float, high: float) -> tuple[float, float]:
+        """Expand an interval to the cell edges that contain it."""
+
+        start, stop = self._cell_interval(low, high)
+        return self.edges[start], self.edges[stop]
+
+    def slice_for_interval(self, low: float, high: float) -> slice:
+        """Return the cells covered by an interval as a NumPy-style slice."""
+
+        start, stop = self._cell_interval(low, high)
+        return slice(start, stop)
+
+    def _cell_interval(self, low: float, high: float) -> tuple[int, int]:
+        low_value = float(low)
+        high_value = float(high)
+        if not math.isfinite(low_value) or not math.isfinite(high_value):
+            raise ValueError("heatmap selection coordinates must be finite.")
+
+        low_value, high_value = sorted((low_value, high_value))
+        lower_bound, upper_bound = self.bounds
+        low_value = min(max(low_value, lower_bound), upper_bound)
+        high_value = min(max(high_value, lower_bound), upper_bound)
+
+        start = bisect_right(self.edges, low_value) - 1
+        start = min(max(start, 0), self.count - 1)
+        stop = bisect_left(self.edges, high_value)
+        stop = min(max(stop, start + 1), self.count)
+        return start, stop
+
+    def _checked_index(self, index: int) -> int:
+        try:
+            checked_index = operator.index(index)
+        except TypeError as error:
+            raise TypeError("axis cell index must be an integer") from error
+        if not 0 <= checked_index < self.count:
+            raise IndexError(
+                f"axis cell index {checked_index} is outside "
+                f"0..{self.count - 1}"
+            )
+        return checked_index
+
+
+@dataclass(frozen=True, slots=True)
+class HeatmapGeometry:
+    """Immutable two-dimensional rectilinear heatmap geometry."""
+
+    x: AxisGeometry
+    y: AxisGeometry
+
+    @classmethod
+    def from_centres(
+            cls,
+            x_centres: Iterable[float],
+            y_centres: Iterable[float],
+            *,
+            x_singleton_span: float = _DEFAULT_SINGLETON_SPAN,
+            y_singleton_span: float = _DEFAULT_SINGLETON_SPAN,
+            uniform_rel_tol: float = _DEFAULT_UNIFORM_REL_TOL,
+            uniform_abs_tol: float = 0.0,
+            ) -> "HeatmapGeometry":
+        """Build heatmap geometry from X and Y cell-centre coordinates."""
+
+        return cls(
+            x=AxisGeometry(
+                x_centres,
+                singleton_span=x_singleton_span,
+                uniform_rel_tol=uniform_rel_tol,
+                uniform_abs_tol=uniform_abs_tol,
+            ),
+            y=AxisGeometry(
+                y_centres,
+                singleton_span=y_singleton_span,
+                uniform_rel_tol=uniform_rel_tol,
+                uniform_abs_tol=uniform_abs_tol,
+            ),
+        )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Expected data-grid shape in NumPy row-major order: ``(Y, X)``."""
+
+        return self.y.count, self.x.count
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        """Return ``(left, bottom, right, top)`` outer cell boundaries."""
+
+        return self.x.edges[0], self.y.edges[0], self.x.edges[-1], self.y.edges[-1]
+
+    @property
+    def rect(self) -> tuple[float, float, float, float]:
+        """Return a Qt-free ``(left, bottom, width, height)`` rectangle."""
+
+        return self.x.edges[0], self.y.edges[0], self.x.span, self.y.span
+
+    @property
+    def is_uniform(self) -> bool:
+        """Whether both axes use uniform cell spacing."""
+
+        return self.x.is_uniform and self.y.is_uniform
+
+    def index_at(
+            self,
+            x_value: float,
+            y_value: float,
+            *,
+            clamp: bool = False,
+            ) -> tuple[int, int] | None:
+        """Return the ``(X, Y)`` cell containing a plot coordinate."""
+
+        x_index = self.x.index_at(x_value, clamp=clamp)
+        y_index = self.y.index_at(y_value, clamp=clamp)
+        if x_index is None or y_index is None:
+            return None
+        return x_index, y_index
+
+    def cell_bounds(
+            self,
+            x_index: int,
+            y_index: int,
+            ) -> tuple[float, float, float, float]:
+        """Return ``(left, bottom, right, top)`` for one heatmap cell."""
+
+        left, right = self.x.cell_bounds(x_index)
+        bottom, top = self.y.cell_bounds(y_index)
+        return left, bottom, right, top
+
+    def cell_rect(
+            self,
+            x_index: int,
+            y_index: int,
+            ) -> tuple[float, float, float, float]:
+        """Return ``(left, bottom, width, height)`` for one heatmap cell."""
+
+        left, bottom, right, top = self.cell_bounds(x_index, y_index)
+        return left, bottom, right - left, top - bottom
+
+
+def canonicalize_heatmap_data(
+        x_centres: npt.ArrayLike,
+        y_centres: npt.ArrayLike,
+        data_grid: npt.ArrayLike,
+        ) -> tuple[
+            npt.NDArray[np.float64],
+            npt.NDArray[np.float64],
+            npt.NDArray[Any],
+            ]:
+    """Return increasing axes while preserving their grid-value mapping."""
+
+    x_values = np.asarray(x_centres, dtype=float)
+    y_values = np.asarray(y_centres, dtype=float)
+    grid = np.asarray(data_grid)
+
+    if x_values.ndim != 1 or y_values.ndim != 1:
+        raise ValueError("Heatmap axes must be one-dimensional.")
+    expected_shape = (y_values.size, x_values.size)
+    if grid.ndim != 2 or grid.shape != expected_shape:
+        raise ValueError(
+            f"Heatmap data shape {grid.shape} does not match "
+            f"axis shape {expected_shape}."
+            )
+
+    if x_values.size > 1 and np.all(np.diff(x_values) < 0.0):
+        x_values = x_values[::-1].copy()
+        grid = np.flip(grid, axis=1).copy()
+    if y_values.size > 1 and np.all(np.diff(y_values) < 0.0):
+        y_values = y_values[::-1].copy()
+        grid = np.flip(grid, axis=0).copy()
+
+    AxisGeometry(x_values)
+    AxisGeometry(y_values)
+    return x_values, y_values, grid

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -22,6 +22,7 @@ from qplot.datahandling.readonly import (
 from qplot.diagnostics import log_exception
 
 from . import data2matrix
+from .heatmap_geometry import canonicalize_heatmap_data
 
 if TYPE_CHECKING:
     import qcodes
@@ -200,8 +201,37 @@ class loader(QtCore.QRunnable):
             if hasattr(self, "dataGrid"):
                 self.dataGrid = results[2]
 
+        try:
+            self._canonicalize_heatmap()
+        except Exception as err:
+            log_exception("Invalid heatmap geometry", err, __name__)
+            self.emitter.errorOccurred.emit(err)
+            self.emitter.finished.emit(False)
+            return
+
         # Callback
         self.emitter.finished.emit(True)
+
+
+    def _canonicalize_heatmap(self) -> None:
+        """Keep worker indices consistent with increasing heatmap axes."""
+
+        if not hasattr(self, "dataGrid"):
+            return
+        x_data = np.asarray(self.axis_data.get("x", []))
+        y_data = np.asarray(self.axis_data.get("y", []))
+        data_grid = np.asarray(self.dataGrid)
+        if x_data.size == 0 or y_data.size == 0 or data_grid.size == 0:
+            return
+
+        x_data, y_data, data_grid = canonicalize_heatmap_data(
+            x_data,
+            y_data,
+            data_grid,
+            )
+        self.axis_data["x"] = x_data
+        self.axis_data["y"] = y_data
+        self.dataGrid = data_grid
 
 
     def _should_use_sql_heatmap(self):

--- a/src/qplot/windows/_plot2d_sweeps.py
+++ b/src/qplot/windows/_plot2d_sweeps.py
@@ -9,6 +9,8 @@ from ._subplots.subplot2d import sweeper
 _SweepAxis = Literal["x", "y"]
 
 if TYPE_CHECKING:
+    from qplot.tools.heatmap_geometry import HeatmapGeometry
+
     class _Plot2DSweepBase(qtw.QMainWindow):
         _guid: str
         active_sweep_line_id: int | None
@@ -25,7 +27,15 @@ if TYPE_CHECKING:
 
         def change_axis(self, key: str) -> None: ...
 
-        def _heatmap_rect(self) -> QtCore.QRectF | None: ...
+        def clear_marquee(self) -> None: ...
+
+        def hide_hover_pixel_outline(self) -> None: ...
+
+        def _heatmap_geometry(self) -> HeatmapGeometry | None: ...
+
+        def _required_heatmap_geometry(self) -> HeatmapGeometry: ...
+
+        def _reset_heatmap_hover(self) -> None: ...
 else:
     class _Plot2DSweepBase:
         pass
@@ -117,6 +127,8 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
 
 
         """
+        if self._heatmap_geometry() is None:
+            return
         # Check if display is possible on current axes
         if sweep_param not in self.axis_options.values() or fixed_param not in self.axis_options.values():
             return
@@ -196,6 +208,9 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         
     @QtCore.pyqtSlot()
     def change_axis(self, key: str) -> None:
+        self._reset_heatmap_hover()
+        if self.__dict__.get("marquee") is not None:
+            self.clear_marquee()
         
         # Rotate lines in case of duplciates
         options = self.axis_options
@@ -246,16 +261,10 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
     
     
     def sweep_axis_count(self, axis: _SweepAxis) -> int:
-        if axis == "x":
-            return self.dataGrid.shape[1]
-        return self.dataGrid.shape[0]
-
-
-    def _required_heatmap_rect(self) -> QtCore.QRectF:
-        rect = self._heatmap_rect()
-        if rect is None:
-            raise RuntimeError("Heatmap geometry is not available.")
-        return rect
+        geometry = self._heatmap_geometry()
+        if geometry is None:
+            return 0
+        return geometry.x.count if axis == "x" else geometry.y.count
 
 
     def sweep_pixel_centre(self, axis: _SweepAxis, index: int) -> float:
@@ -263,13 +272,10 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         Return the plot coordinate at the centre of a heatmap pixel.
 
         """
-        count = self.sweep_axis_count(axis)
-        index = min(max(int(index), 0), count - 1)
-        rect = self._required_heatmap_rect()
-
-        if axis == "x":
-            return rect.x() + (index + 0.5) * rect.width() / count
-        return rect.y() + (index + 0.5) * rect.height() / count
+        geometry = self._required_heatmap_geometry()
+        axis_geometry = geometry.x if axis == "x" else geometry.y
+        index = min(max(int(index), 0), axis_geometry.count - 1)
+        return axis_geometry.centre(index)
 
 
     def sweep_index_at_value(self, axis: _SweepAxis, value: float) -> int | None:
@@ -277,20 +283,11 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         Return the heatmap pixel index containing a plot coordinate.
 
         """
-        count = self.sweep_axis_count(axis)
-        rect = self._required_heatmap_rect()
-        if axis == "x":
-            start = rect.x()
-            width = rect.width()
-        else:
-            start = rect.y()
-            width = rect.height()
-
-        if count <= 0 or width <= 0:
+        geometry = self._heatmap_geometry()
+        if geometry is None:
             return None
-
-        index = int((value - start) / width * count)
-        return min(max(index, 0), count - 1)
+        axis_geometry = geometry.x if axis == "x" else geometry.y
+        return axis_geometry.index_at(value, clamp=True)
 
 
     def line_sweep_axis(self, line: Any) -> _SweepAxis:
@@ -474,6 +471,8 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
     def set_sweep_line_index(self, line: Any, index: int, emit: bool = True) -> None:
         axis = self.line_sweep_axis(line)
         count = self.sweep_axis_count(axis)
+        if count <= 0:
+            return
         index = min(max(int(index), 0), count - 1)
 
         line.setBounds((
@@ -489,16 +488,23 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
 
 
     def _snap_sweep_lines_to_pixel_centres(self) -> None:
-        for line in self.sweep_lines.values():
+        if self._heatmap_geometry() is None:
+            return
+        for line in self.__dict__.get("sweep_lines", {}).values():
             axis = self.line_sweep_axis(line)
-            index = getattr(line, "sweep_index", None)
-            if index is None:
-                index = self.sweep_index_at_value(axis, line.value())
+            previous_index = getattr(line, "sweep_index", None)
+            index = self.sweep_index_at_value(axis, line.value())
             if index is not None:
-                self.set_sweep_line_index(line, index, emit=False)
+                self.set_sweep_line_index(
+                    line,
+                    index,
+                    emit=previous_index is not None and index != previous_index,
+                    )
 
 
     def move_sweep_with_arrow_key(self, key: QtCore.Qt.Key) -> None:
+        if self._heatmap_geometry() is None:
+            return
         moves: dict[QtCore.Qt.Key, tuple[_SweepAxis, int]] = {
             QtCore.Qt.Key.Key_Left: ("x", -1),
             QtCore.Qt.Key.Key_Right: ("x", 1),

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -1208,6 +1208,9 @@ class plotWidget(
             self._set_cursor_index_label("")
             if hasattr(self, "hide_hover_pixel_outline"):
                 self.hide_hover_pixel_outline()
+            z_label = self.pos_labels.get("z")
+            if z_label is not None:
+                z_label.setText("z =")
             return
     
         # get x, y values.
@@ -1220,40 +1223,29 @@ class plotWidget(
         
         # For 2d plots.
         if self.pos_labels.get("z", 0):
-            
             y_txt += ";"
-            
-            rect = self.rect
-            
-            if hasattr(rect, "x"): # Check plot has initalised
-                
-                # Get index for that heatmap 'pixel' as a percentage of width/height
-                i = (mousePoint.x() - rect.x()) / rect.width()
-                j = (mousePoint.y() - rect.y()) / rect.height()
-                
-                # Check index is within heatmap.
-                if (i >= 0 and i <= 1) and (j >= 0 and j <= 1):
-                    # Convert to true index
-                    # Note that pyqtgraph indexes [column, row]
-                    i = min(self.dataGrid.shape[1] - 1, int(i * self.dataGrid.shape[1]))
-                    j = min(self.dataGrid.shape[0] - 1, int(j * self.dataGrid.shape[0]))
-                    x = rect.x() + (i + 0.5) * rect.width() / self.dataGrid.shape[1]
-                    y = rect.y() + (j + 0.5) * rect.height() / self.dataGrid.shape[0]
-                    index_txt = f"[{i},{j}]"
-                    x_txt = f"x = {self.formatNum(x)};"
-                    y_txt = f"y = {self.formatNum(y)};"
-                    self.pos_labels["z"].setText(f"z = {self.formatNum(self.dataGrid[j, i])}")
-                    
-                    # Save z location for subplot use
-                    if hasattr(self, "show_hover_pixel_outline"):
-                        self.show_hover_pixel_outline(i, j)
-                    else:
-                        self.z_index = [i, j]
+            sample_at = getattr(self, "heatmap_sample_at", None)
+            sample = (
+                sample_at(mousePoint.x(), mousePoint.y())
+                if callable(sample_at)
+                else None
+                )
+            if sample is not None:
+                i, j, x, y, z = sample
+                index_txt = f"[{i},{j}]"
+                x_txt = f"x = {self.formatNum(x)};"
+                y_txt = f"y = {self.formatNum(y)};"
+                self.pos_labels["z"].setText(f"z = {self.formatNum(z)}")
+                if hasattr(self, "show_hover_pixel_outline"):
+                    self.show_hover_pixel_outline(i, j)
                 else:
-                    if hasattr(self, "hide_hover_pixel_outline"):
-                        self.hide_hover_pixel_outline()
-                    else:
-                        self.z_index = None
+                    self.z_index = [i, j]
+            else:
+                self.pos_labels["z"].setText("z =")
+                if hasattr(self, "hide_hover_pixel_outline"):
+                    self.hide_hover_pixel_outline()
+                else:
+                    self.z_index = None
         else:
             index = self._nearest_1d_array_index(mousePoint.x())
             if index is not None:

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -6,6 +6,12 @@ import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
+from qplot.tools.heatmap_geometry import (
+    AxisGeometry,
+    HeatmapGeometry,
+    canonicalize_heatmap_data,
+)
+
 from . import _colorbar
 from ._commands import command_spec, create_action
 from ._plot2d_colorbar import Plot2DColorbarMixin
@@ -64,9 +70,12 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
 
         self.image = pg.ImageItem(axisOrder='row-major')
         self.image.setZValue(0) # Like *Send to back*
-        # self.image.setPxMode(True)
-        
+        self.heatmap_mesh = pg.PColorMeshItem()
+        self.heatmap_mesh.setZValue(0)
+        self.heatmap_mesh.hide()
+
         self.plot.addItem(self.image)
+        self.plot.addItem(self.heatmap_mesh)
         self.hover_pixel_outline = qtw.QGraphicsRectItem()
         self.hover_pixel_outline.setPen(
             pg.mkPen((255, 255, 255, 190), width=1.5, cosmetic=True)
@@ -172,6 +181,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         try:
             self._update_large_heatmap_state(plot_worker)
             if not self._has_plottable_heatmap_data():
+                self._invalidate_heatmap_geometry()
                 self.show_status(
                     f"Waiting for plottable data for {self.param.name}...",
                     5000,
@@ -183,39 +193,25 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                     )
                 return
 
-            autoLevels=self.relevel_refresh.isChecked()
-            # Produce Heatmap
-            self.image.setImage(
-                self.dataGrid,
-                autoLevels=autoLevels,
-                autoRange=True
-                )
+            try:
+                self._update_heatmap_geometry()
+            except (TypeError, ValueError) as error:
+                self._invalidate_heatmap_geometry()
+                self.show_status(f"Cannot display heatmap: {error}", 10_000)
+                self.show_plot_state(
+                    "Invalid heatmap geometry",
+                    str(error),
+                    kind="error",
+                    )
+                return
 
-            #set axis values
-            xmin = min(self.axis_data["x"])
-            ymin = min(self.axis_data["y"])
-            xrange = max(self.axis_data["x"]) - xmin
-            yrange = max(self.axis_data["y"]) - ymin
-
-            if xrange == 0:
-                xrange = xmin / 100
-            if yrange == 0:
-                yrange = ymin / 100
-
-            # Link x/y axis values with Heatmap data
-            heatmap_rect = QtCore.QRectF(
-                xmin,
-                ymin,
-                xrange,
-                yrange
-            )
-            self.__dict__["rect"] = heatmap_rect
-            self.image.setRect(heatmap_rect)
+            autoLevels = self.relevel_refresh.isChecked()
+            self._render_heatmap()
 
             # Produce color bar on first run
             if not hasattr(self, "bar"):
                 self.bar = self.plot.addColorBar(
-                    self.image,
+                    self._heatmap_colorbar_items(),
                     colorMap=self._colorbar_colormap(),
                     rounding=(
                         np.nanmax(self.dataGrid) - np.nanmin(self.dataGrid)
@@ -234,10 +230,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             elif self._colorbar_manual_levels is not None:
                 self._set_colorbar_levels(*self._colorbar_manual_levels)
             
-            self._update_hover_pixel_outline_from_index()
-            if self.marquee is not None:
-                self.set_marquee_rect(self.marquee)
-            self._snap_sweep_lines_to_pixel_centres()
+            self._restore_heatmap_interactions()
         finally:
             # Allow new workers after empty live loads or display errors.
             plot_worker.running = False
@@ -967,6 +960,165 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             )
 
 
+    def _update_heatmap_geometry(self) -> HeatmapGeometry:
+        """Build and install geometry from the current setpoint centres."""
+
+        self.__dict__.pop("heatmap_geometry", None)
+        self.__dict__.pop("rect", None)
+        self._reset_heatmap_hover()
+        x_centres, y_centres, data_grid = canonicalize_heatmap_data(
+            self.axis_data["x"],
+            self.axis_data["y"],
+            self.dataGrid,
+            )
+        geometry = HeatmapGeometry.from_centres(x_centres, y_centres)
+
+        axis_data = dict(self.axis_data)
+        axis_data["x"] = x_centres
+        axis_data["y"] = y_centres
+        self.__dict__["axis_data"] = axis_data
+        self.__dict__["dataGrid"] = data_grid
+        self.__dict__["heatmap_geometry"] = geometry
+        self.__dict__["rect"] = QtCore.QRectF(*geometry.rect)
+        return geometry
+
+
+    def _heatmap_geometry(self) -> HeatmapGeometry | None:
+        geometry = self.__dict__.get("heatmap_geometry")
+        if isinstance(geometry, HeatmapGeometry):
+            return geometry
+        return None
+
+
+    def _required_heatmap_geometry(self) -> HeatmapGeometry:
+        geometry = self._heatmap_geometry()
+        if geometry is None:
+            raise RuntimeError("Heatmap geometry is not available.")
+        return geometry
+
+
+    def _render_heatmap(self) -> None:
+        """Render uniform grids as images and rectilinear grids as meshes."""
+
+        geometry = self._required_heatmap_geometry()
+        data_grid = np.asarray(self.dataGrid)
+        if geometry.is_uniform:
+            self.image.setImage(
+                data_grid,
+                autoLevels=False,
+                )
+            self.image.setRect(QtCore.QRectF(*geometry.rect))
+            self.heatmap_mesh.hide()
+            self.image.show()
+            return
+
+        mesh_data = np.asarray(data_grid, dtype=float).copy()
+        mesh_data[~np.isfinite(mesh_data)] = np.nan
+        x_vertices, y_vertices = np.meshgrid(
+            geometry.x.edges,
+            geometry.y.edges,
+            indexing="xy",
+            )
+        self.heatmap_mesh.setData(
+            x_vertices,
+            y_vertices,
+            mesh_data,
+            autoLevels=False,
+            )
+        self.image.hide()
+        self.heatmap_mesh.show()
+
+
+    def _heatmap_colorbar_items(self) -> list[Any]:
+        return [self.image, self.heatmap_mesh]
+
+
+    def _hide_heatmap_renderers(self) -> None:
+        for item_name in ("image", "heatmap_mesh"):
+            item = self.__dict__.get(item_name)
+            if item is not None:
+                item.hide()
+
+
+    def _reset_heatmap_hover(self) -> None:
+        self.hide_hover_pixel_outline()
+        labels = self.__dict__.get("pos_labels")
+        if not isinstance(labels, dict):
+            return
+        index_label = labels.get("index")
+        if index_label is not None:
+            index_label.setText("")
+        z_label = labels.get("z")
+        if z_label is not None:
+            z_label.setText("z =")
+
+
+    def _invalidate_heatmap_geometry(self) -> None:
+        self.__dict__.pop("heatmap_geometry", None)
+        self.__dict__.pop("rect", None)
+        self._hide_heatmap_renderers()
+        self._reset_heatmap_hover()
+        if self.__dict__.get("marquee") is not None:
+            self.clear_marquee()
+        self._set_sweep_lines_visible(False)
+
+
+    def _restore_heatmap_interactions(self) -> None:
+        self._set_sweep_lines_visible(True)
+        marquee = self.__dict__.get("marquee")
+        if isinstance(marquee, QtCore.QRectF):
+            if self._marquee_intersects_heatmap(marquee):
+                self.set_marquee_rect(marquee)
+            else:
+                self.clear_marquee()
+        self._snap_sweep_lines_to_pixel_centres()
+
+
+    def _set_sweep_lines_visible(self, visible: bool) -> None:
+        for line in self.__dict__.get("sweep_lines", {}).values():
+            set_visible = getattr(line, "setVisible", None)
+            if callable(set_visible):
+                set_visible(visible)
+
+
+    def _marquee_intersects_heatmap(self, rect: QtCore.QRectF) -> bool:
+        geometry = self._heatmap_geometry()
+        if geometry is None:
+            return False
+        normalised = rect.normalized()
+        left, bottom, right, top = geometry.bounds
+        return bool(
+            normalised.right() > left
+            and normalised.left() < right
+            and normalised.bottom() > bottom
+            and normalised.top() < top
+            )
+
+
+    def heatmap_sample_at(
+            self,
+            x_value: float,
+            y_value: float,
+            ) -> tuple[int, int, float, float, float] | None:
+        """Return index, recorded coordinates, and value under a point."""
+
+        geometry = self._heatmap_geometry()
+        if geometry is None:
+            return None
+        index = geometry.index_at(x_value, y_value)
+        if index is None:
+            return None
+
+        x_index, y_index = index
+        return (
+            x_index,
+            y_index,
+            geometry.x.centre(x_index),
+            geometry.y.centre(y_index),
+            float(self.dataGrid[y_index, x_index]),
+            )
+
+
     def show_hover_pixel_outline(self, i: int, j: int) -> None:
         """
         Move the hover outline to the heatmap pixel at the given data indices.
@@ -988,48 +1140,33 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
 
         """
         self.__dict__["z_index"] = None
-        if hasattr(self, "hover_pixel_outline"):
-            self.hover_pixel_outline.hide()
-
-
-    def _heatmap_rect(self) -> QtCore.QRectF | None:
-        rect = self.__dict__.get("rect")
-        if isinstance(rect, QtCore.QRectF):
-            return rect
-        return None
+        outline = self.__dict__.get("hover_pixel_outline")
+        if outline is not None:
+            outline.hide()
 
 
     def _update_hover_pixel_outline_from_index(self) -> None:
-        heatmap_rect = self._heatmap_rect()
+        geometry = self._heatmap_geometry()
         z_index = self.__dict__.get("z_index")
         if (
                 not hasattr(self, "hover_pixel_outline")
-                or heatmap_rect is None
-                or not hasattr(self, "dataGrid")
+                or geometry is None
                 or not isinstance(z_index, list)
+                or len(z_index) != 2
                 ):
             if hasattr(self, "hover_pixel_outline"):
                 self.hover_pixel_outline.hide()
             return
 
         i, j = z_index
-        rows, cols = self.dataGrid.shape
-        if rows <= 0 or cols <= 0 or i < 0 or j < 0 or i >= cols or j >= rows:
+        try:
+            cell_rect = geometry.cell_rect(i, j)
+        except (IndexError, TypeError):
+            self.__dict__["z_index"] = None
             self.hover_pixel_outline.hide()
             return
 
-        cell_width = heatmap_rect.width() / cols
-        cell_height = heatmap_rect.height() / rows
-        if cell_width <= 0 or cell_height <= 0:
-            self.hover_pixel_outline.hide()
-            return
-
-        self.hover_pixel_outline.setRect(QtCore.QRectF(
-            heatmap_rect.x() + i * cell_width,
-            heatmap_rect.y() + j * cell_height,
-            cell_width,
-            cell_height,
-        ))
+        self.hover_pixel_outline.setRect(QtCore.QRectF(*cell_rect))
         self.hover_pixel_outline.show()
 
 
@@ -1038,60 +1175,94 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         Snap marquee edges to heatmap pixel boundaries.
 
         """
-        heatmap_rect = self._heatmap_rect()
-        if heatmap_rect is None or not hasattr(self, "dataGrid"):
+        geometry = self._heatmap_geometry()
+        if geometry is None:
             return rect
 
-        rows, cols = self.dataGrid.shape
-        if (
-                rows <= 0
-                or cols <= 0
-                or heatmap_rect.width() <= 0
-                or heatmap_rect.height() <= 0
-                ):
+        try:
+            left, right = geometry.x.snap_interval(rect.left(), rect.right())
+            bottom, top = geometry.y.snap_interval(rect.top(), rect.bottom())
+        except ValueError:
             return rect
-
-        left, right = self._snap_marquee_axis_to_cells(
-            rect.left(),
-            rect.right(),
-            heatmap_rect.x(),
-            heatmap_rect.width(),
-            cols,
-            )
-        bottom, top = self._snap_marquee_axis_to_cells(
-            rect.top(),
-            rect.bottom(),
-            heatmap_rect.y(),
-            heatmap_rect.height(),
-            rows,
-            )
 
         return QtCore.QRectF(left, bottom, right - left, top - bottom)
 
 
-    def _snap_marquee_axis_to_cells(
+    def _snap_translated_marquee_rect(
             self,
-            low: float,
-            high: float,
-            origin: float,
-            span: float,
-            count: int,
-            ) -> tuple[float, float]:
-        cell_size = span / count
-        min_value = origin
-        max_value = origin + span
-        low = min(max(low, min_value), max_value)
-        high = min(max(high, min_value), max_value)
+            rect: QtCore.QRectF,
+            original: QtCore.QRectF,
+            handle: Any,
+            ) -> None:
+        """Preserve selected cell counts during Shift-drag translation."""
 
-        low_index = int(np.floor((low - origin) / cell_size))
-        high_index = int(np.ceil((high - origin) / cell_size))
-        low_index = min(max(low_index, 0), count - 1)
-        high_index = min(max(high_index, low_index + 1), count)
+        geometry = self._heatmap_geometry()
+        if geometry is None:
+            super()._snap_translated_marquee_rect(rect, original, handle)
+            return
 
-        return (
-            origin + low_index * cell_size,
-            origin + high_index * cell_size,
+        original = original.normalized()
+        snapped = self._snap_marquee_rect(QtCore.QRectF(rect).normalized())
+        adjusted = QtCore.QRectF(snapped)
+        try:
+            if "w" in handle or "e" in handle:
+                left, right = self._translated_marquee_axis_bounds(
+                    geometry.x,
+                    original.left(),
+                    original.right(),
+                    snapped.left(),
+                    snapped.right(),
+                    anchor_low="w" in handle,
+                    )
+                adjusted.setLeft(left)
+                adjusted.setRight(right)
+            if "n" in handle or "s" in handle:
+                bottom, top = self._translated_marquee_axis_bounds(
+                    geometry.y,
+                    original.top(),
+                    original.bottom(),
+                    snapped.top(),
+                    snapped.bottom(),
+                    anchor_low="s" in handle,
+                    )
+                adjusted.setTop(bottom)
+                adjusted.setBottom(top)
+        except ValueError:
+            super()._snap_translated_marquee_rect(rect, original, handle)
+            return
+
+        rect.setRect(
+            adjusted.left(),
+            adjusted.top(),
+            adjusted.width(),
+            adjusted.height(),
             )
+
+
+    @staticmethod
+    def _translated_marquee_axis_bounds(
+            axis: AxisGeometry,
+            original_low: float,
+            original_high: float,
+            snapped_low: float,
+            snapped_high: float,
+            *,
+            anchor_low: bool,
+            ) -> tuple[float, float]:
+        original_cells = axis.slice_for_interval(original_low, original_high)
+        target_cells = axis.slice_for_interval(snapped_low, snapped_high)
+        cell_count = original_cells.stop - original_cells.start
+
+        if anchor_low:
+            start = target_cells.start
+            stop = min(start + cell_count, axis.count)
+            start = max(0, stop - cell_count)
+        else:
+            stop = target_cells.stop
+            start = max(0, stop - cell_count)
+            stop = min(axis.count, start + cell_count)
+
+        return axis.edges[start], axis.edges[stop]
 
 
     def _add_marquee_color_context_action(self, menu: qtw.QMenu) -> QtGui.QAction:
@@ -1151,7 +1322,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
     def _marquee_selected_data(self) -> npt.NDArray[np.float64] | None:
         if (
                 self.__dict__.get("marquee") is None
-                or self._heatmap_rect() is None
+                or self._heatmap_geometry() is None
                 or "dataGrid" not in self.__dict__
                 ):
             return None
@@ -1169,63 +1340,15 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
 
 
     def _marquee_cell_slices(self) -> tuple[slice, slice] | None:
-        heatmap_rect = self._heatmap_rect()
-        if heatmap_rect is None or self.marquee is None:
-            return None
-
-        rows, cols = self.dataGrid.shape
-        if (
-                rows <= 0
-                or cols <= 0
-                or heatmap_rect.width() <= 0
-                or heatmap_rect.height() <= 0
-                ):
+        geometry = self._heatmap_geometry()
+        if geometry is None or self.marquee is None:
             return None
 
         rect = self._snap_marquee_rect(self.marquee.normalized())
-        if rect is None:
-            return None
-
-        col_slice = self._marquee_axis_slice(
-            rect.left(),
-            rect.right(),
-            heatmap_rect.x(),
-            heatmap_rect.width(),
-            cols,
-            )
-        row_slice = self._marquee_axis_slice(
-            rect.top(),
-            rect.bottom(),
-            heatmap_rect.y(),
-            heatmap_rect.height(),
-            rows,
-            )
-        if row_slice is None or col_slice is None:
+        try:
+            col_slice = geometry.x.slice_for_interval(rect.left(), rect.right())
+            row_slice = geometry.y.slice_for_interval(rect.top(), rect.bottom())
+        except ValueError:
             return None
 
         return row_slice, col_slice
-
-
-    def _marquee_axis_slice(
-            self,
-            low: float,
-            high: float,
-            origin: float,
-            span: float,
-            count: int,
-            ) -> slice | None:
-        if count <= 0 or span <= 0:
-            return None
-
-        cell_size = span / count
-        min_value = origin
-        max_value = origin + span
-        low = min(max(low, min_value), max_value)
-        high = min(max(high, min_value), max_value)
-
-        start = int(np.floor((low - origin) / cell_size))
-        stop = int(np.ceil((high - origin) / cell_size))
-        start = min(max(start, 0), count - 1)
-        stop = min(max(stop, start + 1), count)
-
-        return slice(start, stop)

--- a/tests/test_heatmap_geometry.py
+++ b/tests/test_heatmap_geometry.py
@@ -1,0 +1,191 @@
+import math
+
+import numpy as np
+import pytest
+
+from qplot.tools.heatmap_geometry import (
+    AxisGeometry,
+    HeatmapGeometry,
+    canonicalize_heatmap_data,
+)
+
+
+@pytest.mark.parametrize(
+    ("x_centres", "y_centres", "expected_grid"),
+    [
+        ([4.0, 1.0, 0.0], [10.0, 13.0], [[3, 2, 1], [6, 5, 4]]),
+        ([0.0, 1.0, 4.0], [13.0, 10.0], [[4, 5, 6], [1, 2, 3]]),
+        ([4.0, 1.0, 0.0], [13.0, 10.0], [[6, 5, 4], [3, 2, 1]]),
+    ],
+)
+def test_canonicalize_heatmap_data_reverses_axes_with_grid(
+        x_centres,
+        y_centres,
+        expected_grid,
+        ):
+    x, y, grid = canonicalize_heatmap_data(
+        x_centres,
+        y_centres,
+        [[1, 2, 3], [4, 5, 6]],
+        )
+
+    np.testing.assert_array_equal(x, [0.0, 1.0, 4.0])
+    np.testing.assert_array_equal(y, [10.0, 13.0])
+    np.testing.assert_array_equal(grid, expected_grid)
+
+
+def test_canonicalize_heatmap_data_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="does not match"):
+        canonicalize_heatmap_data([0.0, 1.0], [10.0, 11.0], np.zeros((3, 2)))
+
+
+class TestAxisGeometry:
+    def test_uniform_centres_are_expanded_to_cell_edges(self):
+        axis = AxisGeometry([0.0, 1.0])
+
+        assert axis.centres == (0.0, 1.0)
+        assert axis.edges == (-0.5, 0.5, 1.5)
+        assert axis.is_uniform
+        assert axis.count == 2
+        assert axis.bounds == (-0.5, 1.5)
+        assert axis.span == 2.0
+
+    def test_nonuniform_centres_use_midpoints_and_end_spacing(self):
+        axis = AxisGeometry([1.0, 2.0, 5.0])
+
+        assert axis.edges == (0.5, 1.5, 3.5, 6.5)
+        assert not axis.is_uniform
+
+    @pytest.mark.parametrize("centre", [0.0, 10.0, -10.0])
+    def test_singleton_has_positive_default_span(self, centre):
+        axis = AxisGeometry([centre])
+
+        assert axis.centres == (centre,)
+        assert axis.edges == (centre - 0.5, centre + 0.5)
+        assert axis.span == 1.0
+        assert axis.is_uniform
+
+    def test_singleton_span_can_be_supplied_by_caller(self):
+        axis = AxisGeometry([1000.0], singleton_span=20.0)
+
+        assert axis.edges == (990.0, 1010.0)
+        assert axis.span == 20.0
+
+    @pytest.mark.parametrize("singleton_span", [0.0, -1.0, math.inf, math.nan])
+    def test_singleton_span_must_be_positive_and_finite(self, singleton_span):
+        with pytest.raises(ValueError, match="singleton_span"):
+            AxisGeometry([0.0], singleton_span=singleton_span)
+
+    @pytest.mark.parametrize(
+        ("centres", "message"),
+        [
+            ([], "at least one"),
+            ([0.0, math.nan], "finite"),
+            ([0.0, math.inf], "finite"),
+            ([2.0, 1.0], "descending"),
+            ([0.0, 0.0], "strictly increasing"),
+            ([0.0, 2.0, 1.0], "strictly increasing"),
+        ],
+    )
+    def test_invalid_axes_are_rejected(self, centres, message):
+        with pytest.raises(ValueError, match=message):
+            AxisGeometry(centres)
+
+    def test_index_at_maps_values_to_cells(self):
+        axis = AxisGeometry([0.0, 1.0, 2.0])
+
+        assert axis.index_at(-0.5) == 0
+        assert axis.index_at(0.49) == 0
+        assert axis.index_at(0.5) == 1
+        assert axis.index_at(2.5) == 2
+        assert axis.index_at(-0.5001) is None
+        assert axis.index_at(2.5001) is None
+        assert axis.index_at(math.nan) is None
+
+    def test_index_at_can_clamp_to_nearest_outer_cell(self):
+        axis = AxisGeometry([0.0, 1.0])
+
+        assert axis.index_at(-100.0, clamp=True) == 0
+        assert axis.index_at(100.0, clamp=True) == 1
+        assert axis.index_at(math.inf, clamp=True) is None
+
+    def test_snap_interval_uses_recorded_cell_edges(self):
+        axis = AxisGeometry([0.0, 1.0, 4.0])
+
+        assert axis.snap_interval(0.6, 4.6) == (0.5, 5.5)
+        assert axis.snap_interval(4.6, 0.6) == (0.5, 5.5)
+        assert axis.snap_interval(-100.0, 100.0) == (-0.5, 5.5)
+        assert axis.snap_interval(*axis.snap_interval(0.6, 4.6)) == (0.5, 5.5)
+
+    def test_slice_for_interval_uses_same_edges_as_snapping(self):
+        axis = AxisGeometry([0.0, 1.0, 4.0])
+
+        assert axis.slice_for_interval(0.6, 4.6) == slice(1, 3)
+        assert axis.slice_for_interval(4.6, 0.6) == slice(1, 3)
+        assert axis.slice_for_interval(-100.0, 100.0) == slice(0, 3)
+
+    def test_centre_and_cell_bounds_validate_index(self):
+        axis = AxisGeometry([0.0, 1.0, 3.0])
+
+        assert axis.centre(1) == 1.0
+        assert axis.cell_bounds(1) == (0.5, 2.0)
+        with pytest.raises(IndexError, match="axis cell index"):
+            axis.centre(3)
+        with pytest.raises(IndexError, match="axis cell index"):
+            axis.cell_bounds(-1)
+
+    def test_uniformity_tolerance_is_configurable(self):
+        nearly_uniform = [0.0, 1.0, 2.0 + 1e-10]
+
+        assert AxisGeometry(nearly_uniform).is_uniform
+        assert not AxisGeometry(nearly_uniform, uniform_rel_tol=1e-12).is_uniform
+
+    def test_edges_must_remain_distinct_at_floating_point_precision(self):
+        left = 1e16
+        adjacent = np.nextafter(left, math.inf)
+
+        with pytest.raises(ValueError, match="precision"):
+            AxisGeometry([left, adjacent])
+
+
+class TestHeatmapGeometry:
+    def test_geometry_exposes_qt_free_rect_shape_and_bounds(self):
+        geometry = HeatmapGeometry.from_centres(
+            x_centres=[0.0, 1.0],
+            y_centres=[10.0, 12.0, 14.0],
+        )
+
+        assert geometry.shape == (3, 2)
+        assert geometry.bounds == (-0.5, 9.0, 1.5, 15.0)
+        assert geometry.rect == (-0.5, 9.0, 2.0, 6.0)
+        assert geometry.is_uniform
+
+    def test_geometry_supports_independent_singleton_spans(self):
+        geometry = HeatmapGeometry.from_centres(
+            x_centres=[-4.0],
+            y_centres=[0.0],
+            x_singleton_span=2.0,
+            y_singleton_span=4.0,
+        )
+
+        assert geometry.rect == (-5.0, -2.0, 2.0, 4.0)
+
+    def test_cell_lookup_and_bounds_share_one_coordinate_model(self):
+        geometry = HeatmapGeometry.from_centres(
+            x_centres=[0.0, 1.0, 3.0],
+            y_centres=[10.0, 20.0],
+        )
+
+        assert geometry.index_at(1.8, 16.0) == (1, 1)
+        assert geometry.cell_bounds(1, 1) == (0.5, 15.0, 2.0, 25.0)
+        assert geometry.cell_rect(1, 1) == (0.5, 15.0, 1.5, 10.0)
+        assert geometry.index_at(-100.0, 16.0) is None
+        assert geometry.index_at(-100.0, 16.0, clamp=True) == (0, 1)
+
+    def test_heatmap_is_nonuniform_when_either_axis_is_nonuniform(self):
+        geometry = HeatmapGeometry.from_centres(
+            x_centres=[0.0, 1.0, 3.0],
+            y_centres=[10.0, 20.0],
+        )
+
+        assert not geometry.is_uniform

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -83,6 +83,26 @@ class ToolFunctionTestCase(unittest.TestCase):
         np.testing.assert_array_equal(axis_data["y"], np.array([0.0, 1.0]))
         np.testing.assert_array_equal(data_grid, np.array([[42.0], [43.0]]))
 
+    def test_worker_canonicalizes_descending_heatmap_axes_and_grid(self):
+        worker = loader.__new__(loader)
+        worker.axis_data = {
+            "x": np.array([4.0, 1.0, 0.0]),
+            "y": np.array([13.0, 10.0]),
+            }
+        worker.dataGrid = np.array([
+            [6.0, 5.0, 4.0],
+            [3.0, 2.0, 1.0],
+            ])
+
+        loader._canonicalize_heatmap(worker)
+
+        np.testing.assert_array_equal(worker.axis_data["x"], [0.0, 1.0, 4.0])
+        np.testing.assert_array_equal(worker.axis_data["y"], [10.0, 13.0])
+        np.testing.assert_array_equal(
+            worker.dataGrid,
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+
     def test_large_heatmap_sql_loader_uses_bounded_sample_and_grid(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             database_path = f"{tmpdir}/heatmap.db"

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -5,6 +5,7 @@ import pyqtgraph as pg
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
+from qplot.tools.heatmap_geometry import HeatmapGeometry
 from qplot.windows._dataset_handle import DatasetHandle
 from qplot.windows._plotWin import plotWidget
 from qplot.windows.plot2d import _COLORBAR_COLORMAPS, plot2d
@@ -35,6 +36,12 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
 
         window = plot2d.__new__(plot2d)
         worker = Worker()
+        window.__dict__["axis_data"] = {
+            "x": np.array([0.0, 1.0]),
+            "y": np.array([0.0, 1.0]),
+            }
+        window.__dict__["dataGrid"] = np.zeros((2, 2))
+        window._update_heatmap_geometry()
         window.worker = worker
         window._guid = "guid"
         window._dataset_holder = {"guid": DatasetHandle(Dataset())}
@@ -49,6 +56,7 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
         self.assertFalse(worker.running)
         self.assertEqual(window.end_wait.emitted, 1)
         self.assertIn("Waiting for plottable data", window.show_status_messages[-1][0])
+        self.assertIsNone(window._heatmap_geometry())
 
     def test_plottable_heatmap_data_requires_axes_and_finite_grid(self):
         window = plot2d.__new__(plot2d)
@@ -94,6 +102,16 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
 
 
 class HeatmapHoverOutlineTestCase(unittest.TestCase):
+    def configure_geometry(self, window, x_centres, y_centres, data_grid=None):
+        window.__dict__["axis_data"] = {
+            "x": np.asarray(x_centres, dtype=float),
+            "y": np.asarray(y_centres, dtype=float),
+            }
+        if data_grid is None:
+            data_grid = np.zeros((len(y_centres), len(x_centres)))
+        window.__dict__["dataGrid"] = np.asarray(data_grid, dtype=float)
+        window._update_heatmap_geometry()
+
     class SignalCatcher:
         def __init__(self):
             self.calls = []
@@ -307,8 +325,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
     def test_hover_outline_tracks_heatmap_cell_geometry(self):
         window = plot2d.__new__(plot2d)
         window.hover_pixel_outline = qtw.QGraphicsRectItem()
-        window.rect = QtCore.QRectF(10.0, 20.0, 8.0, 6.0)
-        window.dataGrid = np.zeros((3, 4))
+        self.configure_geometry(
+            window,
+            x_centres=[10.0, 12.0, 16.0, 20.0],
+            y_centres=[20.0, 23.0, 29.0],
+            )
         window.z_index = None
 
         window.show_hover_pixel_outline(2, 1)
@@ -316,14 +337,182 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         outline_rect = window.hover_pixel_outline.rect()
         self.assertTrue(window.hover_pixel_outline.isVisible())
         self.assertEqual(window.z_index, [2, 1])
-        self.assertEqual(outline_rect, QtCore.QRectF(14.0, 22.0, 2.0, 2.0))
+        self.assertEqual(outline_rect, QtCore.QRectF(14.0, 21.5, 4.0, 4.5))
+
+    def test_geometry_treats_setpoints_as_centres(self):
+        window = plot2d.__new__(plot2d)
+
+        self.configure_geometry(window, x_centres=[0.0, 1.0], y_centres=[0.0, 1.0])
+
+        self.assertEqual(window.rect, QtCore.QRectF(-0.5, -0.5, 2.0, 2.0))
+        self.assertIsInstance(window.heatmap_geometry, HeatmapGeometry)
+        self.assertEqual(window.heatmap_geometry.shape, (2, 2))
+
+    def test_singleton_geometry_has_positive_extent_at_zero_and_negative_values(self):
+        window = plot2d.__new__(plot2d)
+
+        self.configure_geometry(window, x_centres=[0.0], y_centres=[-5.0])
+
+        self.assertEqual(window.rect, QtCore.QRectF(-0.5, -5.5, 1.0, 1.0))
+        self.assertGreater(window.rect.width(), 0.0)
+        self.assertGreater(window.rect.height(), 0.0)
+
+    def test_nonuniform_marquee_snaps_to_recorded_cell_edges(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            )
+
+        rect = window._snap_marquee_rect(QtCore.QRectF(0.6, 9.0, 4.0, 3.0))
+
+        self.assertEqual(rect, QtCore.QRectF(0.5, 8.5, 5.0, 6.0))
+
+    def test_descending_axes_are_reversed_with_the_data_grid(self):
+        window = plot2d.__new__(plot2d)
+        window.__dict__["axis_data"] = {
+            "x": np.array([4.0, 1.0, 0.0]),
+            "y": np.array([13.0, 10.0]),
+            }
+        window.__dict__["dataGrid"] = np.array([
+            [60.0, 50.0, 40.0],
+            [30.0, 20.0, 10.0],
+            ])
+
+        window._update_heatmap_geometry()
+
+        self.assertEqual(window.heatmap_geometry.x.centres, (0.0, 1.0, 4.0))
+        self.assertEqual(window.heatmap_geometry.y.centres, (10.0, 13.0))
+        np.testing.assert_array_equal(
+            window.dataGrid,
+            [[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]],
+            )
+
+    def test_shape_mismatch_invalidates_installed_geometry(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0],
+            y_centres=[10.0, 11.0],
+            )
+        window.__dict__["dataGrid"] = np.zeros((3, 2))
+
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            window._update_heatmap_geometry()
+
+        self.assertIsNone(window._heatmap_geometry())
+        self.assertNotIn("rect", window.__dict__)
+
+    def test_axis_swap_rebuilds_geometry_for_transposed_data(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            data_grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+        window.__dict__["axis_data"] = {
+            "x": np.array([10.0, 13.0]),
+            "y": np.array([0.0, 1.0, 4.0]),
+            }
+        window.__dict__["dataGrid"] = window.dataGrid.transpose()
+
+        window._update_heatmap_geometry()
+
+        self.assertEqual(window.heatmap_geometry.shape, (3, 2))
+        self.assertEqual(window.heatmap_sample_at(13.0, 1.0), (1, 1, 13.0, 1.0, 5.0))
+
+    def test_uniform_grid_uses_image_renderer_at_geometry_bounds(self):
+        window = plot2d.__new__(plot2d)
+        window.__dict__["image"] = pg.ImageItem(axisOrder="row-major")
+        window.__dict__["heatmap_mesh"] = pg.PColorMeshItem()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0],
+            y_centres=[10.0, 13.0],
+            data_grid=[[1.0, 2.0], [3.0, 4.0]],
+            )
+
+        window._render_heatmap()
+
+        self.assertTrue(window.image.isVisible())
+        self.assertFalse(window.heatmap_mesh.isVisible())
+        self.assertEqual(
+            window.image.mapRectToParent(window.image.boundingRect()),
+            QtCore.QRectF(-0.5, 8.5, 2.0, 6.0),
+            )
+
+    def test_nonuniform_grid_uses_mesh_with_exact_cell_edges(self):
+        window = plot2d.__new__(plot2d)
+        window.__dict__["image"] = pg.ImageItem(axisOrder="row-major")
+        window.__dict__["heatmap_mesh"] = pg.PColorMeshItem()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            data_grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+
+        window._render_heatmap()
+
+        self.assertFalse(window.image.isVisible())
+        self.assertTrue(window.heatmap_mesh.isVisible())
+        np.testing.assert_array_equal(
+            window.heatmap_mesh.x,
+            [[-0.5, 0.5, 2.5, 5.5]] * 3,
+            )
+        np.testing.assert_array_equal(
+            window.heatmap_mesh.y,
+            [[8.5] * 4, [11.5] * 4, [14.5] * 4],
+            )
+        np.testing.assert_array_equal(window.heatmap_mesh.z, window.dataGrid)
+
+    def test_colorbar_controls_both_heatmap_renderers(self):
+        widget = pg.GraphicsLayoutWidget()
+        plot_item = widget.addPlot()
+        window = plot2d.__new__(plot2d)
+        window.__dict__["image"] = pg.ImageItem(axisOrder="row-major")
+        window.__dict__["heatmap_mesh"] = pg.PColorMeshItem()
+        plot_item.addItem(window.image)
+        plot_item.addItem(window.heatmap_mesh)
+        window.image.setImage(np.arange(4.0).reshape(2, 2))
+        x_vertices, y_vertices = np.meshgrid(range(3), range(3))
+        window.heatmap_mesh.setData(
+            x_vertices,
+            y_vertices,
+            np.arange(4.0).reshape(2, 2),
+            )
+
+        try:
+            bar = plot_item.addColorBar(
+                window._heatmap_colorbar_items(),
+                values=(0.0, 3.0),
+                colorMap=pg.colormap.get("viridis"),
+                )
+            bar.setLevels((1.0, 2.0))
+            new_colormap = pg.ColorMap(
+                [0.0, 1.0],
+                [[0, 0, 0, 255], [255, 255, 255, 255]],
+                )
+            bar.setColorMap(new_colormap)
+
+            self.assertEqual(tuple(window.image.getLevels()), (1.0, 2.0))
+            self.assertEqual(window.heatmap_mesh.getLevels(), (1.0, 2.0))
+            self.assertIs(window.image.getColorMap(), new_colormap)
+            self.assertIs(window.heatmap_mesh.getColorMap(), new_colormap)
+        finally:
+            widget.deleteLater()
 
     def test_hover_outline_hides_when_hover_index_is_invalid(self):
         window = plot2d.__new__(plot2d)
         window.hover_pixel_outline = qtw.QGraphicsRectItem()
         window.hover_pixel_outline.show()
-        window.rect = QtCore.QRectF(0.0, 0.0, 2.0, 2.0)
-        window.dataGrid = np.zeros((2, 2))
+        self.configure_geometry(
+            window,
+            x_centres=[0.5, 1.5],
+            y_centres=[0.5, 1.5],
+            )
         window.z_index = [3, 0]
 
         window._update_hover_pixel_outline_from_index()
@@ -332,17 +521,59 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_marquee_edges_snap_to_heatmap_pixel_boundaries(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(10.0, 20.0, 8.0, 6.0)
-        window.dataGrid = np.zeros((3, 4))
+        self.configure_geometry(
+            window,
+            x_centres=[11.0, 13.0, 15.0, 17.0],
+            y_centres=[21.0, 23.0, 25.0],
+            )
 
         rect = window._snap_marquee_rect(QtCore.QRectF(10.4, 21.1, 3.8, 4.8))
 
         self.assertEqual(rect, QtCore.QRectF(10.0, 20.0, 6.0, 6.0))
 
+    def test_nonuniform_marquee_selects_cells_from_geometry_edges(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            data_grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+        window.__dict__["marquee"] = QtCore.QRectF(0.6, 9.0, 1.0, 3.0)
+
+        selected = window._marquee_selected_data()
+
+        np.testing.assert_array_equal(selected, [[2.0], [5.0]])
+
+    def test_disjoint_marquee_is_cleared_after_geometry_refresh(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0],
+            y_centres=[0.0, 1.0],
+            )
+        window.__dict__["marquee"] = QtCore.QRectF(-0.5, -0.5, 2.0, 2.0)
+        self.configure_geometry(
+            window,
+            x_centres=[100.0, 101.0],
+            y_centres=[200.0, 201.0],
+            )
+        cleared = []
+        window.clear_marquee = lambda: cleared.append(True)
+        window.set_marquee_rect = lambda _rect: self.fail("marquee was resnapped")
+        window.__dict__["sweep_lines"] = {}
+
+        window._restore_heatmap_interactions()
+
+        self.assertEqual(cleared, [True])
+
     def test_shift_drag_corner_keeps_heatmap_pixel_marquee_size_after_snap(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 0.0, 20.0, 20.0)
-        window.dataGrid = np.zeros((20, 20))
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 20.0),
+            y_centres=np.arange(0.5, 20.0),
+            )
         rect = QtCore.QRectF(0.0, 0.0, 10.0, 10.0)
 
         window._resize_marquee_rect(
@@ -355,11 +586,38 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         self.assertEqual(rect, QtCore.QRectF(1.0, 1.0, 10.0, 10.0))
 
+    def test_shift_drag_preserves_cell_count_on_nonuniform_axis(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0, 10.0],
+            y_centres=[0.0, 1.0],
+            )
+        rect = QtCore.QRectF(-0.5, -0.5, 3.0, 2.0)
+
+        window._resize_marquee_rect(
+            rect,
+            "e",
+            QtCore.QPointF(7.1, 0.5),
+            QtCore.Qt.KeyboardModifier.ShiftModifier,
+            )
+        rect = window._snap_marquee_rect(rect.normalized())
+
+        self.assertEqual(rect, QtCore.QRectF(2.5, -0.5, 10.5, 2.0))
+        self.assertEqual(
+            window.heatmap_geometry.x.slice_for_interval(rect.left(), rect.right()),
+            slice(2, 4),
+            )
+
     def test_marquee_menu_includes_zoom_color_for_2d_plots(self):
         window = plot2d.__new__(plot2d)
         window.marquee = QtCore.QRectF(1.0, 1.0, 2.0, 2.0)
-        window.rect = QtCore.QRectF(0.0, 0.0, 4.0, 4.0)
-        window.dataGrid = np.arange(16.0).reshape(4, 4)
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 4.0),
+            y_centres=np.arange(0.5, 4.0),
+            data_grid=np.arange(16.0).reshape(4, 4),
+            )
 
         menu = window._new_marquee_context_menu()
         action_texts = [action.text() for action in menu.actions()]
@@ -399,8 +657,12 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
     def test_zoom_color_uses_data_inside_marquee(self):
         window = plot2d.__new__(plot2d)
         window.marquee = QtCore.QRectF(1.0, 1.0, 2.0, 2.0)
-        window.rect = QtCore.QRectF(0.0, 0.0, 4.0, 4.0)
-        window.dataGrid = np.arange(16.0).reshape(4, 4)
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 4.0),
+            y_centres=np.arange(0.5, 4.0),
+            data_grid=np.arange(16.0).reshape(4, 4),
+            )
         window.bar = self.Colorbar()
         window._colorbar_manual_levels = None
 
@@ -412,8 +674,12 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
     def test_stats_action_opens_dialog_and_clears_marquee(self):
         window = plot2d.__new__(plot2d)
         window.marquee = QtCore.QRectF(1.0, 1.0, 2.0, 2.0)
-        window.rect = QtCore.QRectF(0.0, 0.0, 4.0, 4.0)
-        window.dataGrid = np.arange(16.0).reshape(4, 4)
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 4.0),
+            y_centres=np.arange(0.5, 4.0),
+            data_grid=np.arange(16.0).reshape(4, 4),
+            )
         opened = []
         window.clear_marquee = lambda: setattr(window, "marquee", None)
         window.show_marquee_stats_dialog = lambda stats_text=None: opened.append(stats_text) or True
@@ -467,9 +733,19 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         widget = pg.GraphicsLayoutWidget()
         plot_item = widget.addPlot()
         window = plot2d.__new__(plot2d)
-        window.plot = plot_item
-        window.rect = QtCore.QRectF(0.0, 0.0, 1.0, 1.0)
-        window.dataGrid = np.array([[1.0, 2.0], [3.0, 4.0]])
+        class Plot:
+            vb = plot_item.vb
+
+            def sceneBoundingRect(self):
+                return QtCore.QRectF(-1e9, -1e9, 2e9, 2e9)
+
+        window.plot = Plot()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0],
+            y_centres=[0.0, 1.0],
+            data_grid=[[1.0, 2.0], [3.0, 4.0]],
+            )
         window.pos_labels = {
             "index": qtw.QLabel(),
             "x": qtw.QLabel(),
@@ -480,15 +756,167 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         shown_indices = []
         window.show_hover_pixel_outline = lambda i, j: shown_indices.append((i, j))
         window.hide_hover_pixel_outline = lambda: shown_indices.append(None)
-        scene_pos = plot_item.vb.mapViewToScene(QtCore.QPointF(1.0, 1.0))
+        scene_pos = plot_item.vb.mapViewToScene(QtCore.QPointF(1.5, 1.5))
 
         plotWidget.mouseMoved(window, scene_pos)
 
         self.assertEqual(shown_indices, [(1, 1)])
         self.assertEqual(window.pos_labels["index"].text(), "[1,1]")
-        self.assertEqual(window.pos_labels["x"].text(), "x = 0.75;")
-        self.assertEqual(window.pos_labels["y"].text(), "y = 0.75;")
+        self.assertEqual(window.pos_labels["x"].text(), "x = 1.0;")
+        self.assertEqual(window.pos_labels["y"].text(), "y = 1.0;")
         self.assertEqual(window.pos_labels["z"].text(), "z = 4.0")
+
+    def test_nonuniform_hover_reports_recorded_setpoint(self):
+        widget = pg.GraphicsLayoutWidget()
+        plot_item = widget.addPlot()
+        window = plot2d.__new__(plot2d)
+        class Plot:
+            vb = plot_item.vb
+
+            def sceneBoundingRect(self):
+                return QtCore.QRectF(-1e9, -1e9, 2e9, 2e9)
+
+        window.plot = Plot()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            data_grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+        window.pos_labels = {
+            "index": qtw.QLabel(),
+            "x": qtw.QLabel(),
+            "y": qtw.QLabel(),
+            "z": qtw.QLabel(),
+            }
+        window.formatNum = lambda value: str(value)
+        window.show_hover_pixel_outline = lambda _i, _j: None
+        window.hide_hover_pixel_outline = lambda: None
+        scene_pos = plot_item.vb.mapViewToScene(QtCore.QPointF(2.0, 12.0))
+
+        try:
+            plotWidget.mouseMoved(window, scene_pos)
+
+            self.assertEqual(window.pos_labels["index"].text(), "[1,1]")
+            self.assertEqual(window.pos_labels["x"].text(), "x = 1.0;")
+            self.assertEqual(window.pos_labels["y"].text(), "y = 13.0;")
+            self.assertEqual(window.pos_labels["z"].text(), "z = 5.0")
+        finally:
+            widget.deleteLater()
+
+    def test_hover_outside_geometry_clears_stale_index_and_value(self):
+        widget = pg.GraphicsLayoutWidget()
+        plot_item = widget.addPlot()
+
+        class Plot:
+            vb = plot_item.vb
+
+            def sceneBoundingRect(self):
+                return QtCore.QRectF(-1e9, -1e9, 2e9, 2e9)
+
+        window = plot2d.__new__(plot2d)
+        window.plot = Plot()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0],
+            y_centres=[0.0, 1.0],
+            data_grid=[[1.0, 2.0], [3.0, 4.0]],
+            )
+        window.pos_labels = {
+            "index": qtw.QLabel(),
+            "x": qtw.QLabel(),
+            "y": qtw.QLabel(),
+            "z": qtw.QLabel(),
+            }
+        window.formatNum = lambda value: str(value)
+        hidden = []
+        window.show_hover_pixel_outline = lambda _i, _j: None
+        window.hide_hover_pixel_outline = lambda: hidden.append(True)
+
+        try:
+            inside = plot_item.vb.mapViewToScene(QtCore.QPointF(1.0, 1.0))
+            outside = plot_item.vb.mapViewToScene(QtCore.QPointF(10.0, 10.0))
+            plotWidget.mouseMoved(window, inside)
+            plotWidget.mouseMoved(window, outside)
+
+            self.assertEqual(window.pos_labels["index"].text(), "")
+            self.assertEqual(window.pos_labels["z"].text(), "z =")
+            self.assertEqual(hidden, [True])
+        finally:
+            widget.deleteLater()
+
+    def test_geometry_replacement_clears_stale_hover_labels(self):
+        window = plot2d.__new__(plot2d)
+        window.__dict__["pos_labels"] = {
+            "index": qtw.QLabel("[1,1]"),
+            "z": qtw.QLabel("z = 4.0"),
+            }
+        window.__dict__["z_index"] = [1, 1]
+
+        self.configure_geometry(
+            window,
+            x_centres=[10.0, 11.0],
+            y_centres=[20.0, 21.0],
+            )
+
+        self.assertIsNone(window.z_index)
+        self.assertEqual(window.pos_labels["index"].text(), "")
+        self.assertEqual(window.pos_labels["z"].text(), "z =")
+
+    def test_nonuniform_sweep_uses_recorded_centres_and_edges(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 4.0],
+            y_centres=[10.0, 13.0],
+            )
+        window.sweep_moved = self.SignalCatcher()
+        line = self.SweepLine(sweep_id=5, angle=90, value=2.6)
+
+        window.moving_sweep(line)
+
+        self.assertEqual(line.sweep_index, 2)
+        self.assertEqual(line.value(), 4.0)
+        self.assertEqual(line.bounds, (0.0, 4.0))
+        self.assertEqual(window.sweep_moved.calls, [(5, 2)])
+
+    def test_geometry_refresh_remaps_sweep_from_its_physical_coordinate(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 1.0, 2.0],
+            y_centres=[10.0, 11.0],
+            )
+        line = self.SweepLine(sweep_id=5, angle=90, value=2.0)
+        line.sweep_index = 2
+        window.__dict__["sweep_lines"] = {5: line}
+        window.__dict__["sweep_moved"] = self.SignalCatcher()
+        self.configure_geometry(
+            window,
+            x_centres=[0.0, 2.0, 4.0],
+            y_centres=[10.0, 11.0],
+            )
+
+        window._snap_sweep_lines_to_pixel_centres()
+
+        self.assertEqual(line.sweep_index, 1)
+        self.assertEqual(line.value(), 2.0)
+        self.assertEqual(window.sweep_moved.calls, [(5, 1)])
+
+    def test_sweep_events_are_noops_without_geometry(self):
+        window = plot2d.__new__(plot2d)
+        window.__dict__["sweep_moved"] = self.SignalCatcher()
+        line = self.SweepLine(sweep_id=5, angle=90, value=2.0)
+        line.sweep_index = 1
+        window.__dict__["sweep_lines"] = {5: line}
+        window.__dict__["active_sweep_line_id"] = 5
+
+        window.moving_sweep(line)
+        window.move_sweep_with_arrow_key(QtCore.Qt.Key.Key_Right)
+
+        self.assertEqual(line.sweep_index, 1)
+        self.assertEqual(line.value(), 2.0)
+        self.assertEqual(window.sweep_moved.calls, [])
 
     def test_mouse_moved_shows_heatmap_indices_before_coordinates(self):
         widget = pg.GraphicsLayoutWidget()
@@ -502,8 +930,12 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         window = plot2d.__new__(plot2d)
         window.plot = Plot()
-        window.rect = QtCore.QRectF(0.0, 0.0, 4.0, 3.0)
-        window.dataGrid = np.arange(12.0).reshape(3, 4)
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 4.0),
+            y_centres=np.arange(0.5, 3.0),
+            data_grid=np.arange(12.0).reshape(3, 4),
+            )
         window.pos_labels = {
             "index": qtw.QLabel(),
             "x": qtw.QLabel(),
@@ -527,8 +959,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_dragged_sweep_line_snaps_to_heatmap_pixel_centre(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 10.0, 4.0, 6.0)
-        window.dataGrid = np.zeros((3, 4))
+        self.configure_geometry(
+            window,
+            x_centres=[0.5, 1.5, 2.5, 3.5],
+            y_centres=[11.0, 13.0, 15.0],
+            )
         window.sweep_moved = self.SignalCatcher()
         line = self.SweepLine(sweep_id=5, angle=90, value=2.7)
 
@@ -542,8 +977,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_shift_drag_moves_same_orientation_sweep_lines_together(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 10.0, 5.0, 4.0)
-        window.dataGrid = np.zeros((4, 5))
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 5.0),
+            y_centres=np.arange(10.5, 14.0),
+            )
         window.sweep_moved = self.SignalCatcher()
         window.sweep_group_drag_requested = lambda: True
         dragged_line = self.SweepLine(sweep_id=1, angle=90, value=2.7)
@@ -571,8 +1009,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_shift_drag_keeps_sweep_group_spacing_at_heatmap_edge(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 10.0, 5.0, 4.0)
-        window.dataGrid = np.zeros((4, 5))
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(0.5, 5.0),
+            y_centres=np.arange(10.5, 14.0),
+            )
         window.sweep_moved = self.SignalCatcher()
         window.sweep_group_drag_requested = lambda: True
         dragged_line = self.SweepLine(sweep_id=1, angle=90, value=2.7)
@@ -705,8 +1146,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_arrow_key_moves_active_sweep_line_by_one_pixel(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 10.0, 4.0, 6.0)
-        window.dataGrid = np.zeros((3, 4))
+        self.configure_geometry(
+            window,
+            x_centres=[0.5, 1.5, 2.5, 3.5],
+            y_centres=[11.0, 13.0, 15.0],
+            )
         window.sweep_moved = self.SignalCatcher()
         line = self.SweepLine(sweep_id=8, angle=90, value=1.5)
         line.sweep_index = 1
@@ -721,8 +1165,11 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
     def test_arrow_key_clamps_sweep_line_to_heatmap_edge(self):
         window = plot2d.__new__(plot2d)
-        window.rect = QtCore.QRectF(0.0, 10.0, 4.0, 6.0)
-        window.dataGrid = np.zeros((3, 4))
+        self.configure_geometry(
+            window,
+            x_centres=[0.5, 1.5, 2.5, 3.5],
+            y_centres=[11.0, 13.0, 15.0],
+            )
         window.sweep_moved = self.SignalCatcher()
         line = self.SweepLine(sweep_id=8, angle=90, value=3.5)
         line.sweep_index = 3


### PR DESCRIPTION
Fix this bug identified by Codex:
The image rectangle treats the minimum and maximum setpoints as pixel boundaries instead of pixel centres. For a two-point axis [0, 1], the rendered centres become 0.25 and 0.75. Hover coordinates and cut positions inherit the error. An existing test actually expects 0.75, encoding the faulty geometry.
Singleton axes are also assigned minimum / 100; zero produces zero width and negative coordinates produce negative width, potentially making early live sweeps invisible.