### PR TITLE
Use spatial aggregation for large heatmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
-No changes yet.
+### Changed
+
+- Large heatmaps now use bounded spatial mean aggregation in SQL instead of
+  periodic database-row sampling. Every matching source row contributes, so
+  the plotted heatmap no longer depends on row insertion order, while axis
+  centres retain the corrected source heatmap extent.
+- Large preview images and run-list thumbnails now originate from spatial bin
+  means instead of periodic row-ID samples, preventing scan-pattern aliasing.
+
+### Fixed
+
+- Zoom to All, the on-plot auto-range button, and manual zooming out now
+  restore and reload the complete source extent after a large heatmap has
+  loaded a zoomed visible range.
 
 ## 1.5.0-a1 - 2026-05-21
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ Config keys use dotted paths in code and in `qplot-cfg`, for example
 | `user_preference.copy_plot_image_resolution` | string | `"screen"` | `screen`, `dpi_300`, or `svg` | Format/resolution used by plot-window Copy Plot Image. |
 | `user_preference.default_refresh_rate` | number | `1` | `value >= 0` | Default plot refresh interval. |
 | `runtime_settings.max_threads` | integer | `4` | `value >= 1` | Maximum worker threads for background loading. |
-| `runtime_settings.max_full_heatmap_points` | integer | `2000000` | `1 <= value <= 2000000000` | Maximum estimated points loaded at full resolution before 2D plot windows use sampled SQL heatmap loading. |
+| `runtime_settings.max_full_heatmap_points` | integer | `2000000` | `1 <= value <= 2000000000` | Maximum estimated points loaded at full resolution before 2D plot windows use SQL spatial aggregation. |
 | `runtime_settings.del_grace_period` | number | `10` | `0 <= value <= 300` | Grace period before deleting temporary files. |
 | `runtime_settings.cloud_sync_timeout` | number | `120` | `1 <= value <= 3600` | Seconds to wait for cloud storage to hydrate a database before failing. |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,20 @@ rows to CSV files in the configured qPlot directory, usually `~/.qplot`.
 Use this only for local performance investigation. The generated CSV files are
 not part of the project source.
 
+## `benchmark_heatmap_aggregation.py`
+
+Creates a temporary 2,000,000-row heatmap database and reports the direct SQL
+spatial-aggregation load and spatial-mean preview generation times separately
+from database creation:
+
+```console
+python scripts/benchmark_heatmap_aggregation.py
+```
+
+The benchmark asserts that every source row contributes, the plotted grid stays
+within its configured cell bound, all plotted values are finite, and a bounded
+preview image is produced. The temporary database is removed automatically.
+
 ## `capture_demo_screenshots.py`
 
 Generates the PNG screenshots used by `docs/demo-data.md`:

