### PR TITLE
Repair fill operations and integer input validation

### DIFF
--- a/src/qplot/tools/plot_tools.py
+++ b/src/qplot/tools/plot_tools.py
@@ -147,57 +147,32 @@ def fill_heatmap(
         data_dict : dict,
         max_depth : int = 10
         ):
-    def set_value_row_major(major, minor, data):
-        new_val = data[major - 1, minor]
-        if np.isnan(new_val):
-            return
-        data[major, minor] = new_val
-        
-    def set_value_col_major(major, minor, data):
-        new_val = data[minor, major - 1]
-        if np.isnan(new_val):
-            return
-        data[minor, major] = new_val
-        
     data = data_dict["z"].copy()
     if which == "below":
-        fetch_row = lambda major: data[major]
-        set_item = set_value_row_major
+        lines = (data[:, column] for column in range(data.shape[1]))
     elif which == "right":
-        fetch_row = lambda major: data[:, major]
-        set_item = set_value_col_major
+        lines = (data[row, :] for row in range(data.shape[0]))
     else:
         raise KeyError(f'Invalid value for which: {which}, must be "below" or "right".')
-        
-    shape = data.shape
-    length = shape[0] if which == "below" else shape[1]
-        
-    
-    truth_arr = np.array([np.isnan(fetch_row(0))])
-    initial_size = max_depth if length >= max_depth else length
-    
-    for itr in range(initial_size):
-        truth_arr = np.append(
-            truth_arr, 
-            [np.isnan(fetch_row(itr))],
-            axis = 0
-            )
-    
-    for major_itr in range(1, length - 1):
-        truth_arr = truth_arr[1:] # remove first item
-        
-        try:
-            truth_arr = np.append(
-                truth_arr, 
-                [np.isnan(fetch_row(major_itr + max_depth))],
-                axis = 0
-                )
-        except IndexError: # Ignore error for last few data points
-            pass
-        
-        for minor_itr, minor_val in enumerate(truth_arr[0]):
-            if minor_val and not truth_arr[:, minor_itr].all():
-                set_item(major_itr, minor_itr, data)
+
+    if max_depth <= 0:
+        return {"z": data}
+
+    for line in lines:
+        position = 0
+        while position < len(line):
+            if not np.isnan(line[position]):
+                position += 1
+                continue
+
+            gap_start = position
+            while position < len(line) and np.isnan(line[position]):
+                position += 1
+
+            gap_length = position - gap_start
+            bounded = gap_start > 0 and position < len(line)
+            if bounded and gap_length <= max_depth:
+                line[gap_start:position] = line[gap_start - 1]
         
     return {"z" : data}
         

--- a/src/qplot/windows/_widgets/operations.py
+++ b/src/qplot/windows/_widgets/operations.py
@@ -218,17 +218,31 @@ class operations_options_base(qtw.QWidget):
             item = cast(rowItem, self.list_order.item(i))
             if item.isHidden():
                 continue
-            
-            output = item.output()
+
+            input_widget = item.input
+            if (
+                    isinstance(input_widget, qtw.QLineEdit)
+                    and input_widget.text()
+                    and not input_widget.hasAcceptableInput()
+                    ):
+                continue
+
+            try:
+                output = item.output()
+            except (TypeError, ValueError, OverflowError):
+                continue
+
             if output == "": # Data not entered
-                input_widget = item.input
                 if hasattr(input_widget, "placeholderText"):
                     output = cast(Any, input_widget).placeholderText()
                     if output == "": # still blank
                         continue
                     
                     if isinstance(item.input_type, type):
-                        output = item.input_type(output)
+                        try:
+                            output = item.input_type(output)
+                        except (TypeError, ValueError, OverflowError):
+                            continue
                 else:
                     continue
             
@@ -330,7 +344,9 @@ class rowItem(qtw.QListWidgetItem):
             self.output = lambda: (scalar_type(line_edit.text()) 
                                    if line_edit.text() else "")
             # Restrict user input to reduce errors
-            if input_type != str:
+            if input_type is int:
+                line_edit.setValidator(QtGui.QIntValidator())
+            elif input_type is float:
                 validator = QtGui.QDoubleValidator()
                 validator.setNotation(QtGui.QDoubleValidator.Notation.ScientificNotation)
                 validator.setLocale(QtCore.QLocale("C"))  # Avoids locale issues like commas

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,7 +8,12 @@ import qplot.tools.worker as worker_module
 from qplot.configuration.scripts import try_as_num
 from qplot.tools.general import data2matrix
 from qplot.tools.heatmap_geometry import HeatmapGeometry
-from qplot.tools.plot_tools import differentiate, pass_filter, subtract_mean
+from qplot.tools.plot_tools import (
+    differentiate,
+    fill_heatmap,
+    pass_filter,
+    subtract_mean,
+)
 from qplot.tools.worker import loader
 from qplot.windows import _plotWin as plotwin_module
 from qplot.windows._dataset_handle import DatasetHandle
@@ -503,6 +508,52 @@ class ToolFunctionTestCase(unittest.TestCase):
 
         np.testing.assert_array_equal(filtered["y"], np.array([2.0, 4.0, 5.0]))
         np.testing.assert_allclose(differentiated["y"], np.array([2.0, 2.0, 2.0]))
