### PR TITLE
Roll back dataset ownership when plot construction fails

### DIFF
--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -51,41 +51,66 @@ class PlotActionsMixin:
             ds = guid_or_ds
             guid = ds.guid
 
-        self.add_ds_at(guid, ds=ds)
+        shared_handle = self.dataset_holder.get(guid)
+        loaded_for_construction = shared_handle is None and ds is None
+        if shared_handle is not None:
+            construction_ds = shared_handle.dataset
+        elif loaded_for_construction:
+            construction_ds = load_by_guid_read_only(guid)
+        else:
+            construction_ds = ds
 
-        win = widget(
-            guid,
-            *args,
-            self.config,
-            self.threadPool,
-            self.dataset_holder,
-            show=show,
-            **kargs,
-        )
+        assert construction_ds.guid == guid
+        construction_holder = {
+            held_guid: DatasetHandle(dataset=handle.dataset, users=handle.users)
+            for held_guid, handle in self.dataset_holder.items()
+        }
+        construction_holder[guid] = DatasetHandle(dataset=construction_ds)
+
+        try:
+            win = widget(
+                guid,
+                *args,
+                self.config,
+                self.threadPool,
+                construction_holder,
+                show=show,
+                **kargs,
+            )
+            window_type = win.__class__.__name__
+            if window_type not in {"plot1d", "plot2d", "sweeper"}:
+                raise TypeError(f"Unknown window of type: {window_type}")
+        except Exception:
+            if loaded_for_construction:
+                try:
+                    construction_ds.conn.close()
+                except Exception as err:
+                    log_exception("Unused plot dataset cleanup failed", err, __name__)
+            raise
+
+        win._dataset_holder = self.dataset_holder
+        self.add_ds_at(guid, ds=construction_ds)
 
         self.windows.append(win)
 
         win.closed.connect(self.onClose)
         win.make_ds.connect(self.add_ds_at)
         win.previewTraceDropRequested.connect(self.add_dropped_preview_to_plot)
-        if win.__class__.__name__ == "plot1d":
+        if window_type == "plot1d":
             win.get_mergables.connect(lambda: self.get_1d_wins(win))
             win.remove_dataset.connect(self.remove_ds_at)
 
-        elif win.__class__.__name__ == "plot2d":
+        elif window_type == "plot2d":
             win.open_subplot.connect(self.openWin)
             win.close_sweeps_requested.connect(self.close_sweeps_from_plot)
 
-        elif win.__class__.__name__ == "sweeper":
+        elif window_type == "sweeper":
             for item in self.windows:
                 if item.ds == win.ds and item.param == win.param and isinstance(item, plot2d):
                     win.sweep_moved.connect(item.update_sweep_line)
                     win.remove_sweep.connect(item.remove_sweep)
                     item.sweep_moved.connect(win.update_sweep_line)
                     break
-
-        else:
-            raise TypeError(f"Unknown window of type: {win.__class__.__name__}")
 
         if show:
             win.update_theme(self.config)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -2,6 +2,7 @@ import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
@@ -131,6 +132,134 @@ class DatasetHandleTestCase(unittest.TestCase):
 
         harness.remove_ds_at("guid")
         self.assertEqual(harness.dataset_holder, {})
+
+    def test_failed_plot_construction_preserves_existing_dataset_ownership(self):
+        class Connection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class Timer:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        class Dataset:
+            guid = "guid"
+
+            def __init__(self):
+                self.conn = Connection()
+
+        class Harness(PlotActionsMixin):
+            def __init__(self, handle):
+                self.config = object()
+                self.dataset_holder = {"guid": handle}
+                self.threadPool = object()
+                self.windows = []
+
+        def failing_widget(*args, **kwargs):
+            construction_handle = args[-1]["guid"]
+            construction_handle.cancel_delete_timer()
+            raise RuntimeError("plot construction failed")
+
+        timer = Timer()
+        dataset = Dataset()
+        handle = DatasetHandle(dataset, users=0, delete_timer=timer)
+        harness = Harness(handle)
+
+        with self.assertRaisesRegex(RuntimeError, "plot construction failed"):
+            harness.openWin(failing_widget, "guid", show=False)
+
+        self.assertEqual(harness.dataset_holder, {"guid": handle})
+        self.assertIs(harness.dataset_holder["guid"].dataset.conn, dataset.conn)
+        self.assertEqual(handle.users, 0)
+        self.assertIs(handle.delete_timer, timer)
+        self.assertFalse(timer.stopped)
+        self.assertFalse(dataset.conn.closed)
+        self.assertEqual(harness.windows, [])
+
+    def test_failed_plot_construction_does_not_publish_new_dataset(self):
+        class Connection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class Dataset:
+            guid = "guid"
+
+            def __init__(self):
+                self.conn = Connection()
+
+        class Harness(PlotActionsMixin):
+            def __init__(self):
+                self.config = object()
+                self.dataset_holder = {}
+                self.threadPool = object()
+                self.windows = []
+
+        constructor_connections = []
+
+        def failing_widget(*args, **kwargs):
+            construction_holder = args[-1]
+            constructor_connections.append(construction_holder["guid"].dataset.conn)
+            raise RuntimeError("plot construction failed")
+
+        dataset = Dataset()
+        harness = Harness()
+
+        with self.assertRaisesRegex(RuntimeError, "plot construction failed"):
+            harness.openWin(failing_widget, dataset, show=False)
+
+        self.assertEqual(constructor_connections, [dataset.conn])
+        self.assertFalse(dataset.conn.closed)
+        self.assertEqual(harness.dataset_holder, {})
+        self.assertEqual(harness.windows, [])
+
+    def test_failed_plot_construction_closes_transient_loaded_connection(self):
+        class Connection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class Dataset:
+            guid = "guid"
+
+            def __init__(self):
+                self.conn = Connection()
+
+        class Harness(PlotActionsMixin):
+            def __init__(self):
+                self.config = object()
+                self.dataset_holder = {}
+                self.threadPool = object()
+                self.windows = []
+
+        def failing_widget(*args, **kwargs):
+            raise RuntimeError("plot construction failed")
+
+        dataset = Dataset()
+        harness = Harness()
+
+        with (
+            patch(
+                "qplot.windows._plot_actions.load_by_guid_read_only",
+                return_value=dataset,
+            ),
+            self.assertRaisesRegex(RuntimeError, "plot construction failed"),
+        ):
+            harness.openWin(failing_widget, "guid", show=False)
+
+        self.assertTrue(dataset.conn.closed)
+        self.assertEqual(harness.dataset_holder, {})
+        self.assertEqual(harness.windows, [])
 
 
 class DatabaseOpenDirectoryTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

- construct plot windows against an isolated dataset-handle map
- publish or retain dataset ownership only after construction succeeds
- preserve existing reference counts, delayed-release timers, and shared database connections on failure
- close transient read-only connections loaded solely for a failed construction

## Root cause

`openWin` updated the shared dataset holder before invoking the plot constructor. If construction raised, the new handle or incremented user count remained behind, and retaining an existing handle could also cancel its pending deletion timer.

## Impact

Failed plot creation now leaves shared ownership state exactly as it was. Successful windows are rebound to the real shared holder before normal signal wiring continues.

Part of #25.

## Validation

- `.venv-mac/bin/python -m pytest -q` — 353 passed, 2 subtests passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m mypy` — passed
- qPlot offscreen startup smoke check — main GUI initialized successfully