--- a/scripts/benchmark_heatmap_aggregation.py
+++ b/scripts/benchmark_heatmap_aggregation.py
@@ -1,0 +1,137 @@
+"""Benchmark large-heatmap spatial aggregation with 2,000,000 rows."""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+
+from qplot.tools.worker import MAX_SQL_HEATMAP_GRID_CELLS, loader
+from qplot.windows._widgets.preview import generate_run_previews
+
+BENCHMARK_COLUMNS = 2_000
+BENCHMARK_ROWS = 2_000_000
+
+
+class _Parameter:
+    def __init__(self, name):
+        self.name = name
+        self.depends_on_ = ("y", "x") if name == "signal" else ()
+        self._complete = False
+
+
+class _Dataset:
+    def __init__(self, database_path):
+        self.path_to_db = str(database_path)
+        self.table_name = "results"
+
+
+class _Rundescriber:
+    shapes = {"signal": (BENCHMARK_ROWS // BENCHMARK_COLUMNS, BENCHMARK_COLUMNS)}
+
+
+class _Cache:
+    def __init__(self, database_path):
+        self._dataset = _Dataset(database_path)
+        self.rundescriber = _Rundescriber()
+
+
+def _create_database(database_path):
+    connection = sqlite3.connect(database_path)
+    try:
+        connection.execute("PRAGMA journal_mode=OFF")
+        connection.execute("PRAGMA synchronous=OFF")
+        connection.execute(
+            "CREATE TABLE results (x REAL, y REAL, signal REAL)"
+            )
+        connection.executemany(
+            "INSERT INTO results (x, y, signal) VALUES (?, ?, ?)",
+            (
+                (
+                    float(index % BENCHMARK_COLUMNS),
+                    float(index // BENCHMARK_COLUMNS),
+                    float(index % BENCHMARK_COLUMNS)
+                    + float(index // BENCHMARK_COLUMNS) / 100,
+                    )
+                for index in range(BENCHMARK_ROWS)
+                ),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _benchmark(database_path):
+    signal = _Parameter("signal")
+    parameters = {
+        "x": _Parameter("x"),
+        "y": _Parameter("y"),
+        "signal": signal,
+        }
+    worker = loader(
+        _Cache(database_path),
+        signal,
+        parameters,
+        {"x": "x", "y": "y"},
+        force_sql_heatmap=True,
+        )
+
+    started = perf_counter()
+    worker._load_large_heatmap_from_sql()
+    elapsed = perf_counter() - started
+
+    assert worker.aggregated_heatmap_source
+    assert worker.heatmap_downsample_info["aggregated_source_row_count"] == (
+        BENCHMARK_ROWS
+        )
+    assert worker.dataGrid.size <= MAX_SQL_HEATMAP_GRID_CELLS
+    assert np.isfinite(worker.dataGrid).all()
+    return worker, elapsed
+
+
+def _benchmark_preview(database_path):
+    metadata = {
+        "result_table_name": "results",
+        "result_count": BENCHMARK_ROWS,
+        "setpoint_shape": [
+            BENCHMARK_ROWS // BENCHMARK_COLUMNS,
+            BENCHMARK_COLUMNS,
+            ],
+        "measure_parameters": ["signal"],
+        "sweep_parameters": ["y", "x"],
+        }
+    started = perf_counter()
+    previews = generate_run_previews(str(database_path), metadata, size=200)
+    elapsed = perf_counter() - started
+
+    assert len(previews) == 1
+    assert previews[0]["downsample_strategy"] == "spatial mean"
+    assert previews[0]["image"].width() == 200
+    assert previews[0]["image"].height() == 200
+    return elapsed
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="qplot-heatmap-benchmark-") as tmpdir:
+        database_path = Path(tmpdir) / "heatmap.db"
+        setup_started = perf_counter()
+        _create_database(database_path)
+        setup_elapsed = perf_counter() - setup_started
+
+        worker, aggregation_elapsed = _benchmark(database_path)
+        preview_elapsed = _benchmark_preview(database_path)
+        info = worker.heatmap_downsample_info
+        print(f"Database rows: {BENCHMARK_ROWS:,}")
+        print(f"Database creation: {setup_elapsed:.3f} s")
+        print(
+            "Aggregated grid: "
+            f"{info['grid_columns']:,} x {info['grid_rows']:,} "
+            f"= {info['grid_cell_count']:,} cells"
+        )
+        print(f"Spatial aggregation load: {aggregation_elapsed:.3f} s")
+        print(f"Spatial-mean preview generation: {preview_elapsed:.3f} s")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -32,7 +32,6 @@ MAX_SQL_HEATMAP_SOURCE_ROWS = 250_000
 MAX_SQL_HEATMAP_GRID_SIDE = 800
 MAX_SQL_HEATMAP_GRID_CELLS = 250_000
 SQL_HEATMAP_SAMPLES_PER_CELL = 4
-SQL_HEATMAP_ROWID_CHUNK = 900
 
 
 def _sqlite_identifier(name):
@@ -100,10 +99,14 @@ class loader(QtCore.QRunnable):
         self.heatmap_axis_ranges = heatmap_axis_ranges
         self.heatmap_full_axis_ranges = heatmap_full_axis_ranges
         self.sampled_heatmap_source = False
-        self.loaded_from_sql_sample = False
+        self.aggregated_heatmap_source = False
+        self.loaded_from_sql_heatmap = False
         self.loaded_point_count: int | None = None
         self.heatmap_downsample_info: dict[str, Any] | None = None
         self.heatmap_source_grid_shape: tuple[int, int] | None = None
+        self.heatmap_source_axis_ranges: (
+            dict[str, tuple[float, float]] | None
+            ) = None
         
     
     def run(self):
@@ -325,7 +328,7 @@ class loader(QtCore.QRunnable):
             "y": self.param_dict[self.axes_dict["y"]],
             }
         self.dataGrid = data_grid
-        self.loaded_from_sql_sample = True
+        self.loaded_from_sql_heatmap = True
         self.loaded_point_count = int(z_data.size)
         self.heatmap_downsample_info = self._heatmap_downsample_info()
 
@@ -350,8 +353,9 @@ class loader(QtCore.QRunnable):
                 "row_count": 0,
                 "estimated_range_rows": None,
                 "sampled": False,
+                "aggregated": False,
                 "sample_limit": MAX_SQL_HEATMAP_SOURCE_ROWS,
-                "sample_stride": 1,
+                "sample_stride": None,
                 "strategy": "empty",
                 "axis_ranges": self._normalised_heatmap_axis_ranges(
                     self.heatmap_axis_ranges
@@ -379,8 +383,9 @@ class loader(QtCore.QRunnable):
             "row_count": int(row_count),
             "estimated_range_rows": int(row_count),
             "sampled": False,
+            "aggregated": False,
             "sample_limit": MAX_SQL_HEATMAP_SOURCE_ROWS,
-            "sample_stride": 1,
+            "sample_stride": None,
             "strategy": "all",
             "axis_ranges": axis_ranges,
             }
@@ -388,48 +393,43 @@ class loader(QtCore.QRunnable):
         axis_where_sql, parameters = self._heatmap_where_clause()
         if axis_where_sql:
             where_sql = f"{selected_where_sql} AND {axis_where_sql}"
-            sample_sql, sample_parameters = self._range_sample_clause(row_count)
-            self.sampled_heatmap_source = bool(sample_sql)
-            self._heatmap_source_info.update({
-                "estimated_range_rows": getattr(
-                    self,
-                    "_heatmap_estimated_range_rows",
-                    None,
-                    ),
-                "sampled": bool(sample_sql),
-                "sample_stride": getattr(self, "_heatmap_source_sample_stride", 1),
-                "strategy": "visible-range stride" if sample_sql else "visible range",
-                })
-            cursor = conn.execute(
-                (
-                    f"SELECT {columns} FROM {table} "
-                    f"WHERE {where_sql}{sample_sql} "
-                    "ORDER BY rowid LIMIT ?"
-                    ),
-                (*parameters, *sample_parameters, MAX_SQL_HEATMAP_SOURCE_ROWS),
+            spatial_where_sql = (
+                f"{where_sql} AND {x_column} IS NOT NULL "
+                f"AND {y_column} IS NOT NULL"
                 )
-            arrays = self._arrays_from_cursor(cursor)
-            if arrays[2].size > 0 or not sample_sql:
-                return arrays
+            range_summary = self._heatmap_spatial_summary(
+                conn,
+                spatial_where_sql,
+                parameters,
+                )
+            range_row_count = range_summary[0]
+            self._heatmap_estimated_range_rows = range_row_count
+            self._heatmap_source_info.update({
+                "estimated_range_rows": range_row_count,
+                "strategy": "visible range",
+                })
+            if range_row_count > MAX_SQL_HEATMAP_SOURCE_ROWS:
+                return self._spatially_aggregated_heatmap_arrays(
+                    conn,
+                    spatial_where_sql,
+                    parameters,
+                    range_summary,
+                    )
 
+            self.sampled_heatmap_source = False
+            self.aggregated_heatmap_source = False
             cursor = conn.execute(
                 (
                     f"SELECT {columns} FROM {table} "
-                    f"WHERE {where_sql} "
-                    "ORDER BY rowid LIMIT ?"
+                    f"WHERE {where_sql} ORDER BY rowid"
                     ),
-                (*parameters, MAX_SQL_HEATMAP_SOURCE_ROWS),
+                parameters,
                 )
-            self.sampled_heatmap_source = False
-            self._heatmap_source_info.update({
-                "sampled": False,
-                "sample_stride": 1,
-                "strategy": "visible range fallback",
-                })
             return self._arrays_from_cursor(cursor)
 
         if row_count <= MAX_SQL_HEATMAP_SOURCE_ROWS:
             self.sampled_heatmap_source = False
+            self.aggregated_heatmap_source = False
             cursor = conn.execute(
                 (
                     f"SELECT {columns} FROM {table} "
@@ -438,38 +438,175 @@ class loader(QtCore.QRunnable):
                 )
             return self._arrays_from_cursor(cursor)
 
-        self.sampled_heatmap_source = True
-        stride = max(1, math.ceil(row_count / MAX_SQL_HEATMAP_SOURCE_ROWS))
-        self._heatmap_source_sample_stride = stride
-        self._heatmap_source_info.update({
-            "sampled": True,
-            "sample_stride": stride,
-            "strategy": "uniform selected-row stride",
-            })
-        cursor = conn.execute(
-            (
-                f"SELECT {columns} FROM {table} "
-                f"WHERE {selected_where_sql} AND ((rowid - ?) % ?) = 0 "
-                "ORDER BY rowid LIMIT ?"
-                ),
-            (1, stride, MAX_SQL_HEATMAP_SOURCE_ROWS),
+        spatial_where_sql = (
+            f"{selected_where_sql} AND {x_column} IS NOT NULL "
+            f"AND {y_column} IS NOT NULL"
             )
-        arrays = self._arrays_from_cursor(cursor)
-        if arrays[2].size > 0:
-            return arrays
+        summary = self._heatmap_spatial_summary(conn, spatial_where_sql, ())
+        return self._spatially_aggregated_heatmap_arrays(
+            conn,
+            spatial_where_sql,
+            (),
+            summary,
+            )
 
+
+    def _heatmap_spatial_summary(self, conn, where_sql, parameters):
+        table = _sqlite_identifier(self.table_name)
+        x_column = _sqlite_identifier(self.axes_dict["x"])
+        y_column = _sqlite_identifier(self.axes_dict["y"])
+        row = conn.execute(
+            (
+                f"SELECT COUNT(*), MIN({x_column}), MAX({x_column}), "
+                f"COUNT(DISTINCT {x_column}), MIN({y_column}), "
+                f"MAX({y_column}), COUNT(DISTINCT {y_column}) "
+                f"FROM {table} WHERE {where_sql}"
+                ),
+            parameters,
+            ).fetchone()
+        if row is None or row[0] is None:
+            return (0, None, None, 0, None, None, 0)
+
+        return (
+            int(row[0]),
+            row[1],
+            row[2],
+            int(row[3] or 0),
+            row[4],
+            row[5],
+            int(row[6] or 0),
+            )
+
+
+    def _spatially_aggregated_heatmap_arrays(
+            self,
+            conn,
+            where_sql,
+            parameters,
+            summary,
+            ):
+        (
+            matching_rows,
+            x_min,
+            x_max,
+            x_count,
+            y_min,
+            y_max,
+            y_count,
+            ) = summary
+        if (
+                matching_rows <= 0
+                or x_min is None
+                or x_max is None
+                or y_min is None
+                or y_max is None
+                or x_count <= 0
+                or y_count <= 0
+                ):
+            self.sampled_heatmap_source = False
+            self.aggregated_heatmap_source = False
+            return self._arrays_from_values([], [], [])
+
+        x_bins, y_bins = self._bounded_grid_shape(x_count, y_count)
+        x_centres, x_lower_edge, x_scale = self._spatial_axis_bins(
+            float(x_min),
+            float(x_max),
+            x_count,
+            x_bins,
+            )
+        y_centres, y_lower_edge, y_scale = self._spatial_axis_bins(
+            float(y_min),
+            float(y_max),
+            y_count,
+            y_bins,
+            )
+        if x_centres.size == 0 or y_centres.size == 0:
+            self.sampled_heatmap_source = False
+            self.aggregated_heatmap_source = False
+            return self._arrays_from_values([], [], [])
+
+        table = _sqlite_identifier(self.table_name)
+        x_column = _sqlite_identifier(self.axes_dict["x"])
+        y_column = _sqlite_identifier(self.axes_dict["y"])
+        z_column = _sqlite_identifier(self.param.name)
+        x_bin_sql = f"MIN(CAST(({x_column} - ?) * ? AS INTEGER), ?)"
+        y_bin_sql = f"MIN(CAST(({y_column} - ?) * ? AS INTEGER), ?)"
         cursor = conn.execute(
             (
-                f"SELECT {columns} FROM {table} "
-                f"WHERE {selected_where_sql} ORDER BY rowid LIMIT ?"
+                "SELECT x_bin, y_bin, AVG(z_value), COUNT(*) FROM ("
+                f"SELECT {x_bin_sql} AS x_bin, {y_bin_sql} AS y_bin, "
+                f"{z_column} AS z_value FROM {table} WHERE {where_sql}"
+                ") GROUP BY x_bin, y_bin ORDER BY y_bin, x_bin"
                 ),
-            (MAX_SQL_HEATMAP_SOURCE_ROWS,),
+            (
+                x_lower_edge,
+                x_scale,
+                x_bins - 1,
+                y_lower_edge,
+                y_scale,
+                y_bins - 1,
+                *parameters,
+                ),
             )
+        x_indices = []
+        y_indices = []
+        z_values = []
+        aggregated_source_rows = 0
+        for x_index, y_index, z_value, bin_rows in cursor:
+            if z_value is None:
+                continue
+            x_indices.append(int(x_index))
+            y_indices.append(int(y_index))
+            z_values.append(z_value)
+            aggregated_source_rows += int(bin_rows)
+
+        x_index_data = np.asarray(x_indices, dtype=np.int64)
+        y_index_data = np.asarray(y_indices, dtype=np.int64)
+        z_data = np.asarray(z_values, dtype=float)
+        finite = np.isfinite(z_data)
+        x_index_data = x_index_data[finite]
+        y_index_data = y_index_data[finite]
+        z_data = z_data[finite]
+        self._spatial_heatmap_axes = (x_centres, y_centres)
+        self._spatial_heatmap_indices = (x_index_data, y_index_data)
+        self._spatial_heatmap_source_unique_counts = (x_count, y_count)
+        self._heatmap_aggregated_source_rows = aggregated_source_rows
+        full_axis_ranges = self._normalised_heatmap_axis_ranges(
+            self.heatmap_full_axis_ranges
+            )
+        if full_axis_ranges is not None:
+            self.heatmap_source_axis_ranges = full_axis_ranges
+        elif self.heatmap_axis_ranges is None:
+            self.heatmap_source_axis_ranges = {
+                "x": (float(x_min), float(x_max)),
+                "y": (float(y_min), float(y_max)),
+                }
+        self.sampled_heatmap_source = False
+        self.aggregated_heatmap_source = True
         self._heatmap_source_info.update({
-            "sample_stride": 1,
-            "strategy": "selected-row fallback",
+            "estimated_range_rows": matching_rows,
+            "sampled": False,
+            "aggregated": True,
+            "sample_limit": None,
+            "sample_stride": None,
+            "strategy": "spatial mean",
             })
-        return self._arrays_from_cursor(cursor)
+        return x_centres[x_index_data], y_centres[y_index_data], z_data
+
+
+    @staticmethod
+    def _spatial_axis_bins(lower, upper, source_count, bin_count):
+        if not np.isfinite(lower) or not np.isfinite(upper):
+            return np.array([], dtype=float), 0.0, 1.0
+        if source_count <= 1 or bin_count <= 1 or lower == upper:
+            return np.array([lower], dtype=float), lower, 1.0
+
+        source_step = (upper - lower) / (source_count - 1)
+        lower_edge = lower - source_step / 2
+        upper_edge = upper + source_step / 2
+        bin_width = (upper_edge - lower_edge) / bin_count
+        centres = lower_edge + (np.arange(bin_count, dtype=float) + 0.5) * bin_width
+        return centres, lower_edge, 1.0 / bin_width
 
 
     def _selected_parameter_row_count(self, conn):
@@ -509,48 +646,6 @@ class loader(QtCore.QRunnable):
         return " AND ".join(clauses), parameters
 
 
-    def _range_sample_clause(self, row_count):
-        stride = self._range_sample_stride(row_count)
-        self._heatmap_source_sample_stride = stride
-        if stride <= 1:
-            return "", ()
-
-        return " AND ((rowid - ?) % ?) = 0", (1, stride)
-
-
-    def _range_sample_stride(self, row_count):
-        ranges = self.heatmap_axis_ranges or {}
-        full_ranges = self.heatmap_full_axis_ranges or {}
-        fraction = 1.0
-
-        for axis in ("x", "y"):
-            axis_range = ranges.get(axis)
-            full_axis_range = full_ranges.get(axis)
-            if axis_range is None or full_axis_range is None:
-                continue
-
-            try:
-                low, high = sorted(float(value) for value in axis_range)
-                full_low, full_high = sorted(float(value) for value in full_axis_range)
-            except (TypeError, ValueError):
-                continue
-
-            full_width = full_high - full_low
-            if (
-                    not np.isfinite(full_width)
-                    or full_width <= 0
-                    or not np.isfinite(low)
-                    or not np.isfinite(high)
-                    ):
-                continue
-
-            fraction *= min(max((high - low) / full_width, 0.0), 1.0)
-
-        estimated_rows = max(1, int(row_count * fraction))
-        self._heatmap_estimated_range_rows = estimated_rows
-        return max(1, math.ceil(estimated_rows / MAX_SQL_HEATMAP_SOURCE_ROWS))
-
-
     def _normalised_heatmap_axis_ranges(self, ranges):
         if not ranges:
             return None
@@ -572,24 +667,6 @@ class loader(QtCore.QRunnable):
             normalised[axis] = (low, high)
 
         return normalised
-
-
-    def _sample_rowids(self, rowid_min, rowid_max):
-        span = rowid_max - rowid_min + 1
-        count = min(MAX_SQL_HEATMAP_SOURCE_ROWS, span)
-        if count <= 0:
-            return np.array([], dtype=np.int64)
-
-        starts = (np.arange(count, dtype=np.int64) * span) // count
-        ends = ((np.arange(1, count + 1, dtype=np.int64) * span) // count) - 1
-        widths = np.maximum(ends - starts + 1, 1)
-        jitter = (
-            np.arange(count, dtype=np.int64) * 1_103_515_245 + 12_345
-            ) % widths
-        rowids = rowid_min + starts + jitter
-        rowids[0] = rowid_min
-        rowids[-1] = rowid_max
-        return np.unique(rowids)
 
 
     def _arrays_from_cursor(self, cursor):
@@ -638,11 +715,25 @@ class loader(QtCore.QRunnable):
         exact_cells = unique_x.size * unique_y.size
         source_grid_shape = getattr(self, "heatmap_source_grid_shape", None)
         if source_grid_shape is None:
-            source_grid_rows = int(unique_y.size)
-            source_grid_columns = int(unique_x.size)
+            if getattr(self, "aggregated_heatmap_source", False):
+                source_x_count, source_y_count = (
+                    self._spatial_heatmap_source_unique_counts
+                    )
+                source_grid_rows = int(source_y_count)
+                source_grid_columns = int(source_x_count)
+            else:
+                source_grid_rows = int(unique_y.size)
+                source_grid_columns = int(unique_x.size)
         else:
             source_grid_rows, source_grid_columns = source_grid_shape
         source_grid_cell_count = int(source_grid_rows * source_grid_columns)
+        if getattr(self, "aggregated_heatmap_source", False):
+            return self._spatial_aggregation_grid(
+                z_data,
+                source_grid_rows,
+                source_grid_columns,
+                )
+
         if (
                 not getattr(self, "sampled_heatmap_source", False)
                 and exact_cells <= MAX_SQL_HEATMAP_GRID_CELLS
@@ -705,10 +796,50 @@ class loader(QtCore.QRunnable):
         return x_axis, y_axis, data_grid
 
 
+    def _spatial_aggregation_grid(
+            self,
+            z_data,
+            source_grid_rows,
+            source_grid_columns,
+            ):
+        x_axis, y_axis = self._spatial_heatmap_axes
+        x_indices, y_indices = self._spatial_heatmap_indices
+        data_grid = np.full(
+            (y_axis.size, x_axis.size),
+            np.nan,
+            dtype=np.float32,
+            )
+        data_grid[y_indices, x_indices] = z_data
+        empty_bins_filled = bool(np.any(~np.isfinite(data_grid)))
+        if empty_bins_filled:
+            data_grid = self._fill_empty_heatmap_bins(data_grid)
+
+        source_x_count, source_y_count = self._spatial_heatmap_source_unique_counts
+        source_grid_cell_count = int(source_grid_rows * source_grid_columns)
+        self._heatmap_grid_info = {
+            "unique_x_count": int(source_x_count),
+            "unique_y_count": int(source_y_count),
+            "exact_cell_count": int(source_x_count * source_y_count),
+            "source_grid_columns": int(source_grid_columns),
+            "source_grid_rows": int(source_grid_rows),
+            "source_grid_cell_count": source_grid_cell_count,
+            "grid_columns": int(x_axis.size),
+            "grid_rows": int(y_axis.size),
+            "grid_cell_count": int(data_grid.size),
+            "grid_binned": (
+                x_axis.size < source_x_count or y_axis.size < source_y_count
+                ),
+            "grid_cell_limit": MAX_SQL_HEATMAP_GRID_CELLS,
+            "empty_bins_filled": empty_bins_filled,
+            }
+        return x_axis, y_axis, data_grid
+
+
     def _heatmap_downsample_info(self):
         source_info = getattr(self, "_heatmap_source_info", None) or {}
         grid_info = getattr(self, "_heatmap_grid_info", None) or {}
         source_sampled = bool(source_info.get("sampled", False))
+        source_aggregated = bool(source_info.get("aggregated", False))
         grid_reduced = bool(grid_info.get("grid_binned", False))
         source_grid_columns = grid_info.get("source_grid_columns")
         source_grid_rows = grid_info.get("source_grid_rows")
@@ -724,7 +855,7 @@ class loader(QtCore.QRunnable):
                 int(grid_columns) < int(source_grid_columns)
                 or int(grid_rows) < int(source_grid_rows)
                 )
-        if not source_sampled and not grid_reduced:
+        if not source_sampled and not source_aggregated and not grid_reduced:
             return None
 
         return {
@@ -732,9 +863,20 @@ class loader(QtCore.QRunnable):
             "estimated_range_rows": source_info.get("estimated_range_rows"),
             "loaded_point_count": getattr(self, "loaded_point_count", None),
             "source_sampled": source_sampled,
+            "source_aggregated": source_aggregated,
+            "aggregated_source_row_count": getattr(
+                self,
+                "_heatmap_aggregated_source_rows",
+                None,
+                ),
             "source_sample_limit": source_info.get("sample_limit"),
             "source_sample_stride": source_info.get("sample_stride"),
-            "source_sample_strategy": source_info.get("strategy"),
+            "source_sample_strategy": (
+                source_info.get("strategy") if source_sampled else None
+                ),
+            "source_aggregation_strategy": (
+                source_info.get("strategy") if source_aggregated else None
+                ),
             "axis_ranges": source_info.get("axis_ranges"),
             "unique_x_count": grid_info.get("unique_x_count"),
             "unique_y_count": grid_info.get("unique_y_count"),

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -267,13 +267,20 @@ class PlotRefreshMixin(_PlotRefreshBase):
             self._set_param_axis_labels()
             elapsed = perf_counter() - worker.started_at
 
-            if getattr(worker, "loaded_from_sql_sample", False):
+            if getattr(worker, "loaded_from_sql_heatmap", False):
                 loaded_points = getattr(worker, "loaded_point_count", None)
-                point_text = (
-                    f"{loaded_points:,} sampled points"
-                    if loaded_points is not None
-                    else "sampled points"
-                    )
+                if getattr(worker, "aggregated_heatmap_source", False):
+                    point_text = (
+                        f"{loaded_points:,} aggregated cells"
+                        if loaded_points is not None
+                        else "aggregated cells"
+                        )
+                else:
+                    point_text = (
+                        f"{loaded_points:,} sampled points"
+                        if loaded_points is not None
+                        else "sampled points"
+                        )
                 self.show_status(
                     f"Loaded {point_text} for {self.param.name} "
                     f"in {elapsed:.2f} seconds",

--- a/src/qplot/windows/_preferences.py
+++ b/src/qplot/windows/_preferences.py
@@ -268,7 +268,7 @@ class PreferencesDialog(qtw.QDialog):
             self.maxFullHeatmapPointsSpin.setGroupSeparatorShown(True)
         self.maxFullHeatmapPointsSpin.setToolTip(
             "Use full-resolution heatmap loading up to this many points; "
-            "larger heatmaps use SQL sampling."
+            "larger heatmaps use SQL spatial aggregation."
             )
         self._add_row(
             form,

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -17,7 +17,6 @@ MAX_PREVIEW_ROWS = 50_000
 MAX_PREVIEW_GRID_CELLS = 250_000
 PREVIEW_SAMPLES_PER_CELL = 4
 PREVIEW_ROWID_CHUNK = 900
-PREVIEW_GRID_SAMPLE_MIN_COVERAGE = 0.9
 PREVIEW_FILL_EMPTY_MIN_COVERAGE = 0.75
 PREVIEW_REMAINING_PRIORITY = 0
 PREVIEW_VISIBLE_PRIORITY = 50
@@ -657,13 +656,14 @@ def _preview_1d(cursor, table_name, metadata, parameter, axis, size):
 
 def _preview_2d(cursor, table_name, metadata, parameter, axes, size):
     grid_shape = _preview_grid_shape(metadata, parameter)
-    grid = _sample_large_known_grid_preview(
+    grid = _aggregate_large_heatmap_preview(
         cursor,
         table_name,
         metadata,
         parameter,
         grid_shape,
         size,
+        axes=axes,
         )
     if grid is not None:
         image = render_heatmap_grid_preview(grid, size=size)
@@ -672,6 +672,7 @@ def _preview_2d(cursor, table_name, metadata, parameter, axes, size):
             "axes": list(axes),
             "title": _preview_title(parameter, axes),
             "image": image,
+            "downsample_strategy": "spatial mean",
             }
 
     x, y, z = _select_arrays(
@@ -832,105 +833,366 @@ def render_heatmap_grid_preview(grid, size=PREVIEW_SIZE):
         ).convertToFormat(QtGui.QImage.Format.Format_RGB32)
 
 
-def _sample_large_known_grid_preview(
+def _aggregate_large_heatmap_preview(
         cursor,
         table_name,
         metadata,
         parameter,
         grid_shape,
         size,
+        *,
+        axes=None,
         ):
     shape = _normalise_grid_shape(grid_shape)
-    if shape is None:
+    if not _preview_requires_spatial_aggregation(
+            cursor,
+            table_name,
+            metadata,
+            shape,
+            ):
         return None
 
-    rows, columns = shape
-    grid_cells = rows * columns
-    if grid_cells <= MAX_PREVIEW_GRID_CELLS:
+    if axes is None:
+        axes = _dependencies_from_metadata(metadata).get(parameter, [])
+    if len(axes) < 2:
         return None
+
+    try:
+        return _spatial_mean_preview_grid(
+            cursor,
+            table_name,
+            parameter,
+            x_axis=axes[1],
+            y_axis=axes[0],
+            grid_shape=shape,
+            size=size,
+            )
+    except Exception as error:
+        log_exception(
+            "SQL preview aggregation failed; using streaming spatial means",
+            error,
+            __name__,
+            )
+        return _streaming_spatial_mean_preview_grid(
+            cursor,
+            table_name,
+            parameter,
+            x_axis=axes[1],
+            y_axis=axes[0],
+            grid_shape=shape,
+            size=size,
+            )
+
+
+def _preview_requires_spatial_aggregation(
+        cursor,
+        table_name,
+        metadata,
+        grid_shape,
+        ):
+    shape = _normalise_grid_shape(grid_shape)
+    if shape is not None and shape[0] * shape[1] > MAX_PREVIEW_GRID_CELLS:
+        return True
+
+    row_limit = _preview_2d_row_limit(shape)
+    if _metadata_result_count(metadata) > row_limit:
+        return True
 
     rowid_span = _rowid_span(cursor, table_name)
-    if rowid_span is None:
-        return None
+    if rowid_span is not None:
+        first_rowid, last_rowid = rowid_span
+        return last_rowid - first_rowid + 1 > row_limit
 
-    first_rowid, last_rowid = rowid_span
-    span = max(0, last_rowid - first_rowid + 1)
-    count = _metadata_result_count(metadata)
-    if count <= 0:
-        count = grid_cells
-
-    available = min(count, grid_cells, span)
-    if available <= 0:
-        return None
-
-    target_rows, target_columns = _preview_bin_shape(
-        shape,
-        size,
-        max_cells=min(MAX_PREVIEW_ROWS, max(1, int(size) * int(size))),
-        )
-    row_indices = _sample_axis_positions(rows, target_rows)
-    column_indices = _sample_axis_positions(columns, target_columns)
-    offsets = (
-        row_indices[:, None] * np.int64(columns)
-        + column_indices[None, :]
-        )
-    valid = offsets < available
-    if not np.any(valid):
-        return None
-
-    grid = np.full((target_rows, target_columns), np.nan, dtype=float)
-    flat_positions = np.flatnonzero(valid.ravel())
-    sample_rowids = first_rowid + offsets.ravel()[flat_positions]
-    rowid_positions = {
-        int(rowid): int(position)
-        for rowid, position in zip(sample_rowids, flat_positions, strict=False)
-    }
-
-    found = 0
-    flat_grid = grid.ravel()
     table = _sqlite_identifier(table_name)
-    column = _sqlite_identifier(parameter)
-    for start in range(0, len(sample_rowids), PREVIEW_ROWID_CHUNK):
-        chunk = [
-            int(value)
-            for value in sample_rowids[start:start + PREVIEW_ROWID_CHUNK]
-            ]
-        placeholders = ", ".join("?" for _ in chunk)
-        cursor.execute(
-            f"SELECT rowid, {column} FROM {table} WHERE rowid IN ({placeholders})",
-            chunk,
+    cursor.execute(f"SELECT COUNT(*) FROM {table}")
+    row = cursor.fetchone()
+    return bool(row and row[0] and int(row[0]) > row_limit)
+
+
+def _spatial_mean_preview_grid(
+        cursor,
+        table_name,
+        parameter,
+        *,
+        x_axis,
+        y_axis,
+        grid_shape,
+        size,
+        ):
+    setup = _spatial_preview_aggregation_setup(
+        cursor,
+        table_name,
+        parameter,
+        x_axis=x_axis,
+        y_axis=y_axis,
+        grid_shape=grid_shape,
+        size=size,
+        )
+    if setup is None:
+        return None
+
+    (
+        table,
+        x_column,
+        y_column,
+        z_column,
+        where_sql,
+        full_shape,
+        aggregate_shape,
+        x_lower_edge,
+        x_scale,
+        y_lower_edge,
+        y_scale,
+        ) = setup
+    target_rows, target_columns = aggregate_shape
+    x_bin_sql = f"MIN(CAST(({x_column} - ?) * ? AS INTEGER), ?)"
+    y_bin_sql = f"MIN(CAST(({y_column} - ?) * ? AS INTEGER), ?)"
+    cursor.execute(
+        (
+            "SELECT x_bin, y_bin, AVG(z_value) FROM ("
+            f"SELECT {x_bin_sql} AS x_bin, {y_bin_sql} AS y_bin, "
+            f"{z_column} AS z_value FROM {table} WHERE {where_sql}"
+            ") GROUP BY x_bin, y_bin ORDER BY y_bin, x_bin"
+            ),
+        (
+            x_lower_edge,
+            x_scale,
+            target_columns - 1,
+            y_lower_edge,
+            y_scale,
+            target_rows - 1,
+            ),
+        )
+
+    grid = np.full(aggregate_shape, np.nan, dtype=float)
+    for x_index, y_index, mean_value in cursor:
+        if mean_value is None:
+            continue
+        try:
+            mean_value = float(mean_value)
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(mean_value):
+            continue
+        grid[int(y_index), int(x_index)] = mean_value
+
+    if not np.any(np.isfinite(grid)):
+        return None
+
+    return _pad_spatial_preview_grid(grid, full_shape)
+
+
+def _streaming_spatial_mean_preview_grid(
+        cursor,
+        table_name,
+        parameter,
+        *,
+        x_axis,
+        y_axis,
+        grid_shape,
+        size,
+        ):
+    setup = _spatial_preview_aggregation_setup(
+        cursor,
+        table_name,
+        parameter,
+        x_axis=x_axis,
+        y_axis=y_axis,
+        grid_shape=grid_shape,
+        size=size,
+        )
+    if setup is None:
+        return None
+
+    (
+        table,
+        x_column,
+        y_column,
+        z_column,
+        where_sql,
+        full_shape,
+        aggregate_shape,
+        x_lower_edge,
+        x_scale,
+        y_lower_edge,
+        y_scale,
+        ) = setup
+    target_rows, target_columns = aggregate_shape
+    grid_sum = np.zeros(aggregate_shape, dtype=float)
+    grid_count = np.zeros(aggregate_shape, dtype=np.int64)
+    cursor.execute(
+        f"SELECT {x_column}, {y_column}, {z_column} FROM {table} "
+        f"WHERE {where_sql} ORDER BY {y_column}, {x_column}, {z_column}"
+        )
+    for x_value, y_value, z_value in cursor:
+        try:
+            x_value = float(x_value)
+            y_value = float(y_value)
+            z_value = float(z_value)
+        except (TypeError, ValueError):
+            continue
+        if not (
+                np.isfinite(x_value)
+                and np.isfinite(y_value)
+                and np.isfinite(z_value)
+                ):
+            continue
+
+        x_index = int((x_value - x_lower_edge) * x_scale)
+        y_index = int((y_value - y_lower_edge) * y_scale)
+        x_index = min(max(x_index, 0), target_columns - 1)
+        y_index = min(max(y_index, 0), target_rows - 1)
+        grid_sum[y_index, x_index] += z_value
+        grid_count[y_index, x_index] += 1
+
+    grid = np.full(aggregate_shape, np.nan, dtype=float)
+    populated = grid_count > 0
+    grid[populated] = grid_sum[populated] / grid_count[populated]
+    if not np.any(populated):
+        return None
+
+    return _pad_spatial_preview_grid(grid, full_shape)
+
+
+def _spatial_preview_aggregation_setup(
+        cursor,
+        table_name,
+        parameter,
+        *,
+        x_axis,
+        y_axis,
+        grid_shape,
+        size,
+        ):
+    table = _sqlite_identifier(table_name)
+    x_column = _sqlite_identifier(x_axis)
+    y_column = _sqlite_identifier(y_axis)
+    z_column = _sqlite_identifier(parameter)
+    where_sql = (
+        f"{x_column} IS NOT NULL AND {y_column} IS NOT NULL "
+        f"AND {z_column} IS NOT NULL"
+        )
+    cursor.execute(
+        f"SELECT COUNT(*), MIN({x_column}), MAX({x_column}), "
+        f"COUNT(DISTINCT {x_column}), MIN({y_column}), "
+        f"MAX({y_column}), COUNT(DISTINCT {y_column}) "
+        f"FROM {table} WHERE {where_sql}"
+        )
+    summary = cursor.fetchone()
+    if summary is None:
+        return None
+
+    (
+        source_rows,
+        x_min,
+        x_max,
+        x_count,
+        y_min,
+        y_max,
+        y_count,
+        ) = summary
+    if (
+            not source_rows
+            or x_min is None
+            or x_max is None
+            or y_min is None
+            or y_max is None
+            or not x_count
+            or not y_count
+            ):
+        return None
+
+    full_shape, aggregate_shape = _spatial_preview_grid_shapes(
+        grid_shape,
+        observed_rows=int(y_count),
+        observed_columns=int(x_count),
+        size=size,
+        )
+    target_rows, target_columns = aggregate_shape
+    x_lower_edge, x_scale = _spatial_preview_axis_bins(
+        float(x_min),
+        float(x_max),
+        int(x_count),
+        target_columns,
+        )
+    y_lower_edge, y_scale = _spatial_preview_axis_bins(
+        float(y_min),
+        float(y_max),
+        int(y_count),
+        target_rows,
+        )
+    return (
+        table,
+        x_column,
+        y_column,
+        z_column,
+        where_sql,
+        full_shape,
+        aggregate_shape,
+        x_lower_edge,
+        x_scale,
+        y_lower_edge,
+        y_scale,
+        )
+
+
+def _spatial_preview_grid_shapes(
+        grid_shape,
+        *,
+        observed_rows,
+        observed_columns,
+        size,
+        ):
+    max_cells = min(MAX_PREVIEW_ROWS, max(1, int(size) * int(size)))
+    observed_shape = (int(observed_rows), int(observed_columns))
+    shape = _normalise_grid_shape(grid_shape)
+    if shape is None:
+        target_shape = _preview_bin_shape(
+            observed_shape,
+            size,
+            max_cells=max_cells,
             )
-        for rowid, value in cursor.fetchall():
-            position = rowid_positions.get(int(rowid))
-            if position is None:
-                continue
-            try:
-                flat_grid[position] = float(value)
-            except (TypeError, ValueError):
-                flat_grid[position] = np.nan
-            found += 1
+        return target_shape, target_shape
 
-    expected = int(sample_rowids.size)
-    if found == 0:
-        return None
-    if found < expected * PREVIEW_GRID_SAMPLE_MIN_COVERAGE:
-        return None
-
-    return grid
+    full_shape = _preview_bin_shape(shape, size, max_cells=max_cells)
+    aggregate_shape = (
+        _covered_preview_bin_count(observed_rows, shape[0], full_shape[0]),
+        _covered_preview_bin_count(observed_columns, shape[1], full_shape[1]),
+        )
+    return full_shape, aggregate_shape
 
 
-def _sample_axis_positions(length, target_count):
-    length = max(1, int(length))
-    target_count = max(1, min(int(target_count), length))
-    if target_count == length:
-        return np.arange(length, dtype=np.int64)
+def _covered_preview_bin_count(observed_count, planned_count, target_count):
+    observed_count = max(1, int(observed_count))
+    planned_count = max(1, int(planned_count))
+    target_count = max(1, int(target_count))
+    covered = (
+        observed_count * target_count + planned_count - 1
+        ) // planned_count
+    return min(target_count, max(1, covered))
 
-    starts = (np.arange(target_count, dtype=np.int64) * length) // target_count
-    ends = (
-        (np.arange(1, target_count + 1, dtype=np.int64) * length)
-        // target_count
-        ) - 1
-    return (starts + ends) // 2
+
+def _pad_spatial_preview_grid(grid, full_shape):
+    if grid.shape == full_shape:
+        return grid
+
+    padded = np.full(full_shape, np.nan, dtype=float)
+    rows = min(grid.shape[0], full_shape[0])
+    columns = min(grid.shape[1], full_shape[1])
+    padded[:rows, :columns] = grid[:rows, :columns]
+    return padded
+
+
+def _spatial_preview_axis_bins(lower, upper, source_count, bin_count):
+    if not np.isfinite(lower) or not np.isfinite(upper):
+        raise ValueError("Preview axis bounds must be finite")
+    if source_count <= 1 or bin_count <= 1 or lower == upper:
+        return lower, 1.0
+
+    source_step = (upper - lower) / (source_count - 1)
+    lower_edge = lower - source_step / 2
+    bin_width = (upper - lower + source_step) / bin_count
+    return lower_edge, 1.0 / bin_width
 
 
 def _fixed_heatmap_grid(x, y, z, grid_shape, max_cells=None):

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -58,6 +58,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         """
         self._large_heatmap_sql_mode = False
         self._heatmap_full_axis_ranges: dict[str, tuple[float, float]] | None = None
+        self._heatmap_full_view_ranges: dict[str, tuple[float, float]] | None = None
         self._heatmap_last_view_ranges: dict[str, tuple[float, float]] | None = None
         self._heatmap_worker_downsample_info: dict[str, Any] | None = None
         self._heatmap_downsample_info: dict[str, Any] | None = None
@@ -66,7 +67,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         self._heatmap_view_reload_timer.timeout.connect(
             self._reload_visible_heatmap_data
             )
-        self.vb.main_moved.connect(self._schedule_visible_heatmap_reload)
+        self._connect_heatmap_range_controls()
 
         self.image = pg.ImageItem(axisOrder='row-major')
         self.image.setZValue(0) # Like *Send to back*
@@ -88,6 +89,16 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         # Wait for loader to finish to enure needed data is collected.
         self.load_data()
         self.show_status("Heatmap ready; loading data...", 5000)
+
+
+    def _connect_heatmap_range_controls(self) -> None:
+        self.plot.sigRangeChangedManually.connect(
+            self._schedule_visible_heatmap_reload
+            )
+        self.vb.autoRange_triggered.connect(self._zoom_large_heatmap_to_all)
+        self.plot.autoBtn.clicked.connect(
+            lambda _button: self._zoom_large_heatmap_to_all()
+            )
       
 
     def initRefresh(self, refresh: Any) -> None:
@@ -238,13 +249,19 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
 
     def _update_large_heatmap_state(self, worker: Any) -> None:
         self._update_heatmap_downsample_state(worker)
-        if not getattr(worker, "loaded_from_sql_sample", False):
+        if not getattr(worker, "loaded_from_sql_heatmap", False):
             return
 
         self._large_heatmap_sql_mode = True
         worker_ranges = getattr(worker, "heatmap_axis_ranges", None)
         if worker_ranges is None or self._heatmap_full_axis_ranges is None:
-            self._heatmap_full_axis_ranges = self._axis_ranges_from_data()
+            source_ranges = self._normalise_axis_ranges(
+                getattr(worker, "heatmap_source_axis_ranges", None)
+                )
+            self._heatmap_full_axis_ranges = (
+                source_ranges or self._axis_ranges_from_data()
+                )
+            self._heatmap_full_view_ranges = self._axis_view_ranges_from_data()
 
         if worker_ranges is not None:
             self._heatmap_last_view_ranges = self._normalise_axis_ranges(worker_ranges)
@@ -346,7 +363,9 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             ) -> dict[str, Any] | None:
         info = getattr(worker, "heatmap_downsample_info", None)
         if isinstance(info, dict) and (
-                info.get("source_sampled") or info.get("grid_binned")
+                info.get("source_sampled")
+                or info.get("source_aggregated")
+                or info.get("grid_binned")
                 ):
             return dict(info)
 
@@ -394,8 +413,11 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             return None
 
         loaded_point_count = getattr(worker, "loaded_point_count", None)
+        source_aggregated = bool(
+            getattr(worker, "aggregated_heatmap_source", False)
+            )
         source_sampled = bool(getattr(worker, "sampled_heatmap_source", False))
-        if loaded_point_count is not None:
+        if loaded_point_count is not None and not source_aggregated:
             try:
                 source_sampled = source_sampled or int(loaded_point_count) < int(
                     source_cell_count
@@ -416,6 +438,12 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 ),
             "loaded_point_count": loaded_point_count,
             "source_sampled": source_sampled,
+            "source_aggregated": source_aggregated,
+            "aggregated_source_row_count": getattr(
+                worker,
+                "_heatmap_aggregated_source_rows",
+                None,
+                ),
             "source_sample_limit": (
                 loaded_point_count if source_sampled else None
                 ),
@@ -425,6 +453,9 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 None,
                 ),
             "source_sample_strategy": None,
+            "source_aggregation_strategy": (
+                "spatial mean" if source_aggregated else None
+                ),
             "axis_ranges": getattr(worker, "heatmap_axis_ranges", None),
             "unique_x_count": source_columns,
             "unique_y_count": source_rows,
@@ -595,7 +626,11 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             info_source_rows = self._format_heatmap_count(
                 info.get("source_grid_rows")
                 )
-            if info.get("source_sampled") or info.get("grid_binned"):
+            if (
+                    info.get("source_sampled")
+                    or info.get("source_aggregated")
+                    or info.get("grid_binned")
+                    ):
                 return (
                     "Resolution: downsampled "
                     f"{grid_columns} x {grid_rows} of "
@@ -662,7 +697,11 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         info = self._heatmap_downsample_info or {}
         lines = ["This heatmap is displayed from downsampled data."]
 
-        if not info.get("source_sampled") and not info.get("grid_binned"):
+        if (
+                not info.get("source_sampled")
+                and not info.get("source_aggregated")
+                and not info.get("grid_binned")
+                ):
             return "\n".join(lines)
 
         lines.append("")
@@ -708,7 +747,15 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         lines.append("Source rows:")
         loaded_count = info.get("loaded_point_count")
         source_count = info.get("source_row_count")
-        if loaded_count is not None and source_count is not None:
+        aggregated_count = info.get("aggregated_source_row_count")
+        if info.get("source_aggregated") and aggregated_count is not None:
+            lines.append(
+                "All "
+                f"{self._format_heatmap_count(aggregated_count)} matching "
+                "source rows contributed to "
+                f"{self._format_heatmap_count(loaded_count)} spatial mean cells."
+                )
+        elif loaded_count is not None and source_count is not None:
             lines.append(
                 "Loaded "
                 f"{self._format_heatmap_count(loaded_count)} finite "
@@ -746,7 +793,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                     "Database rows were uniformly sampled before plotting, capped at "
                     f"{sample_limit} rows."
                     )
-        else:
+        elif not info.get("source_aggregated"):
             lines.append("All matching source rows were read before display binning.")
 
         lines.extend(["", "Display grid:"])
@@ -762,9 +809,14 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 f"{unique_x} x {unique_y} cells."
                 )
             if info.get("empty_bins_filled"):
-                lines.append(
-                    "Empty sampled display bins were filled by interpolation."
-                    )
+                if info.get("source_sampled"):
+                    lines.append(
+                        "Empty sampled display bins were filled by interpolation."
+                        )
+                else:
+                    lines.append(
+                        "Empty display bins were filled by interpolation."
+                        )
         else:
             lines.append(
                 "The sampled source rows were displayed on an exact "
@@ -829,6 +881,62 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         return ranges
 
 
+    def _axis_view_ranges_from_data(
+            self,
+            ) -> dict[str, tuple[float, float]] | None:
+        try:
+            geometry = HeatmapGeometry.from_centres(
+                self.axis_data.get("x", []),
+                self.axis_data.get("y", []),
+                )
+        except (TypeError, ValueError):
+            return None
+
+        return {
+            "x": (float(geometry.x.edges[0]), float(geometry.x.edges[-1])),
+            "y": (float(geometry.y.edges[0]), float(geometry.y.edges[-1])),
+            }
+
+
+    def _zoom_large_heatmap_to_all(self) -> None:
+        if not self._large_heatmap_sql_mode:
+            return
+
+        full_axis_ranges = self._heatmap_full_axis_ranges
+        if full_axis_ranges is None:
+            return
+
+        self._heatmap_view_reload_timer.stop()
+        view_ranges = self._heatmap_full_view_ranges or full_axis_ranges
+        self.vb.setRange(
+            xRange=view_ranges["x"],
+            yRange=view_ranges["y"],
+            padding=0,
+            )
+
+        self._reload_full_heatmap_data()
+
+
+    def _reload_full_heatmap_data(self) -> bool:
+        full_axis_ranges = self._heatmap_full_axis_ranges
+        if full_axis_ranges is None or self._heatmap_last_view_ranges is None:
+            return False
+        if getattr(getattr(self, "worker", None), "running", False):
+            self._heatmap_view_reload_timer.start(
+                _HEATMAP_VIEW_RELOAD_DEBOUNCE_MS
+                )
+            return False
+
+        self._heatmap_last_view_ranges = None
+        self.load_data(
+            force_sql_heatmap=True,
+            heatmap_axis_ranges=None,
+            heatmap_full_axis_ranges=full_axis_ranges,
+            status_message=f"Loading full heatmap for {self.param.name}...",
+            )
+        return True
+
+
     def _schedule_visible_heatmap_reload(self, *_args: Any) -> None:
         if not self._large_heatmap_sql_mode:
             return
@@ -848,7 +956,10 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             return
 
         ranges = self._visible_heatmap_axis_ranges()
-        if ranges is None or self._axis_ranges_match(ranges, self._heatmap_last_view_ranges):
+        if ranges is None:
+            self._reload_full_heatmap_data()
+            return
+        if self._axis_ranges_match(ranges, self._heatmap_last_view_ranges):
             return
 
         self._heatmap_last_view_ranges = ranges

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,6 +7,7 @@ import numpy as np
 import qplot.tools.worker as worker_module
 from qplot.configuration.scripts import try_as_num
 from qplot.tools.general import data2matrix
+from qplot.tools.heatmap_geometry import HeatmapGeometry
 from qplot.tools.plot_tools import differentiate, pass_filter, subtract_mean
 from qplot.tools.worker import loader
 from qplot.windows import _plotWin as plotwin_module
@@ -103,7 +104,7 @@ class ToolFunctionTestCase(unittest.TestCase):
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
             )
 
-    def test_large_heatmap_sql_loader_uses_bounded_sample_and_grid(self):
+    def test_large_heatmap_sql_loader_uses_bounded_spatial_aggregation(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             database_path = f"{tmpdir}/heatmap.db"
             self._create_heatmap_table(database_path)
@@ -131,16 +132,26 @@ class ToolFunctionTestCase(unittest.TestCase):
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
 
-            self.assertTrue(worker.loaded_from_sql_sample)
+            self.assertTrue(worker.loaded_from_sql_heatmap)
             self.assertFalse(worker.read_data)
-            self.assertLessEqual(worker.loaded_point_count, 60)
+            self.assertLessEqual(worker.loaded_point_count, 16)
             self.assertLessEqual(worker.dataGrid.size, 16)
             self.assertGreater(np.isfinite(worker.dataGrid).sum(), 0)
             self.assertIsNotNone(worker.heatmap_downsample_info)
-            self.assertTrue(worker.heatmap_downsample_info["source_sampled"])
+            self.assertFalse(worker.heatmap_downsample_info["source_sampled"])
+            self.assertTrue(worker.heatmap_downsample_info["source_aggregated"])
             self.assertTrue(worker.heatmap_downsample_info["grid_binned"])
             self.assertEqual(worker.heatmap_downsample_info["source_row_count"], 1200)
-            self.assertEqual(worker.heatmap_downsample_info["source_sample_limit"], 60)
+            self.assertIsNone(worker.heatmap_downsample_info["source_sample_limit"])
+            self.assertIsNone(worker.heatmap_downsample_info["source_sample_stride"])
+            self.assertEqual(
+                worker.heatmap_downsample_info["source_aggregation_strategy"],
+                "spatial mean",
+                )
+            self.assertEqual(
+                worker.heatmap_downsample_info["aggregated_source_row_count"],
+                1200,
+                )
             self.assertEqual(worker.heatmap_downsample_info["source_grid_columns"], 40)
             self.assertEqual(worker.heatmap_downsample_info["source_grid_rows"], 30)
             self.assertEqual(
@@ -151,6 +162,138 @@ class ToolFunctionTestCase(unittest.TestCase):
                 worker.heatmap_downsample_info["grid_cell_count"],
                 worker.dataGrid.size,
                 )
+
+    def test_large_heatmap_sql_output_is_independent_of_insertion_order(self):
+        rows = [
+            (float(x), float(y), float(x + y * 100))
+            for y in range(30)
+            for x in range(40)
+            ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = []
+            old_database_path = worker_module.cache_database_path
+            old_set_complete = worker_module.set_parameter_complete
+            old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
+            old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
+            old_grid_side = worker_module.MAX_SQL_HEATMAP_GRID_SIDE
+            try:
+                worker_module.set_parameter_complete = (
+                    lambda param, complete=False: setattr(param, "_complete", complete)
+                    )
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 60
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 16
+                worker_module.MAX_SQL_HEATMAP_GRID_SIDE = 4
+
+                for name, insertion_order in (
+                        ("forward", rows),
+                        ("reverse", list(reversed(rows))),
+                        ):
+                    database_path = f"{tmpdir}/{name}.db"
+                    self._create_heatmap_table_from_rows(
+                        database_path,
+                        insertion_order,
+                    )
+                    worker = self._sql_heatmap_worker(database_path)
+                    worker.cache.rundescriber.shapes = None
+                    worker_module.cache_database_path = (
+                        lambda _cache, path=database_path: path
+                        )
+
+                    loader._load_large_heatmap_from_sql(worker)
+                    loader._canonicalize_heatmap(worker)
+                    self.assertEqual(
+                        worker.heatmap_source_axis_ranges,
+                        {"x": (0.0, 39.0), "y": (0.0, 29.0)},
+                        )
+                    results.append((
+                        worker.axis_data["x"],
+                        worker.axis_data["y"],
+                        worker.dataGrid,
+                        worker.heatmap_downsample_info,
+                        ))
+            finally:
+                worker_module.cache_database_path = old_database_path
+                worker_module.set_parameter_complete = old_set_complete
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
+                worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
+
+        forward_x, forward_y, forward_grid, forward_info = results[0]
+        reverse_x, reverse_y, reverse_grid, reverse_info = results[1]
+        np.testing.assert_array_equal(forward_x, reverse_x)
+        np.testing.assert_array_equal(forward_y, reverse_y)
+        np.testing.assert_array_equal(forward_grid, reverse_grid)
+        self.assertEqual(
+            forward_info["source_aggregation_strategy"],
+            "spatial mean",
+            )
+        self.assertEqual(
+            reverse_info["source_aggregation_strategy"],
+            "spatial mean",
+            )
+        self.assertEqual(forward_info["source_grid_columns"], 40)
+        self.assertEqual(forward_info["source_grid_rows"], 30)
+        np.testing.assert_array_equal(
+            forward_grid,
+            [[304.5, 314.5, 324.5, 334.5],
+             [1054.5, 1064.5, 1074.5, 1084.5],
+             [1804.5, 1814.5, 1824.5, 1834.5],
+             [2554.5, 2564.5, 2574.5, 2584.5]],
+            )
+
+        geometry = HeatmapGeometry.from_centres(forward_x, forward_y)
+        np.testing.assert_allclose(
+            [geometry.x.edges[0], geometry.x.edges[-1]],
+            [-0.5, 39.5],
+            )
+        np.testing.assert_allclose(
+            [geometry.y.edges[0], geometry.y.edges[-1]],
+            [-0.5, 29.5],
+            )
+
+    def test_small_heatmap_sql_loader_preserves_exact_grid(self):
+        rows = [
+            (float(x), float(y), float(x + y * 10))
+            for y in range(3)
+            for x in range(4)
+            ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            database_path = f"{tmpdir}/small.db"
+            self._create_heatmap_table_from_rows(database_path, list(reversed(rows)))
+            worker = self._sql_heatmap_worker(database_path)
+            worker.cache.rundescriber.shapes = {"signal": (3, 4)}
+
+            old_database_path = worker_module.cache_database_path
+            old_set_complete = worker_module.set_parameter_complete
+            old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
+            old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
+            try:
+                worker_module.cache_database_path = lambda _cache: database_path
+                worker_module.set_parameter_complete = (
+                    lambda param, complete=False: setattr(param, "_complete", complete)
+                    )
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 12
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 12
+
+                loader._load_large_heatmap_from_sql(worker)
+                loader._canonicalize_heatmap(worker)
+            finally:
+                worker_module.cache_database_path = old_database_path
+                worker_module.set_parameter_complete = old_set_complete
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
+
+        np.testing.assert_array_equal(worker.axis_data["x"], [0.0, 1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(worker.axis_data["y"], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(
+            worker.dataGrid,
+            [[0.0, 1.0, 2.0, 3.0],
+             [10.0, 11.0, 12.0, 13.0],
+             [20.0, 21.0, 22.0, 23.0]],
+            )
+        self.assertFalse(worker.sampled_heatmap_source)
 
     def test_large_heatmap_sql_loader_can_reload_visible_axis_range(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -295,16 +438,22 @@ class ToolFunctionTestCase(unittest.TestCase):
                 worker_module.cache_database_path = old_database_path
 
     def _create_heatmap_table(self, database_path):
+        self._create_heatmap_table_from_rows(
+            database_path,
+            [
+                (float(x), float(y), float(x + y * 100))
+                for y in range(30)
+                for x in range(40)
+                ],
+            )
+
+    def _create_heatmap_table_from_rows(self, database_path, rows):
         conn = sqlite3.connect(database_path)
         try:
             conn.execute("CREATE TABLE results (x REAL, y REAL, signal REAL)")
             conn.executemany(
                 "INSERT INTO results (x, y, signal) VALUES (?, ?, ?)",
-                [
-                    (float(x), float(y), float(x + y * 100))
-                    for y in range(30)
-                    for x in range(40)
-                    ],
+                rows,
                 )
             conn.commit()
         finally:

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from PyQt6 import QtCore, QtGui
@@ -772,7 +773,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
             preview_module.MAX_PREVIEW_GRID_CELLS = old_max_grid_cells
 
-    def test_large_known_grid_preview_samples_dense_grid(self):
+    def test_large_known_grid_preview_uses_spatial_means_independent_of_row_order(self):
         old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
         old_max_grid_cells = preview_module.MAX_PREVIEW_GRID_CELLS
         preview_module.MAX_PREVIEW_ROWS = 16
@@ -780,31 +781,222 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         conn = sqlite3.connect(":memory:")
         try:
             cursor = conn.cursor()
-            cursor.execute("CREATE TABLE results (x REAL, y REAL, signal REAL)")
-            cursor.executemany(
-                "INSERT INTO results VALUES (?, ?, ?)",
-                [
-                    (float(column), float(row), float(row * 10 + column))
-                    for row in range(4)
-                    for column in range(10)
-                    ],
-                )
-
-            grid = preview_module._sample_large_known_grid_preview(
-                cursor,
-                "results",
-                {"result_count": 40},
-                "signal",
-                (4, 10),
-                size=4,
-                )
+            values = [
+                (float(row), float(column), float(column % 2))
+                for row in range(4)
+                for column in range(40)
+                ]
+            metadata = {
+                "result_count": len(values),
+                "setpoint_shape": [4, 40],
+                "measure_parameters": ["signal"],
+                "sweep_parameters": ["slow_y", "fast_x"],
+                }
+            grids = []
+            with patch.object(
+                    preview_module,
+                    "render_heatmap_grid_preview",
+                    side_effect=lambda grid, size: np.array(grid, copy=True),
+                    ):
+                for table_name, table_values in (
+                        ("forward_results", values),
+                        ("reverse_results", list(reversed(values))),
+                        ):
+                    cursor.execute(
+                        f"CREATE TABLE {table_name} "
+                        "(slow_y REAL, fast_x REAL, signal REAL)"
+                        )
+                    cursor.executemany(
+                        f"INSERT INTO {table_name} VALUES (?, ?, ?)",
+                        table_values,
+                        )
+                    preview = preview_module._preview_2d(
+                        cursor,
+                        table_name,
+                        metadata,
+                        "signal",
+                        ["slow_y", "fast_x"],
+                        size=4,
+                        )
+                    grids.append(preview["image"])
         finally:
             conn.close()
             preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
             preview_module.MAX_PREVIEW_GRID_CELLS = old_max_grid_cells
 
+        for grid in grids:
+            self.assertEqual(grid.shape, (4, 4))
+            np.testing.assert_allclose(grid, np.full((4, 4), 0.5))
+        np.testing.assert_array_equal(grids[0], grids[1])
+
+    def test_large_partial_preview_preserves_unmeasured_grid_area(self):
+        old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
+        old_max_grid_cells = preview_module.MAX_PREVIEW_GRID_CELLS
+        preview_module.MAX_PREVIEW_ROWS = 16
+        preview_module.MAX_PREVIEW_GRID_CELLS = 4
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "CREATE TABLE results "
+                "(slow_y REAL, fast_x REAL, signal REAL)"
+                )
+            values = [
+                (0.0, float(column), float(column % 2))
+                for column in range(40)
+                ]
+            cursor.executemany(
+                "INSERT INTO results VALUES (?, ?, ?)",
+                values,
+                )
+            metadata = {
+                "result_count": len(values),
+                "setpoint_shape": [4, 40],
+                "measure_parameters": ["signal"],
+                "sweep_parameters": ["slow_y", "fast_x"],
+                }
+            with patch.object(
+                    preview_module,
+                    "render_heatmap_grid_preview",
+                    side_effect=lambda grid, size: np.array(grid, copy=True),
+                    ):
+                preview = preview_module._preview_2d(
+                    cursor,
+                    "results",
+                    metadata,
+                    "signal",
+                    ["slow_y", "fast_x"],
+                    size=4,
+                    )
+        finally:
+            conn.close()
+            preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
+            preview_module.MAX_PREVIEW_GRID_CELLS = old_max_grid_cells
+
+        grid = preview["image"]
         self.assertEqual(grid.shape, (4, 4))
-        self.assertTrue(np.isfinite(grid).all())
+        np.testing.assert_allclose(grid[0], np.full(4, 0.5))
+        self.assertTrue(np.isnan(grid[1:]).all())
+
+    def test_large_preview_without_shape_uses_spatial_means(self):
+        old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
+        old_max_grid_cells = preview_module.MAX_PREVIEW_GRID_CELLS
+        preview_module.MAX_PREVIEW_ROWS = 16
+        preview_module.MAX_PREVIEW_GRID_CELLS = 4
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            values = [
+                (float(row), float(column), float(column % 2))
+                for row in range(4)
+                for column in range(40)
+                ]
+            metadata = {
+                "result_count": len(values),
+                "measure_parameters": ["signal"],
+                "sweep_parameters": ["slow_y", "fast_x"],
+                }
+            grids = []
+            with patch.object(
+                    preview_module,
+                    "render_heatmap_grid_preview",
+                    side_effect=lambda grid, size: np.array(grid, copy=True),
+                    ):
+                for table_name, table_values in (
+                        ("forward_results", values),
+                        ("reverse_results", list(reversed(values))),
+                        ):
+                    cursor.execute(
+                        f"CREATE TABLE {table_name} "
+                        "(slow_y REAL, fast_x REAL, signal REAL)"
+                        )
+                    cursor.executemany(
+                        f"INSERT INTO {table_name} VALUES (?, ?, ?)",
+                        table_values,
+                        )
+                    preview = preview_module._preview_2d(
+                        cursor,
+                        table_name,
+                        metadata,
+                        "signal",
+                        ["slow_y", "fast_x"],
+                        size=4,
+                        )
+                    grids.append(preview["image"])
+        finally:
+            conn.close()
+            preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
+            preview_module.MAX_PREVIEW_GRID_CELLS = old_max_grid_cells
+
+        for grid in grids:
+            self.assertEqual(grid.shape, (4, 4))
+            np.testing.assert_allclose(grid, np.full((4, 4), 0.5))
+        np.testing.assert_array_equal(grids[0], grids[1])
+
+    def test_large_preview_falls_back_to_streaming_spatial_means(self):
+        old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
+        old_max_grid_cells = preview_module.MAX_PREVIEW_GRID_CELLS
+        preview_module.MAX_PREVIEW_ROWS = 16
+        preview_module.MAX_PREVIEW_GRID_CELLS = 4
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            values = [
+                (float(row), float(column), float(column % 2))
+                for row in range(4)
+                for column in range(40)
+                ]
+            metadata = {
+                "result_count": len(values),
+                "setpoint_shape": [4, 40],
+                "measure_parameters": ["signal"],
+                "sweep_parameters": ["slow_y", "fast_x"],
+                }
+            grids = []
+            with (
+                    patch.object(
+                        preview_module,
+                        "_spatial_mean_preview_grid",
+                        side_effect=sqlite3.OperationalError("unsupported"),
+                        ),
+                    patch.object(preview_module, "log_exception") as logged,
+                    patch.object(
+                        preview_module,
+                        "render_heatmap_grid_preview",
+                        side_effect=lambda grid, size: np.array(grid, copy=True),
+                        ),
+                    ):
+                for table_name, table_values in (
+                        ("forward_results", values),
+                        ("reverse_results", list(reversed(values))),
+                        ):
+                    cursor.execute(
+                        f"CREATE TABLE {table_name} "
+                        "(slow_y REAL, fast_x REAL, signal REAL)"
+                        )
+                    cursor.executemany(
+                        f"INSERT INTO {table_name} VALUES (?, ?, ?)",
+                        table_values,
+                        )
+                    preview = preview_module._preview_2d(
+                        cursor,
+                        table_name,
+                        metadata,
+                        "signal",
+                        ["slow_y", "fast_x"],
+                        size=4,
+                        )
+                    grids.append(preview["image"])
+        finally:
+            conn.close()
+            preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
+            preview_module.MAX_PREVIEW_GRID_CELLS = old_max_grid_cells
+
+        self.assertEqual(logged.call_count, 2)
+        for grid in grids:
+            self.assertEqual(grid.shape, (4, 4))
+            np.testing.assert_allclose(grid, np.full((4, 4), 0.5))
+        np.testing.assert_array_equal(grids[0], grids[1])
 
     def test_sampled_2d_preview_bins_to_avoid_sparse_grid_artifacts(self):
         old_samples_per_cell = preview_module.PREVIEW_SAMPLES_PER_CELL

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -12,6 +12,38 @@ from qplot.windows.plot2d import _COLORBAR_COLORMAPS, plot2d
 
 
 class Plot2dLiveRefreshTestCase(unittest.TestCase):
+    def test_large_heatmap_range_controls_cover_axis_and_auto_actions(self):
+        class Signal:
+            def __init__(self):
+                self.callbacks = []
+
+            def connect(self, callback):
+                self.callbacks.append(callback)
+
+            def emit(self, *args):
+                for callback in self.callbacks:
+                    callback(*args)
+
+        window = plot2d.__new__(plot2d)
+        window.plot = type("Plot", (), {})()
+        window.plot.sigRangeChangedManually = Signal()
+        window.plot.autoBtn = type("AutoButton", (), {"clicked": Signal()})()
+        window.vb = type("ViewBox", (), {"autoRange_triggered": Signal()})()
+        scheduled = []
+        zoomed_all = []
+        window._schedule_visible_heatmap_reload = (
+            lambda *_args: scheduled.append(True)
+            )
+        window._zoom_large_heatmap_to_all = lambda: zoomed_all.append(True)
+
+        window._connect_heatmap_range_controls()
+        window.plot.sigRangeChangedManually.emit(object())
+        window.vb.autoRange_triggered.emit()
+        window.plot.autoBtn.clicked.emit(object())
+
+        self.assertEqual(scheduled, [True])
+        self.assertEqual(zoomed_all, [True, True])
+
     def test_empty_live_worker_data_releases_worker_without_rendering(self):
         class Signal:
             def __init__(self):
@@ -99,6 +131,167 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
             }
 
         self.assertIsNone(window._visible_heatmap_axis_ranges())
+
+    def test_large_heatmap_state_keeps_source_and_outer_view_ranges(self):
+        class Worker:
+            loaded_from_sql_heatmap = True
+            heatmap_axis_ranges = None
+            heatmap_source_axis_ranges = {
+                "x": (0.0, 39.0),
+                "y": (0.0, 29.0),
+                }
+
+        window = plot2d.__new__(plot2d)
+        window.axis_data = {
+            "x": np.array([4.5, 14.5, 24.5, 34.5]),
+            "y": np.array([3.25, 10.75, 18.25, 25.75]),
+            }
+        window._heatmap_full_axis_ranges = None
+        window._heatmap_full_view_ranges = None
+        window._heatmap_last_view_ranges = None
+        window._update_heatmap_downsample_state = lambda _worker: None
+
+        window._update_large_heatmap_state(Worker())
+
+        self.assertEqual(
+            window._heatmap_full_axis_ranges,
+            {"x": (0.0, 39.0), "y": (0.0, 29.0)},
+            )
+        np.testing.assert_allclose(
+            window._heatmap_full_view_ranges["x"],
+            (-0.5, 39.5),
+            )
+        np.testing.assert_allclose(
+            window._heatmap_full_view_ranges["y"],
+            (-0.5, 29.5),
+            )
+
+    def test_zoom_to_all_reloads_full_large_heatmap(self):
+        class ViewBox:
+            def __init__(self):
+                self.ranges = []
+
+            def setRange(self, **kwargs):
+                self.ranges.append(kwargs)
+
+        class Timer:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        window = plot2d.__new__(plot2d)
+        window.vb = ViewBox()
+        window._heatmap_view_reload_timer = Timer()
+        window._large_heatmap_sql_mode = True
+        window._heatmap_full_axis_ranges = {
+            "x": (0.0, 39.0),
+            "y": (0.0, 29.0),
+            }
+        window._heatmap_full_view_ranges = {
+            "x": (-0.5, 39.5),
+            "y": (-0.5, 29.5),
+            }
+        window._heatmap_last_view_ranges = {
+            "x": (10.0, 20.0),
+            "y": (5.0, 10.0),
+            }
+        window.worker = type("Worker", (), {"running": False})()
+        window.param = type("Param", (), {"name": "signal"})()
+        loads = []
+        window.load_data = lambda **kwargs: loads.append(kwargs)
+
+        window._zoom_large_heatmap_to_all()
+
+        self.assertTrue(window._heatmap_view_reload_timer.stopped)
+        self.assertEqual(
+            window.vb.ranges,
+            [{
+                "xRange": (-0.5, 39.5),
+                "yRange": (-0.5, 29.5),
+                "padding": 0,
+                }],
+            )
+        self.assertIsNone(window._heatmap_last_view_ranges)
+        self.assertEqual(loads[0]["heatmap_axis_ranges"], None)
+        self.assertEqual(
+            loads[0]["heatmap_full_axis_ranges"],
+            window._heatmap_full_axis_ranges,
+            )
+
+    def test_zooming_out_of_visible_range_reloads_full_large_heatmap(self):
+        window = plot2d.__new__(plot2d)
+        window._large_heatmap_sql_mode = True
+        window._heatmap_full_axis_ranges = {
+            "x": (0.0, 39.0),
+            "y": (0.0, 29.0),
+            }
+        window._heatmap_last_view_ranges = {
+            "x": (10.0, 20.0),
+            "y": (5.0, 10.0),
+            }
+        window.worker = type("Worker", (), {"running": False})()
+        window.param = type("Param", (), {"name": "signal"})()
+        window._visible_heatmap_axis_ranges = lambda: None
+        loads = []
+        window.load_data = lambda **kwargs: loads.append(kwargs)
+
+        window._reload_visible_heatmap_data()
+
+        self.assertIsNone(window._heatmap_last_view_ranges)
+        self.assertEqual(len(loads), 1)
+        self.assertIsNone(loads[0]["heatmap_axis_ranges"])
+        self.assertEqual(
+            loads[0]["heatmap_full_axis_ranges"],
+            window._heatmap_full_axis_ranges,
+            )
+
+    def test_zoom_to_all_retries_full_reload_after_worker_finishes(self):
+        class ViewBox:
+            def setRange(self, **_kwargs):
+                pass
+
+        class Timer:
+            def __init__(self):
+                self.starts = []
+
+            def stop(self):
+                pass
+
+            def start(self, interval):
+                self.starts.append(interval)
+
+        window = plot2d.__new__(plot2d)
+        window.vb = ViewBox()
+        window._heatmap_view_reload_timer = Timer()
+        window._large_heatmap_sql_mode = True
+        window._heatmap_full_axis_ranges = {
+            "x": (0.0, 39.0),
+            "y": (0.0, 29.0),
+            }
+        window._heatmap_full_view_ranges = window._heatmap_full_axis_ranges
+        window._heatmap_last_view_ranges = {
+            "x": (10.0, 20.0),
+            "y": (5.0, 10.0),
+            }
+        window.worker = type("Worker", (), {"running": True})()
+        window.param = type("Param", (), {"name": "signal"})()
+        window._visible_heatmap_axis_ranges = lambda: None
+        loads = []
+        window.load_data = lambda **kwargs: loads.append(kwargs)
+
+        window._zoom_large_heatmap_to_all()
+
+        self.assertEqual(len(window._heatmap_view_reload_timer.starts), 1)
+        self.assertGreater(window._heatmap_view_reload_timer.starts[0], 0)
+        self.assertEqual(loads, [])
+
+        window.worker.running = False
+        window._reload_visible_heatmap_data()
+
+        self.assertEqual(len(loads), 1)
+        self.assertIsNone(loads[0]["heatmap_axis_ranges"])
 
 
 class HeatmapHoverOutlineTestCase(unittest.TestCase):
@@ -1460,6 +1653,56 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
             self.assertIn("full-resolution heatmap limit is 1,000,000", text)
             self.assertIn("176 x 176 = 30,976 cells", text)
             self.assertIn("uniformly sampled", text)
+        finally:
+            host.deleteLater()
+
+    def test_spatially_aggregated_heatmap_explains_that_all_rows_contributed(self):
+        class Worker:
+            heatmap_downsample_info = {
+                "source_row_count": 2_000_000,
+                "estimated_range_rows": 2_000_000,
+                "loaded_point_count": 200_000,
+                "source_sampled": False,
+                "source_aggregated": True,
+                "aggregated_source_row_count": 2_000_000,
+                "source_sample_limit": None,
+                "source_sample_stride": None,
+                "source_sample_strategy": None,
+                "source_aggregation_strategy": "spatial mean",
+                "axis_ranges": None,
+                "unique_x_count": 2_000,
+                "unique_y_count": 1_000,
+                "exact_cell_count": 2_000_000,
+                "source_grid_columns": 2_000,
+                "source_grid_rows": 1_000,
+                "source_grid_cell_count": 2_000_000,
+                "grid_columns": 500,
+                "grid_rows": 400,
+                "grid_cell_count": 200_000,
+                "grid_binned": True,
+                "grid_cell_limit": 250_000,
+                "full_resolution_point_limit": 1_000_000,
+                "empty_bins_filled": False,
+                }
+
+        host = plot2d.__new__(plot2d)
+        qtw.QMainWindow.__init__(host)
+        host.toolbarCo_ord = qtw.QToolBar(host)
+        host.widget = qtw.QWidget(host)
+        host._heatmap_worker_downsample_info = None
+        host._heatmap_downsample_info = None
+
+        try:
+            host._init_heatmap_downsample_warning_button()
+            host._update_heatmap_downsample_state(Worker())
+
+            text = host._heatmap_downsample_dialog_text()
+            self.assertIn(
+                "All 2,000,000 matching source rows contributed",
+                text,
+                )
+            self.assertIn("200,000 spatial mean cells", text)
+            self.assertNotIn("sampled before plotting", text)
         finally:
             host.deleteLater()
 


### PR DESCRIPTION
## Summary

- replace periodic row-ID sampling with coordinate-based spatial mean aggregation for large heatmaps
- apply the same spatial-mean semantics to previews and run-list thumbnails, including partial and metadata-poor runs
- reload complete spatial bounds when zooming back out, while preserving corrected heatmap geometry and exact small-dataset behaviour
- add regression coverage and a two-million-row aggregation/preview benchmark

## Root cause

Large heatmaps and previews selected periodic database rows, so their output depended on row insertion order and could alias into misleading stripe patterns. The displayed aggregate also retained only its loaded extent, which meant zoom-to-all could zoom in but could not always recover the complete bounds.

## Impact

Large heatmaps, previews, and thumbnails now represent spatial bin means independently of insertion order. Partial scans preserve their unmeasured area, and zoom-to-all can request the complete dataset extent again.

## Validation

- `.venv-mac/bin/python -m pytest` — 366 passed, 2 subtests passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m mypy` — passed
- qPlot offscreen startup smoke test — passed
- 2,000,000-row benchmark:
  - spatial aggregation load: 1.957 s
  - spatial-mean preview generation: 1.544 s

Part of #25.
