### PR TITLE
Prepare qPlot 1.5.0 beta 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+No changes yet.
+
+## 1.5.0-b1 - 2026-07-31
+
+### Added
+
+- Add a shared heatmap geometry model for uniform, nonuniform, descending, and
+  singleton setpoint axes, with exact cell bounds used consistently by
+  rendering, hovering, marquee selection, and sweep controls.
+- Add a benchmark helper for spatial heatmap aggregation.
+
 ### Changed
 
 - Large heatmaps now use bounded spatial mean aggregation in SQL instead of
@@ -15,12 +26,30 @@ installation commands and release validation, see `docs/distribution.md`.
   centres retain the corrected source heatmap extent.
 - Large preview images and run-list thumbnails now originate from spatial bin
   means instead of periodic row-ID samples, preventing scan-pattern aliasing.
+- Use run IDs instead of timestamps as the new-run refresh cursor, so runs with
+  equal or missing timestamps cannot hide later runs.
+- Require pyqtgraph 0.14 or newer for the heatmap rendering model.
+- Let mypy use the active Python version during developer validation.
 
 ### Fixed
 
 - Zoom to All, the on-plot auto-range button, and manual zooming out now
   restore and reload the complete source extent after a large heatmap has
   loaded a zoomed visible range.
+- Render nonuniform heatmaps against their exact cell edges, keep descending
+  axes aligned with their data, and give singleton axes a visible extent.
+- Keep heatmap hover values, marquee selection, axis swapping, and extracted
+  sweeps aligned with the recorded setpoints as geometry changes.
+- Preserve the active database when another database load fails, is cancelled,
+  or finishes after a newer load has started.
+- Roll back dataset ownership cleanly when plot construction fails, including
+  closing transient read-only connections without disturbing shared datasets.
+- Fill Below and Fill Right now handle bounded, leading, trailing, and
+  over-limit gaps consistently.
+- Reject invalid integer operation input without raising from the UI callback,
+  while preserving valid floating-point scientific notation.
+- Keep 1D trace colors, axes, and appearance settings synchronized across the
+  trace controls, appearance dialog, and theme changes.
 
 ## 1.5.0-a1 - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ No changes yet.
 
 ## 1.5.0-b1 - 2026-07-31
 
+
+### Highlights
+
+- Bugs identified by GPT-5.6 Sol have all been fixed.
+- As a result, thumbnails and previews now work properly.
+- Handling large datasets remains slow and I have not benchmarked this against Ben Wordsworth's original version.
+- I have also not tested this version thoroughly, which is why it's still a beta.
+
 ### Added
 
 - Add a shared heatmap geometry model for uniform, nonuniform, descending, and

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ automatically when qPlot is installed.
 ## Install
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
-The commands below install the latest full release, `1.4.0`. Prereleases are
-listed on the GitHub releases page but are not used for the default install.
+The commands below install the latest full release, `1.4.0`. The current beta
+is `1.5.0-b1`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -38,6 +38,13 @@ python3 -m venv .venv-mac
 source .venv-mac/bin/activate
 python -m pip install -U pip
 python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.4.0
+```
+
+To test the current beta instead, install its explicit tag in the same virtual
+environment:
+
+```console
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b1
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -25,15 +25,15 @@ python -m pip install -e ".[dev]"
 
 Both commands expose the `qplot` and `qplot-cfg` entry points.
 
-## Current Prerelease
+## Current Beta
 
-The current prerelease is `1.5.0-a1`. The package metadata uses the PEP 440
-normal form `1.5.0a1`; the GitHub release tag should be `v1.5.0-a1`.
+The current beta is `1.5.0-b1`. The package metadata uses the PEP 440 normal
+form `1.5.0b1`; the GitHub release tag should be `v1.5.0-b1`.
 
-Prerelease test install:
+Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-a1
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b1
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0a1`, even if the Git tag includes a separator,
-   such as `v1.5.0-a1`.
+   package form, such as `1.5.0b1`, even if the Git tag includes a separator,
+   such as `v1.5.0-b1`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.
@@ -68,9 +68,11 @@ Before creating a tagged release:
 5. Run `python -m pytest`.
 6. Run `python -m build`.
 7. Run `python -m twine check dist/*`.
-8. Run the manual GUI check from `CONTRIBUTING.md`.
-9. Confirm README install and compatibility notes still match the release.
-10. Create a GitHub release from the tag and include user-facing changes.
+8. Create a fresh virtual environment, install only the built wheel, and check
+   `qplot-cfg -version` plus `python -c "import qplot; print(qplot.__version__)"`.
+9. Run the manual GUI check from `CONTRIBUTING.md`.
+10. Confirm README install and compatibility notes still match the release.
+11. Create a GitHub release from the tag and include user-facing changes.
 
 ## Future Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0a1"
+version = "1.5.0b1"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]


### PR DESCRIPTION
## Summary

- update the package version from `1.5.0a1` to `1.5.0b1` while retaining the Beta maturity classifier
- add the dated `1.5.0-b1` changelog covering the complete post-alpha release delta
- keep `v1.4.0` as the default stable README install and document `v1.5.0-b1` as the current beta
- update distribution examples and add fresh-wheel validation to the release checklist

## Impact

This prepares the focused metadata and documentation changes needed for the first qPlot 1.5.0 beta. It does not create the release tag or GitHub release. Issue #25 intentionally remains open.

## Validation

- `.venv-mac/bin/python -m ruff check .`
- `.venv-mac/bin/python -m mypy`
- `.venv-mac/bin/python -m pytest` (`373 passed`)
- `.venv-mac/bin/python -m build`
- `.venv-mac/bin/python -m twine check` on the beta wheel and source distribution
- fresh virtual environment install of the built wheel
- `qplot-cfg -version` and installed-package import both reported `1.5.0b1`
- fresh-environment `python -m pip check`
- qPlot GUI startup smoke check from the project virtual environment
