### PR TITLE
Fix transactional database switching

### DIFF
--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -28,6 +28,7 @@ DATABASE_ACCESS_TIMEOUT_SECONDS = 3
 DATABASE_CLOUD_SYNC_TIMEOUT_SECONDS = 120
 DATABASE_CLOUD_SYNC_CHUNK_BYTES = 4 * 1024 * 1024
 DATABASE_CLOUD_SYNC_STATUS_INTERVAL = 1.0
+DATABASE_CLOUD_SYNC_RETRY_INTERVAL = 0.25
 DATABASE_PREFETCH_STATUS_PREFIX = "QPLOT_PREFETCH_PROGRESS:"
 CLOUD_PLACEHOLDER_XATTR_MARKERS = (
     "com.apple.fileprovider",
@@ -217,36 +218,7 @@ def prefetch_database_file_with_timeout(
     if status_callback is not None:
         status_callback(f"Waiting for {provider} sync...")
 
-    script = (
-        "import os, sys, time\n"
-        f"prefix = {DATABASE_PREFETCH_STATUS_PREFIX!r}\n"
-        f"chunk_size = {DATABASE_CLOUD_SYNC_CHUNK_BYTES!r}\n"
-        f"status_interval = {DATABASE_CLOUD_SYNC_STATUS_INTERVAL!r}\n"
-        "path = sys.argv[1]\n"
-        "total = os.path.getsize(path)\n"
-        "read = 0\n"
-        "last = 0.0\n"
-        "def report(force=False):\n"
-        "    global last\n"
-        "    if total <= 0:\n"
-        "        percent = 100.0\n"
-        "    else:\n"
-        "        percent = min(100.0, (read / total) * 100.0)\n"
-        "    now = time.perf_counter()\n"
-        "    if force or now - last >= status_interval:\n"
-        "        print(prefix + f'{percent:.0f}', flush=True)\n"
-        "        last = now\n"
-        "report(True)\n"
-        "with open(path, 'rb') as handle:\n"
-        "    while True:\n"
-        "        chunk = handle.read(chunk_size)\n"
-        "        if not chunk:\n"
-        "            break\n"
-        "        read += len(chunk)\n"
-        "        report(False)\n"
-        "report(True)\n"
-        "print(read, flush=True)\n"
-    )
+    script = _database_prefetch_script()
 
     try:
         process = subprocess.Popen(
@@ -333,6 +305,65 @@ def prefetch_database_file_with_timeout(
         raise RuntimeError(details)
 
     return bytes_read
+
+
+def _database_prefetch_script():
+    """
+    Returns the isolated cloud-hydration script used by the load worker.
+
+    Cloud providers can report a transient OS-level TimeoutError while a
+    placeholder is being materialised. The subprocess keeps retrying those
+    reads; its parent remains responsible for the overall timeout and cancel.
+
+    """
+    return (
+        "import errno, os, sys, time\n"
+        f"prefix = {DATABASE_PREFETCH_STATUS_PREFIX!r}\n"
+        f"chunk_size = {DATABASE_CLOUD_SYNC_CHUNK_BYTES!r}\n"
+        f"status_interval = {DATABASE_CLOUD_SYNC_STATUS_INTERVAL!r}\n"
+        f"retry_interval = {DATABASE_CLOUD_SYNC_RETRY_INTERVAL!r}\n"
+        "transient_errors = {errno.ETIMEDOUT, errno.ECANCELED}\n"
+        "path = sys.argv[1]\n"
+        "total = os.path.getsize(path)\n"
+        "read = 0\n"
+        "last = 0.0\n"
+        "def report(force=False):\n"
+        "    global last\n"
+        "    if total <= 0:\n"
+        "        percent = 100.0\n"
+        "    else:\n"
+        "        percent = min(100.0, (read / total) * 100.0)\n"
+        "    now = time.perf_counter()\n"
+        "    if force or now - last >= status_interval:\n"
+        "        print(prefix + f'{percent:.0f}', flush=True)\n"
+        "        last = now\n"
+        "report(True)\n"
+        "while True:\n"
+        "    try:\n"
+        "        handle = open(path, 'rb')\n"
+        "        break\n"
+        "    except OSError as error:\n"
+        "        if error.errno not in transient_errors:\n"
+        "            raise\n"
+        "        report(True)\n"
+        "        time.sleep(retry_interval)\n"
+        "with handle:\n"
+        "    while True:\n"
+        "        try:\n"
+        "            chunk = handle.read(chunk_size)\n"
+        "        except OSError as error:\n"
+        "            if error.errno not in transient_errors:\n"
+        "                raise\n"
+        "            report(True)\n"
+        "            time.sleep(retry_interval)\n"
+        "            continue\n"
+        "        if not chunk:\n"
+        "            break\n"
+        "        read += len(chunk)\n"
+        "        report(False)\n"
+        "report(True)\n"
+        "print(read, flush=True)\n"
+    )
 
 
 def _read_prefetch_pipe(pipe, stream_name, output_queue):

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -550,14 +550,7 @@ class DatabaseActionsMixin:
             self.show_status("Wait for the current database load to finish.", 5000)
             return False
 
-        self._cancel_database_detail_load()
-
-        previous_file = self.fileTextbox.text()
-        previous_runs = self._current_run_metadata()
-        monitorTimer = self.spinBox.value()
         load_message = f"Loading database {os.path.basename(abspath)}..."
-
-        self.monitor.stop()
 
         self._database_load_generation += 1
         generation = self._database_load_generation
@@ -565,13 +558,8 @@ class DatabaseActionsMixin:
         self._database_load_state = {
             "abspath": abspath,
             "load_started_at": load_started_at,
-            "monitorTimer": monitorTimer,
-            "previous_file": previous_file,
-            "previous_runs": previous_runs,
         }
 
-        self._prepare_database_load_ui(abspath)
-        self._set_database_load_controls_enabled(False)
         self._show_database_load_panel(load_message)
 
         try:
@@ -589,7 +577,7 @@ class DatabaseActionsMixin:
 
     def _prepare_database_load_ui(self, abspath):
         """
-        Clears the main-window state for a new database load.
+        Replaces the main-window state with a successfully loaded database.
 
         """
         self.run_idBox.setText("")
@@ -610,7 +598,6 @@ class DatabaseActionsMixin:
             self.localLastFile = self.fileTextbox.text()
 
         self.fileTextbox.setText(abspath)
-        self._sync_empty_state()
 
 
     def _set_database_load_controls_enabled(self, enabled):
@@ -627,50 +614,6 @@ class DatabaseActionsMixin:
             widget = getattr(self, attr, None)
             if widget is not None:
                 widget.setEnabled(enabled)
-
-
-    def _current_run_metadata(self):
-        """
-        Returns the currently displayed run metadata, if available.
-
-        """
-        all_run_metadata = getattr(self.RunList, "all_run_metadata", None)
-        if not callable(all_run_metadata):
-            return {}
-
-        try:
-            return all_run_metadata()
-        except Exception as err:
-            log_exception("Could not capture current run metadata", err, __name__)
-            return {}
-
-
-    def _restore_database_load_previous_state(self, state):
-        """
-        Restores the visible database state after a cancelled or failed load.
-
-        """
-        previous_file = state.get("previous_file", "")
-        previous_runs = state.get("previous_runs") or {}
-
-        self.fileTextbox.setText(previous_file)
-        self.run_idBox.setText("")
-        self.measurementBox.setText("*")
-        self.selected_run_id = None
-        self.ds = None
-
-        self.RunList.clearSelection()
-        self.RunList.clear()
-        self.RunList.watching = []
-        self.RunList.maxRunId = 0
-        if previous_runs:
-            self.RunList.addRuns(previous_runs)
-        self.RunList.scrollToTop()
-
-        self.infoBox.clear()
-        self.infoBox.scrollToTop()
-        self.infoBox.preview.set_database_runs(previous_file, previous_runs)
-        self._sync_empty_state()
 
 
     def _show_database_load_panel(self, message):
@@ -701,14 +644,13 @@ class DatabaseActionsMixin:
     @QtCore.pyqtSlot()
     def cancel_database_load(self):
         """
-        Cancels the active database load and restores the previous view.
+        Cancels the pending database load without changing the current view.
 
         """
         if not getattr(self, "_database_load_active", False):
             self._hide_database_load_panel()
             return
 
-        state = self._database_load_state or {}
         worker = getattr(self, "_database_load_worker", None)
         if worker is not None:
             worker.cancel()
@@ -718,11 +660,6 @@ class DatabaseActionsMixin:
         self._database_load_state = None
         self._database_load_worker = None
         self._set_database_load_controls_enabled(True)
-        self._restore_database_load_previous_state(state)
-
-        monitorTimer = state.get("monitorTimer", 0)
-        if monitorTimer > 0:
-            self.monitor.start(int(monitorTimer * 1000))
 
         self._hide_database_load_panel()
         self.show_status("Database load cancelled.", 3000)
@@ -748,45 +685,46 @@ class DatabaseActionsMixin:
         """
         if generation != self._database_load_generation:
             return
+        if not getattr(self, "_database_load_active", False):
+            return
 
         state = self._database_load_state or {}
+        if state.get("abspath") != abspath:
+            return
+
         self._database_load_active = False
         self._database_load_state = None
         self._database_load_worker = None
         self._set_database_load_controls_enabled(True)
         self._hide_database_load_panel()
-        self._sync_empty_state()
-
-        monitorTimer = state.get("monitorTimer", 0)
         load_started_at = state.get("load_started_at") or perf_counter()
 
         if error is not None:
-            self._restore_database_load_previous_state(state)
             log_exception("Database load failed", error, __name__)
             self.show_error(
                 "Database Load Failed",
                 f"Could not load database {abspath}.",
                 str(error),
             )
-            if monitorTimer > 0:
-                self.monitor.start(int(monitorTimer * 1000))
             return
 
+        self._cancel_database_detail_load()
         set_qcodes_database_location(abspath)
         runs = runs or {}
-        self.RunList.clear()
-        self.RunList.watching = []
-        self.RunList.maxRunId = 0
-        self.RunList.addRuns(runs)
-        self.infoBox.preview.set_database_runs(abspath, runs)
+        run_id_signals_blocked = self.run_idBox.blockSignals(True)
+        run_list_signals_blocked = self.RunList.blockSignals(True)
+        try:
+            self._prepare_database_load_ui(abspath)
+            self.RunList.addRuns(runs)
+            self.infoBox.preview.set_database_runs(abspath, runs)
+        finally:
+            self.RunList.blockSignals(run_list_signals_blocked)
+            self.run_idBox.blockSignals(run_id_signals_blocked)
         self.select_default_run()
         prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
         if callable(prioritize_previews):
             prioritize_previews()
         self._sync_empty_state()
-
-        if monitorTimer > 0:
-            self.monitor.start(int(monitorTimer * 1000))
 
         elapsed = perf_counter() - load_started_at
         self.remember_loaded_database(abspath)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -1829,7 +1829,7 @@ class CloudDatabasePrefetchTestCase(unittest.TestCase):
                     patch(
                         "builtins.open",
                         side_effect=[
-                            TimeoutError(60, "Operation timed out"),
+                            TimeoutError(errno.ETIMEDOUT, "Operation timed out"),
                             handle,
                             ],
                         ) as open_file,

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -1,4 +1,6 @@
+import errno
 import sqlite3
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -950,12 +952,18 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
     class Field:
         def __init__(self, text=""):
             self.value = text
+            self.signals_blocked = False
 
         def setText(self, text):
             self.value = text
 
         def text(self):
             return self.value
+
+        def blockSignals(self, blocked):
+            previous = self.signals_blocked
+            self.signals_blocked = blocked
+            return previous
 
     class Button:
         def __init__(self):
@@ -999,13 +1007,18 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
     class Timer:
         def __init__(self):
             self.started = []
+            self.stopped = False
 
         def start(self, interval):
             self.started.append(interval)
 
+        def stop(self):
+            self.stopped = True
+
     class RunList:
         def __init__(self):
             self.runs = {}
+            self.signals_blocked = False
             self.selection_cleared = False
             self.scrolled = False
             self.watching = ["old"]
@@ -1015,6 +1028,11 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
         def clearSelection(self):
             self.selection_cleared = True
+
+        def blockSignals(self, blocked):
+            previous = self.signals_blocked
+            self.signals_blocked = blocked
+            return previous
 
         def clear(self):
             self.runs = {}
@@ -1029,6 +1047,9 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         def topLevelItemCount(self):
             return len(self.runs)
 
+        def all_run_metadata(self):
+            return self.runs
+
         def selected_run_ids(self):
             return list(self.selected_ids)
 
@@ -1041,6 +1062,12 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
         def set_database_runs(self, database_path, runs):
             self.database_runs = (database_path, runs)
+
+        def has_database(self, database_path):
+            return (
+                self.database_runs is not None
+                and self.database_runs[0] == database_path
+                )
 
     class InfoBox:
         def __init__(self):
@@ -1061,13 +1088,30 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         def cancel(self):
             self.cancelled = True
 
-    class Harness:
+    class ThreadPool:
+        def __init__(self):
+            self.started = []
+
+        def start(self, worker):
+            self.started.append(worker)
+
+    class Config:
+        def get(self, key):
+            if key == "runtime_settings.cloud_sync_timeout":
+                return 30
+            raise KeyError(key)
+
+    class Harness(QtCore.QObject):
+        load_file = main_window.MainWindow.load_file
         cancel_database_load = main_window.MainWindow.cancel_database_load
         database_load_finished = main_window.MainWindow.database_load_finished
         database_load_status = main_window.MainWindow.database_load_status
+        _cancel_database_detail_load = (
+            main_window.MainWindow._cancel_database_detail_load
+            )
         _hide_database_load_panel = main_window.MainWindow._hide_database_load_panel
-        _restore_database_load_previous_state = (
-            main_window.MainWindow._restore_database_load_previous_state
+        _prepare_database_load_ui = (
+            main_window.MainWindow._prepare_database_load_ui
             )
         _set_database_load_controls_enabled = (
             main_window.MainWindow._set_database_load_controls_enabled
@@ -1099,10 +1143,17 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             )
 
         def __init__(self):
+            super().__init__()
             self._database_load_generation = 2
             self._database_load_active = False
             self._database_load_state = None
             self._database_load_worker = None
+            self._database_detail_generation = 4
+            self._database_detail_active = False
+            self._database_detail_worker = None
+            self._database_expensive_detail_generation = 6
+            self._database_expensive_detail_active = False
+            self._database_expensive_detail_worker = None
             self.fileTextbox = DatabaseLoadUiTestCase.Field()
             self.run_idBox = DatabaseLoadUiTestCase.Field()
             self.measurementBox = DatabaseLoadUiTestCase.Field()
@@ -1124,6 +1175,9 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             self.emptyStateRefreshButton = DatabaseLoadUiTestCase.Button()
             self.emptyStateHelpButton = DatabaseLoadUiTestCase.Button()
             self.spinBox = DatabaseLoadUiTestCase.SpinBox()
+            self.config = DatabaseLoadUiTestCase.Config()
+            self.databaseLoadThreadPool = DatabaseLoadUiTestCase.ThreadPool()
+            self.localLastFile = None
             self.status_messages = []
             self.error_messages = []
             self.remembered_databases = []
@@ -1136,13 +1190,166 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             self.error_messages.append((title, message, details))
 
         def select_default_run(self):
-            pass
+            self.database_at_default_selection = get_DB_location()
 
         def remember_loaded_database(self, database_path):
             self.remembered_databases.append(database_path)
 
         def _start_database_detail_load(self, database_path, runs):
             self.detail_loads.append((database_path, runs))
+
+    @staticmethod
+    def _database_view(harness):
+        return {
+            "path": harness.fileTextbox.text(),
+            "run_id": harness.run_idBox.text(),
+            "measurement": harness.measurementBox.text(),
+            "selected_run_id": harness.selected_run_id,
+            "dataset": harness.ds,
+            "runs": harness.RunList.runs,
+            "selected_ids": harness.RunList.selected_ids,
+            "selection_cleared": harness.RunList.selection_cleared,
+            "run_list_signals_blocked": harness.RunList.signals_blocked,
+            "run_id_signals_blocked": harness.run_idBox.signals_blocked,
+            "watching": harness.RunList.watching,
+            "max_run_id": harness.RunList.maxRunId,
+            "previews": harness.infoBox.preview.database_runs,
+            "info_cleared": harness.infoBox.cleared,
+            "monitor_stopped": harness.monitor.stopped,
+            "detail_worker": harness._database_detail_worker,
+            "detail_active": harness._database_detail_active,
+            "expensive_detail_worker": harness._database_expensive_detail_worker,
+            "expensive_detail_active": harness._database_expensive_detail_active,
+            }
+
+    def _active_database_harness(self):
+        old_runs = {5: {"guid": "guid-5", "run_timestamp": 123.0}}
+        harness = self.Harness()
+        harness.fileTextbox.setText("database-a.db")
+        harness.run_idBox.setText("5")
+        harness.measurementBox.setText("signal")
+        harness.selected_run_id = 5
+        harness.ds = object()
+        harness.RunList.runs = old_runs
+        harness.RunList.selected_ids = [5]
+        harness.infoBox.preview.set_database_runs("database-a.db", old_runs)
+        harness._database_detail_active = True
+        harness._database_detail_worker = self.Worker()
+        harness._database_expensive_detail_active = True
+        harness._database_expensive_detail_worker = self.Worker()
+        return harness
+
+    def test_current_view_remains_unchanged_while_another_database_is_pending(self):
+        active_database = get_DB_location()
+        set_qcodes_database_location("database-a.db")
+        try:
+            harness = self._active_database_harness()
+            previous_view = self._database_view(harness)
+
+            self.assertTrue(harness.load_file("database-b.db"))
+
+            self.assertEqual(self._database_view(harness), previous_view)
+            self.assertEqual(get_DB_location(), "database-a.db")
+            self.assertTrue(harness._database_load_active)
+            self.assertEqual(harness._database_load_state["abspath"], "database-b.db")
+            self.assertEqual(len(harness.databaseLoadThreadPool.started), 1)
+            self.assertTrue(harness.refreshDatabaseButton.enabled)
+            self.assertTrue(harness.databaseInfoButton.enabled)
+            self.assertTrue(harness.openDatabaseFolderButton.enabled)
+        finally:
+            set_qcodes_database_location(active_database)
+
+    def test_successful_load_commits_path_runs_and_previews_together(self):
+        active_database = get_DB_location()
+        new_runs = {9: {"guid": "guid-9", "run_timestamp": 456.0}}
+        set_qcodes_database_location("database-a.db")
+        try:
+            harness = self._active_database_harness()
+            harness.load_file("database-b.db")
+            generation = harness._database_load_generation
+
+            harness.database_load_finished(
+                generation,
+                "database-b.db",
+                new_runs,
+                None,
+                )
+
+            self.assertEqual(get_DB_location(), "database-b.db")
+            self.assertEqual(harness.fileTextbox.text(), "database-b.db")
+            self.assertEqual(harness.RunList.runs, new_runs)
+            self.assertEqual(
+                harness.infoBox.preview.database_runs,
+                ("database-b.db", new_runs),
+                )
+            self.assertEqual(harness.database_at_default_selection, "database-b.db")
+            self.assertFalse(harness.RunList.signals_blocked)
+            self.assertFalse(harness.run_idBox.signals_blocked)
+        finally:
+            set_qcodes_database_location(active_database)
+
+    def test_cancellation_preserves_existing_database_state(self):
+        active_database = get_DB_location()
+        set_qcodes_database_location("database-a.db")
+        try:
+            harness = self._active_database_harness()
+            previous_view = self._database_view(harness)
+            harness.load_file("database-b.db")
+
+            harness.cancel_database_load()
+
+            self.assertEqual(self._database_view(harness), previous_view)
+            self.assertEqual(get_DB_location(), "database-a.db")
+            self.assertFalse(harness._database_load_active)
+        finally:
+            set_qcodes_database_location(active_database)
+
+    def test_failure_preserves_existing_database_state(self):
+        active_database = get_DB_location()
+        set_qcodes_database_location("database-a.db")
+        try:
+            harness = self._active_database_harness()
+            previous_view = self._database_view(harness)
+            harness.load_file("database-b.db")
+            generation = harness._database_load_generation
+
+            harness.database_load_finished(
+                generation,
+                "database-b.db",
+                {},
+                RuntimeError("broken database"),
+                )
+
+            self.assertEqual(self._database_view(harness), previous_view)
+            self.assertEqual(get_DB_location(), "database-a.db")
+            self.assertFalse(harness._database_load_active)
+        finally:
+            set_qcodes_database_location(active_database)
+
+    def test_stale_callbacks_cannot_commit(self):
+        active_database = get_DB_location()
+        stale_runs = {12: {"guid": "guid-12"}}
+        set_qcodes_database_location("database-a.db")
+        try:
+            harness = self._active_database_harness()
+            previous_view = self._database_view(harness)
+            harness._database_load_generation = 20
+            harness._database_load_active = False
+            harness._database_load_state = None
+
+            harness.database_load_finished(
+                20,
+                "database-b.db",
+                stale_runs,
+                None,
+                )
+
+            self.assertEqual(self._database_view(harness), previous_view)
+            self.assertEqual(get_DB_location(), "database-a.db")
+            self.assertEqual(harness.remembered_databases, [])
+            self.assertEqual(harness.detail_loads, [])
+        finally:
+            set_qcodes_database_location(active_database)
 
     def test_database_load_status_shows_inline_progress(self):
         harness = self.Harness()
@@ -1210,16 +1417,17 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
         self.assertEqual(priority, [7, 8, 9, 6])
 
-    def test_cancel_database_load_cancels_worker_and_restores_previous_view(self):
+    def test_cancel_database_load_cancels_worker_and_preserves_current_view(self):
         previous_runs = {5: {"guid": "guid-5", "run_timestamp": 123.0}}
         worker = self.Worker()
         harness = self.Harness()
+        harness.fileTextbox.setText("old.db")
+        harness.RunList.runs = previous_runs
+        harness.infoBox.preview.set_database_runs("old.db", previous_runs)
         harness._database_load_active = True
         harness._database_load_worker = worker
         harness._database_load_state = {
-            "monitorTimer": 1.5,
-            "previous_file": "old.db",
-            "previous_runs": previous_runs,
+            "abspath": "pending.db",
             }
 
         harness.cancel_database_load()
@@ -1235,9 +1443,9 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             harness.infoBox.preview.database_runs,
             ("old.db", previous_runs),
             )
-        self.assertEqual(harness.RunList.watching, [])
-        self.assertEqual(harness.RunList.maxRunId, 5)
-        self.assertEqual(harness.monitor.started, [1500])
+        self.assertEqual(harness.RunList.watching, ["old"])
+        self.assertEqual(harness.RunList.maxRunId, 9)
+        self.assertEqual(harness.monitor.started, [])
         self.assertFalse(harness.databaseLoadFrame.visible)
         self.assertEqual(harness.databaseLoadLabel.text, "")
         self.assertTrue(harness.loadDatabaseButton.enabled)
@@ -1593,6 +1801,51 @@ class AutoPlotToggleTestCase(unittest.TestCase):
 
 
 class CloudDatabasePrefetchTestCase(unittest.TestCase):
+    def test_prefetch_subprocess_retries_transient_timeout_errors(self):
+        class Handle:
+            def __init__(self):
+                self.read_calls = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                pass
+
+            def read(self, _chunk_size):
+                self.read_calls += 1
+                if self.read_calls == 1:
+                    raise OSError(errno.ECANCELED, "Operation canceled")
+                if self.read_calls == 2:
+                    return b"database"
+                return b""
+
+        handle = Handle()
+        output = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = str(Path(temp_dir) / "placeholder.db")
+            Path(database_path).write_bytes(b"database")
+            with (
+                    patch(
+                        "builtins.open",
+                        side_effect=[
+                            TimeoutError(60, "Operation timed out"),
+                            handle,
+                            ],
+                        ) as open_file,
+                    patch(
+                        "builtins.print",
+                        side_effect=lambda value, **_kwargs: output.append(value),
+                        ),
+                    patch("time.sleep"),
+                    patch.object(sys, "argv", ["prefetch", database_path]),
+                    ):
+                exec(database_module._database_prefetch_script(), {})
+
+        self.assertEqual(open_file.call_count, 2)
+        self.assertEqual(handle.read_calls, 3)
+        self.assertEqual(output[-1], 8)
+
     def test_prefetch_database_file_reads_file_and_reports_cloud_sync_progress(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = str(Path(temp_dir) / "prefetch.db")
@@ -1854,8 +2107,8 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             harness = DatabaseLoadUiTestCase.Harness()
             harness._database_load_generation = 14
             harness._database_load_active = True
-            harness._database_load_state = {"monitorTimer": 0}
-            harness.fileTextbox.setText("committed.db")
+            harness._database_load_state = {"abspath": "committed.db"}
+            harness.fileTextbox.setText("active.db")
             worker = main_window.DatabaseLoadWorker(14, "committed.db")
             worker.signals.finished.connect(
                 lambda *args: harness.database_load_finished(*args)


### PR DESCRIPTION
## Summary

- keep the current database fully active while a replacement database loads
- commit the new path, run list, previews, and QCoDeS location together only after the worker succeeds
- preserve the current state on cancellation or failure and reject stale/post-cancellation callbacks
- retry transient OneDrive/File Provider timeout and cancellation errors during cloud hydration

## Root cause

Starting a database load mutated the active window state before the replacement database worker had succeeded. Failure and cancellation then depended on reconstructing the old state, while stale callbacks could still reach the commit path. Cloud placeholders could also surface transient provider errors immediately instead of waiting within the configured load timeout.

## Impact

Database switching is now transactional: the existing path, runs, selection, dataset, previews, monitor, and metadata workers remain usable until the new database is ready. The QCoDeS database location is updated before selecting a run from the new database.

The separate database-aware GUID cache issue is intentionally unchanged.

## Validation

- focused database-load tests: 17 passed
- Ruff: all checks passed
- full test suite: 379 passed
- git diff check: clean
- runtime smoke test: OneDrive hydrated a 297 MB database and qPlot loaded 29 runs in 10.82 seconds