### PR TITLE
Use run IDs for the database refresh cursor

### DIFF
--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -177,16 +177,17 @@ def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
         conn.close()
 
 
-def find_new_runs(last_time):
+def find_new_runs(last_run_id):
     """
-    Fetches all runs produced after the last_time. Otherwise functions the same
-    as get_runs_via_sql()
+    Fetch all runs created after the last seen run ID.
+
+    Run IDs provide a monotonic cursor even when a run has no timestamp or
+    multiple runs share the same timestamp.
 
     Parameters
     ----------
-    last_time : float
-        Only data after produced last_time will be returned.
-        last_time is in unix time.
+    last_run_id : int
+        Only runs with a greater run ID will be returned.
 
     Returns
     -------
@@ -199,7 +200,7 @@ def find_new_runs(last_time):
 
     try:
         cursor = conn.cursor()
-        return _fetch_run_rows(cursor, "WHERE runs.run_timestamp > ?", (last_time, ))
+        return _fetch_run_rows(cursor, "WHERE runs.run_id > ?", (last_run_id, ))
     finally:
         conn.close()
 

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -1,7 +1,6 @@
 import os
 from time import perf_counter
 
-import numpy as np
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 from PyQt6.QtGui import QDesktopServices
@@ -231,7 +230,7 @@ class DatabaseActionsMixin:
         self.RunList.clearSelection()
         self.RunList.clear()
         self.RunList.watching = []
-        self.RunList.maxTime = 0
+        self.RunList.maxRunId = 0
         self.RunList.blockSignals(False)
         self.RunList.scrollToTop()
 
@@ -286,7 +285,7 @@ class DatabaseActionsMixin:
         self.show_status("Checking for new runs...", 0)
 
         try:
-            newRuns = find_new_runs(self.RunList.maxTime)
+            newRuns = find_new_runs(self.RunList.maxRunId)
             updatedRuns = self.RunList.checkWatching()
             if updatedRuns:
                 self.infoBox.preview.add_runs(updatedRuns)
@@ -298,6 +297,16 @@ class DatabaseActionsMixin:
             self.show_error("Refresh Failed", "Could not refresh the run list.", str(err))
             return
 
+        if newRuns:
+            self.RunList.maxRunId = max(self.RunList.maxRunId, max(newRuns))
+            # Failed initialisations without a timestamp remain hidden, but
+            # still advance the cursor so later valid runs can be discovered.
+            newRuns = {
+                run_id: metadata
+                for run_id, metadata in newRuns.items()
+                if metadata.get("run_timestamp")
+                }
+
         if not newRuns:
             self._sync_empty_state()
             if self.RunList.topLevelItemCount() == 0:
@@ -306,13 +315,6 @@ class DatabaseActionsMixin:
                 self.show_status("No new runs found.", 3000)
             return
 
-        self.RunList.maxTime = max(
-            np.array(
-                [subDict["run_timestamp"] for subDict in newRuns.values()],
-                dtype=float,
-            ),
-            default=0,
-        )
         self.RunList.addRuns(newRuns)
         self.infoBox.preview.add_runs(newRuns)
         prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
@@ -598,7 +600,7 @@ class DatabaseActionsMixin:
         self.RunList.clearSelection()
         self.RunList.clear()
         self.RunList.watching = []
-        self.RunList.maxTime = 0
+        self.RunList.maxRunId = 0
         self.RunList.scrollToTop()
 
         self.infoBox.clear()
@@ -660,7 +662,7 @@ class DatabaseActionsMixin:
         self.RunList.clearSelection()
         self.RunList.clear()
         self.RunList.watching = []
-        self.RunList.maxTime = 0
+        self.RunList.maxRunId = 0
         if previous_runs:
             self.RunList.addRuns(previous_runs)
         self.RunList.scrollToTop()
@@ -774,7 +776,7 @@ class DatabaseActionsMixin:
         runs = runs or {}
         self.RunList.clear()
         self.RunList.watching = []
-        self.RunList.maxTime = 0
+        self.RunList.maxRunId = 0
         self.RunList.addRuns(runs)
         self.infoBox.preview.set_database_runs(abspath, runs)
         self.select_default_run()

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -143,6 +143,7 @@ class RunList(qtw.QTreeWidget):
         
         self.watching: list[SortableTreeWidgetItem] = []
         self.preview_cells: dict[str, RunPreviewCell] = {}
+        self.maxRunId = 0
         
         self.setColumnCount(len(self.cols))
         self.setHeaderLabels(self.cols)
@@ -197,7 +198,7 @@ class RunList(qtw.QTreeWidget):
 
         self.setSortingEnabled(False) # Prevent constant restort on adding items
 
-        self.maxTime = max(np.array([subDict["run_timestamp"] for subDict in runs.values()], dtype=float), default=0)
+        self.maxRunId = max(self.maxRunId, max(runs, default=0))
         
         for run_id, metadata in runs.items():
             append_to_watching = False

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -8,6 +8,61 @@ from qplot.datahandling import readSQL
 
 
 class RunSizeTestCase(unittest.TestCase):
+    def test_find_new_runs_uses_run_id_when_timestamps_are_missing_or_equal(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "runs.db")
+            conn = sqlite3.connect(database_path)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    CREATE TABLE experiments (
+                        exp_id INTEGER,
+                        name TEXT,
+                        sample_name TEXT
+                    )
+                    """
+                    )
+                cursor.execute(
+                    """
+                    CREATE TABLE runs (
+                        run_id INTEGER,
+                        exp_id INTEGER,
+                        name TEXT,
+                        run_timestamp REAL,
+                        completed_timestamp REAL,
+                        is_completed INTEGER,
+                        guid TEXT,
+                        result_table_name TEXT,
+                        parameters TEXT,
+                        run_description TEXT
+                    )
+                    """
+                    )
+                cursor.execute("INSERT INTO experiments VALUES (1, 'exp', 'sample')")
+                for run_id, run_timestamp in ((1, 100.0), (2, None), (3, 100.0)):
+                    table_name = f"results_{run_id}"
+                    cursor.execute(f"CREATE TABLE {table_name} (signal REAL)")
+                    cursor.execute(
+                        "INSERT INTO runs VALUES (?, 1, 'run', ?, NULL, 0, ?, ?, "
+                        "'signal', '{}')",
+                        (run_id, run_timestamp, f"guid-{run_id}", table_name),
+                        )
+                conn.commit()
+            finally:
+                conn.close()
+
+            old_connection = readSQL.qcodes_read_only_connection
+            readSQL.qcodes_read_only_connection = (
+                lambda _database_path: sqlite3.connect(database_path)
+                )
+            try:
+                runs = readSQL.find_new_runs(1)
+            finally:
+                readSQL.qcodes_read_only_connection = old_connection
+
+        self.assertEqual(set(runs), {2, 3})
+
     def test_fetch_basic_run_rows_does_not_scan_result_tables(self):
         conn = sqlite3.connect(":memory:")
         try:

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -12,6 +12,30 @@ from qplot.windows._widgets.preview import (
 
 
 class RunListTooltipTestCase(unittest.TestCase):
+    def test_add_runs_advances_run_id_cursor_past_missing_timestamp(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                2: {"run_timestamp": None},
+                3: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": 110.0,
+                    "is_completed": True,
+                    "guid": "guid-3",
+                    "sweep_parameters": [],
+                    "measure_parameters": ["signal"],
+                    "result_count": 1,
+                    },
+                })
+
+            self.assertEqual(run_list.maxRunId, 3)
+            self.assertEqual(run_list.topLevelItemCount(), 1)
+        finally:
+            treeWidgets.isfile = old_isfile
+
     def test_run_tooltip_summarises_parameters(self):
         tooltip = treeWidgets.run_tooltip_text({
             "sweep_parameters": ["dac_ch1", "dac_ch2"],

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -827,7 +827,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
                 self.selection_cleared = False
                 self.scrolled = False
                 self.watching = ["run"]
-                self.maxTime = 123
+                self.maxRunId = 123
 
             def blockSignals(self, blocked):
                 self.signals_blocked = blocked
@@ -908,7 +908,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
         self.assertTrue(harness.RunList.selection_cleared)
         self.assertTrue(harness.RunList.cleared)
         self.assertEqual(harness.RunList.watching, [])
-        self.assertEqual(harness.RunList.maxTime, 0)
+        self.assertEqual(harness.RunList.maxRunId, 0)
         self.assertTrue(harness.infoBox.cleared)
         self.assertEqual(harness.infoBox.preview.database_runs, ("", {}))
         self.assertTrue(harness.emptyStateFrame.visible)
@@ -1009,7 +1009,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             self.selection_cleared = False
             self.scrolled = False
             self.watching = ["old"]
-            self.maxTime = 9
+            self.maxRunId = 9
             self.selected_ids = [8]
             self.visible_ids = [9, 7, 6]
 
@@ -1021,6 +1021,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
         def addRuns(self, runs):
             self.runs = runs
+            self.maxRunId = max(runs, default=0)
 
         def scrollToTop(self):
             self.scrolled = True
@@ -1235,7 +1236,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             ("old.db", previous_runs),
             )
         self.assertEqual(harness.RunList.watching, [])
-        self.assertEqual(harness.RunList.maxTime, 0)
+        self.assertEqual(harness.RunList.maxRunId, 5)
         self.assertEqual(harness.monitor.started, [1500])
         self.assertFalse(harness.databaseLoadFrame.visible)
         self.assertEqual(harness.databaseLoadLabel.text, "")
@@ -1292,7 +1293,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
     class RunList:
         def __init__(self):
-            self.maxTime = 0
+            self.maxRunId = 0
             self.checked_watching = False
 
         def checkWatching(self):
@@ -1327,7 +1328,7 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
 
     def test_refresh_empty_database_reports_waiting_state(self):
         old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda last_time: {}
+        database_actions.find_new_runs = lambda last_run_id: {}
 
         try:
             harness = self.Harness()
@@ -1349,7 +1350,7 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
 class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
     class RunList:
         def __init__(self, updated_runs):
-            self.maxTime = 12.0
+            self.maxRunId = 3
             self.updated_runs = updated_runs
 
         def checkWatching(self):
@@ -1397,7 +1398,7 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
                 },
             }
         old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda _last_time: {}