+
+    def test_fill_below_handles_bounded_leading_trailing_and_over_limit_gaps(self):
+        data_grid = np.array([
+            [1.0, np.nan, 1.0, 1.0],
+            [np.nan, np.nan, 2.0, np.nan],
+            [np.nan, 3.0, 3.0, np.nan],
+            [4.0, 4.0, 4.0, np.nan],
+            [5.0, 5.0, 5.0, 5.0],
+            [6.0, 6.0, np.nan, 6.0],
+            [7.0, 7.0, np.nan, 7.0],
+        ])
+
+        result = fill_heatmap("below", {"z": data_grid}, max_depth=2)
+
+        np.testing.assert_array_equal(
+            result["z"],
+            np.array([
+                [1.0, np.nan, 1.0, 1.0],
+                [1.0, np.nan, 2.0, np.nan],
+                [1.0, 3.0, 3.0, np.nan],
+                [4.0, 4.0, 4.0, np.nan],
+                [5.0, 5.0, 5.0, 5.0],
+                [6.0, 6.0, np.nan, 6.0],
+                [7.0, 7.0, np.nan, 7.0],
+            ]),
+        )
+
+    def test_fill_right_handles_bounded_leading_trailing_and_over_limit_gaps(self):
+        data_grid = np.array([
+            [1.0, np.nan, np.nan, 4.0, 5.0, 6.0, 7.0],
+            [np.nan, np.nan, 3.0, 4.0, 5.0, 6.0, 7.0],
+            [1.0, 2.0, 3.0, 4.0, 5.0, np.nan, np.nan],
+            [1.0, np.nan, np.nan, np.nan, 5.0, 6.0, 7.0],
+        ])
+
+        result = fill_heatmap("right", {"z": data_grid}, max_depth=2)
+
+        np.testing.assert_array_equal(
+            result["z"],
+            np.array([
+                [1.0, 1.0, 1.0, 4.0, 5.0, 6.0, 7.0],
+                [np.nan, np.nan, 3.0, 4.0, 5.0, 6.0, 7.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0, np.nan, np.nan],
+                [1.0, np.nan, np.nan, np.nan, 5.0, 6.0, 7.0],
+            ]),
+        )
 
     def test_worker_operations_continue_after_one_operation_fails(self):
         class Signal:

--- a/tests/widgets/test_operations.py
+++ b/tests/widgets/test_operations.py
@@ -1,14 +1,30 @@
 import unittest
 
-from PyQt6 import QtCore
+import numpy as np
+from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot.tools.operation_registry import operation_specs_for
-from qplot.windows._widgets.operations import operations_options_1d
+from qplot.windows._widgets.operations import (
+    operations_options_1d,
+    operations_options_2d,
+)
 from qplot.windows._widgets.toolbar import QDock_context
 
 
 class OperationsPanelTestCase(unittest.TestCase):
+    def _panel(self, panel_type):
+        main = qtw.QMainWindow()
+        main.oper_dock = QDock_context("Operations", main)
+        return main, panel_type(main)
+
+    def _option(self, widget, label):
+        for index in range(widget.list_options.count()):
+            item = widget.list_options.item(index)
+            if item.label == label:
+                return item
+        self.fail(f"Operation option not found: {label}")
+
     def test_operations_panel_layout_is_installed_once(self):
         messages = []
 
@@ -39,4 +55,47 @@ class OperationsPanelTestCase(unittest.TestCase):
         self.assertIn("Subtract Row Mean", names)
         self.assertIn("Fill Below", names)
 
+    def test_invalid_integer_operation_input_does_not_raise_from_callback(self):
+        main, widget = self._panel(operations_options_2d)
+        try:
+            option = self._option(widget, "Fill Below")
+            option.input.setChecked(True)
+            operation = option.operation_row
+            operation.input.setText("1.5")
+            callback_errors = []
+            callback_results = []
 
+            def refresh_callback():
+                try:
+                    callback_results.append(widget.get_data())
+                except Exception as error:
+                    callback_errors.append(error)
+
+            widget.apply_but.clicked.connect(refresh_callback)
+            widget.apply_but.click()
+
+            self.assertIsInstance(operation.input.validator(), QtGui.QIntValidator)
+            self.assertFalse(operation.input.hasAcceptableInput())
+            self.assertEqual(callback_errors, [])
+            self.assertEqual(callback_results, [[]])
+        finally:
+            main.deleteLater()
+
+    def test_float_operation_input_preserves_scientific_notation(self):
+        main, widget = self._panel(operations_options_1d)
+        try:
+            option = self._option(widget, "Limit Maximum")
+            option.input.setChecked(True)
+            option.operation_row.input.setText("1e1")
+
+            operations = widget.get_data()
+
+            self.assertEqual(len(operations), 1)
+            result = operations[0]({
+                "x": np.array([0.0, 1.0]),
+                "y": np.array([5.0, 15.0]),
+                "z": None,
+            })
+            np.testing.assert_array_equal(result["y"], [5.0, 10.0])
+        finally:
+            main.deleteLater()


### PR DESCRIPTION
## Summary

- repair Fill Below and Fill Right so they fill only bounded gaps within the configured depth
- preserve leading, trailing, and over-limit gaps
- use integer validation for integer operation inputs and safely ignore invalid callback values
- preserve float operation input, including scientific notation
- add regression coverage for both fill directions and the GUI callback path

## Root cause

The previous sliding look-ahead duplicated and misaligned rows near the start of a gap, so valid bounded gaps could remain empty and depth limits were not applied reliably. Integer operations also used a floating-point validator, allowing values that later raised during `int(...)` conversion from the refresh callback.

## Validation

- `.venv-mac/bin/python -m pytest -q` — 370 passed, 2 subtests passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m mypy` — passed
- `.venv-mac/bin/python -m qplot` — started successfully

Part of #25.