+        database_actions.find_new_runs = lambda _last_run_id: {}
 
         try:
             harness = self.Harness(updated_runs)
@@ -1415,7 +1416,7 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
 class RefreshMainAutoPlotTestCase(unittest.TestCase):
     class RunList:
         def __init__(self):
-            self.maxTime = 10.0
+            self.maxRunId = 10
             self.checked_watching = False
             self.added_runs = None
 
@@ -1471,14 +1472,15 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
 
     def test_refresh_auto_plots_new_runs_when_enabled(self):
         new_runs = {
-            1: {"guid": "guid-1", "run_timestamp": 11.0},
-            2: {"guid": "guid-2", "run_timestamp": 12.5},
+            11: {"guid": "guid-11", "run_timestamp": None},
+            12: {"guid": "guid-12", "run_timestamp": 12.5},
+            13: {"guid": "guid-13", "run_timestamp": 12.5},
             }
-        seen_last_times = []
+        seen_last_run_ids = []
         old_find_new_runs = database_actions.find_new_runs
 
-        def find_new_runs(last_time):
-            seen_last_times.append(last_time)
+        def find_new_runs(last_run_id):
+            seen_last_run_ids.append(last_run_id)
             return new_runs
 
         database_actions.find_new_runs = find_new_runs
@@ -1488,13 +1490,14 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
         finally:
             database_actions.find_new_runs = old_find_new_runs
 
-        self.assertEqual(seen_last_times, [10.0])
+        self.assertEqual(seen_last_run_ids, [10])
         self.assertTrue(harness.RunList.checked_watching)
-        self.assertEqual(harness.RunList.maxTime, 12.5)
-        self.assertIs(harness.RunList.added_runs, new_runs)
-        self.assertIs(harness.infoBox.preview.added_runs, new_runs)
+        self.assertEqual(harness.RunList.maxRunId, 13)
+        expected_runs = {12: new_runs[12], 13: new_runs[13]}
+        self.assertEqual(harness.RunList.added_runs, expected_runs)
+        self.assertEqual(harness.infoBox.preview.added_runs, expected_runs)
         self.assertEqual(harness.sync_count, 1)
-        self.assertEqual(harness.plotted_guids, ["guid-1", "guid-2"])
+        self.assertEqual(harness.plotted_guids, ["guid-12", "guid-13"])
         self.assertEqual(
             harness.status_messages,
             [
@@ -1505,8 +1508,8 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
 
     def test_refresh_does_not_auto_plot_new_runs_when_disabled(self):
         old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda _last_time: {
-            1: {"guid": "guid-1", "run_timestamp": 11.0},
+        database_actions.find_new_runs = lambda _last_run_id: {
+            11: {"guid": "guid-11", "run_timestamp": 11.0},
             }
         try:
             harness = self.Harness(auto_plot_checked=False)


### PR DESCRIPTION
## Summary

- replace the timestamp refresh watermark with a monotonic run-ID cursor
- advance the cursor past timestamp-less failed initialisations while keeping those rows hidden
- preserve run-list, preview, status, watched-run, and auto-plot refresh behaviour
- add regression coverage for missing and equal timestamps

## Root cause

Refreshes queried for `run_timestamp > last_timestamp`. Runs with a missing timestamp were excluded, and later runs sharing the watermark timestamp were also excluded, so the run list could fail to discover valid newer run IDs.

## Impact

Later runs now appear based on their run ID even when an intervening run has no timestamp or multiple runs have the same timestamp.

## Validation

- `.venv-mac/bin/python -m pytest -q` — 355 passed, 2 subtests passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m mypy` — passed
- `.venv-mac/bin/python -m qplot` — startup smoke passed
- `git diff --check` — passed

Part of #25.