### PR TITLE
Make dataset cache database-aware

### DIFF
--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -35,8 +35,15 @@ def qcodes_read_only_connection(database_path):
         )
 
 
-def load_by_guid_read_only(guid):
+def load_by_guid_read_only(guid, database_path=None):
     """Load a QCoDeS dataset by GUID through a read-only connection."""
+    if database_path is not None:
+        conn = qcodes_read_only_connection(database_path)
+        try:
+            return load_by_guid(guid, conn=conn)
+        except Exception:
+            conn.close()
+            raise
     return load_by_guid(guid, read_only=True)
 
 

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -220,6 +220,7 @@ class DatabaseActionsMixin:
         self.measurementBox.setText("*")
         self.selected_run_id = None
         self.ds = None
+        self._selected_dataset_key = None
         self.localLastFile = None
 
         for holder in self.dataset_holder.values():
@@ -584,6 +585,7 @@ class DatabaseActionsMixin:
         self.measurementBox.setText("*")
         self.selected_run_id = None
         self.ds = None
+        self._selected_dataset_key = None
 
         self.RunList.clearSelection()
         self.RunList.clear()

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -1,6 +1,24 @@
+import os
 from dataclasses import dataclass
 
 from PyQt6 import QtCore
+
+
+def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
+    """Return a stable, platform-normalised identity for a database file."""
+    return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetKey:
+    """Identifies a dataset within one particular database file."""
+
+    database_path: str
+    guid: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "database_path", canonical_database_path(self.database_path))
+        object.__setattr__(self, "guid", str(self.guid))
 
 
 @dataclass

--- a/src/qplot/windows/_dragdrop.py
+++ b/src/qplot/windows/_dragdrop.py
@@ -5,12 +5,14 @@ from PyQt6 import QtCore
 RUN_PREVIEW_MIME = "application/x-qplot-run-preview"
 
 
-def make_run_preview_mime(guid, parameter, axes=None):
+def make_run_preview_mime(guid, parameter, axes=None, database_path=None):
     payload = {
         "guid": str(guid or ""),
         "parameter": str(parameter or ""),
         "axes": [str(axis) for axis in (axes or [])],
         }
+    if database_path:
+        payload["database_path"] = str(database_path)
     mime_data = QtCore.QMimeData()
     mime_data.setData(
         RUN_PREVIEW_MIME,
@@ -40,11 +42,15 @@ def run_preview_payload_from_mime(mime_data):
     elif not isinstance(axes, (list, tuple)):
         axes = []
 
-    return {
+    normalised = {
         "guid": guid,
         "parameter": parameter,
         "axes": [str(axis) for axis in axes],
         }
+    database_path = str(payload.get("database_path") or "")
+    if database_path:
+        normalised["database_path"] = database_path
+    return normalised
 
 
 def preview_drop_is_compatible(target_axes, payload):

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -386,7 +386,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         self.add_option_box()
         
         # Create and track new line
-        self.make_ds.emit(win._guid)
+        self.make_ds.emit(win._dataset_key)
         subplot = subplot1d(self, win)
         self.lines[label] = subplot
         
@@ -428,7 +428,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     def closeEvent(self, event: object) -> None:
         # Stopped lines as needed
         for line in list(self.lines.values())[1:]:
-            self.remove_dataset.emit(line.from_win._guid)
+            self.remove_dataset.emit(line.from_win._dataset_key)
             if not line.from_win.visible:
                 line.from_win.monitor.stop()
                 
@@ -472,7 +472,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             self.plot.getAxis('right').setStyle(showValues=False)
         
         # Remove track of window
-        self.remove_dataset.emit(line.from_win._guid)
+        self.remove_dataset.emit(line.from_win._dataset_key)
         # Stop refresh monitor for line if needed
         if not line.from_win.visible:
             line.from_win.monitor.stop()
@@ -1351,6 +1351,7 @@ class _TraceAppearanceDialog(qtw.QDialog):
             guid,
             parameter,
             getattr(param, "depends_on_", ()),
+            getattr(getattr(source, "_dataset_key", None), "database_path", None),
             )
 
     def _sync_controls_from_selection(self):

--- a/src/qplot/windows/_plot2d_sweeps.py
+++ b/src/qplot/windows/_plot2d_sweeps.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from qplot.tools.heatmap_geometry import HeatmapGeometry
 
     class _Plot2DSweepBase(qtw.QMainWindow):
-        _guid: str
+        _dataset_key: Any
         active_sweep_line_id: int | None
         axis_options: dict[str, str]
         close_sweeps_requested: Any
@@ -84,7 +84,7 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         # Emit to Main window to open new window
         self.open_subplot.emit(
                 sweeper,
-                self._guid,
+                self._dataset_key,
                 (
                 self.sweep_id,
                 sweep_var,

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
-from qcodes.dataset.sqlite.database import get_DB_location
 
 from qplot.datahandling.qcodes_cache import set_parameter_complete
 from qplot.tools import (
@@ -19,6 +18,7 @@ from ._commands import (
     create_action,
     toolbar_toggle_command_spec,
 )
+from ._dataset_handle import DatasetKey
 from ._dragdrop import (
     preview_drop_is_compatible,
     run_preview_payload_from_mime,
@@ -154,12 +154,12 @@ class plotWidget(
     
     closed = QtCore.pyqtSignal([object])
     end_wait = QtCore.pyqtSignal()
-    make_ds = QtCore.pyqtSignal([str])
-    previewTraceDropRequested = QtCore.pyqtSignal(object, str, str)
+    make_ds = QtCore.pyqtSignal([object])
+    previewTraceDropRequested = QtCore.pyqtSignal(object, object, str)
     
     _label_width = 95 #About the size of 3 s.f. scientific
     def __init__(self, 
-                 guid : str, 
+                 dataset_key: DatasetKey,
                  param : "qcodes.dataset.ParamSpec",
                  config : "qplot.configuration.config.config",
                  threadPool : "QtCore.QThreadPool",
@@ -173,16 +173,16 @@ class plotWidget(
 
         Parameters
         ----------
-        guid : str
-            The guid of dataset which contains the data to be plotted.
+        dataset_key : DatasetKey
+            The database-aware identity of the dataset to plot.
         param : qcodes.dataset.ParamSpec
             Which parameter within dataset to plot.
         config : qplot.configuration.config.config
             Holds configuration data, mainly theme and window size.
         threadPool : PyQt6.QtCore.QThreadPool
             A pool of threads for the refresh worker to be placed in.
-        dataset_holder : dict[str, DatasetHandle]
-            Shared map of dataset GUIDs to open-dataset ownership handles.
+        dataset_holder : dict[DatasetKey, DatasetHandle]
+            Shared map of dataset identities to open-dataset ownership handles.
         refrate : float, optional
             Default value for the refresh timer. The default is None, which 
             corresponds to a 5.0s refresh time.
@@ -195,7 +195,8 @@ class plotWidget(
         
         ### CORE VARIABLES
         self._dataset_holder = dataset_holder
-        self._guid = guid
+        self._dataset_key = dataset_key
+        self._guid = dataset_key.guid
         self.param = param
         if not hasattr(self.param, "_complete"): # Add completed load track
             set_parameter_complete(self.param, False)
@@ -330,9 +331,15 @@ class plotWidget(
         if event.type() == QtCore.QEvent.Type.Drop:
             event.setDropAction(QtCore.Qt.DropAction.CopyAction)
             event.accept()
+            source_identity = payload["guid"]
+            if payload.get("database_path"):
+                source_identity = DatasetKey(
+                    payload["database_path"],
+                    payload["guid"],
+                )
             self.previewTraceDropRequested.emit(
                 self,
-                payload["guid"],
+                source_identity,
                 payload["parameter"]
                 )
             return True
@@ -353,7 +360,7 @@ class plotWidget(
 
 
     def __str__(self):
-        filenameStr = path.basename(get_DB_location())
+        filenameStr = path.basename(self._dataset_key.database_path)
         fstr = (f"{filenameStr} | " 
                 f"Run ID: {self.ds.run_id} | "
                 f"{self.param.name} ({self.param.label})"
@@ -372,11 +379,11 @@ class plotWidget(
 
         """
         # Check dataset exists, produce new one if needed.
-        handle = self._dataset_holder.get(self._guid)
+        handle = self._dataset_holder.get(self._dataset_key)
         if handle is None:
             self.show_status(f"Dataset {self._guid} not found. Reloading...", 5000)
-            self.make_ds.emit(self._guid)
-            handle = self._dataset_holder[self._guid]
+            self.make_ds.emit(self._dataset_key)
+            handle = self._dataset_holder[self._dataset_key]
         
         # Check a deletion timer is not active and stop
         else:

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -8,7 +8,7 @@ from PyQt6 import QtWidgets as qtw
 from qplot.datahandling.readonly import load_by_guid_read_only, load_by_id_read_only
 from qplot.diagnostics import log_exception
 
-from ._dataset_handle import DatasetHandle
+from ._dataset_handle import DatasetHandle, DatasetKey
 from .plot1d import plot1d
 from .plot2d import plot2d
 
@@ -29,14 +29,14 @@ class PlotActionsMixin:
 
         """
         self.windows.remove(win)
-        self.remove_ds_at(win._guid)
+        self.remove_ds_at(win._dataset_key)
         self.post_admin()
         self.show_status(f"Closed {win.label}", 3000)
         del win
 
 
-    @QtCore.pyqtSlot(object, str, tuple)
-    def openWin(self, widget, guid_or_ds, *args, show=True, **kargs):
+    @QtCore.pyqtSlot(object, object, tuple)
+    def openWin(self, widget, key_or_ds, *args, show=True, **kargs):
         """
         Handles opening Plot window, widget.
 
@@ -44,32 +44,32 @@ class PlotActionsMixin:
         if len(args) == 1 and isinstance(args[0], (tuple, list)):
             args = tuple(args[0])
 
-        if isinstance(guid_or_ds, str):
+        if isinstance(key_or_ds, DatasetKey):
             ds = None
-            guid = guid_or_ds
+            dataset_key = key_or_ds
         else:
-            ds = guid_or_ds
-            guid = ds.guid
+            ds = key_or_ds
+            dataset_key = self._current_dataset_key(ds.guid)
 
-        shared_handle = self.dataset_holder.get(guid)
+        shared_handle = self.dataset_holder.get(dataset_key)
         loaded_for_construction = shared_handle is None and ds is None
         if shared_handle is not None:
             construction_ds = shared_handle.dataset
         elif loaded_for_construction:
-            construction_ds = load_by_guid_read_only(guid)
+            construction_ds = self._load_dataset(dataset_key)
         else:
             construction_ds = ds
 
-        assert construction_ds.guid == guid
+        assert construction_ds.guid == dataset_key.guid
         construction_holder = {
-            held_guid: DatasetHandle(dataset=handle.dataset, users=handle.users)
-            for held_guid, handle in self.dataset_holder.items()
+            held_key: DatasetHandle(dataset=handle.dataset, users=handle.users)
+            for held_key, handle in self.dataset_holder.items()
         }
-        construction_holder[guid] = DatasetHandle(dataset=construction_ds)
+        construction_holder[dataset_key] = DatasetHandle(dataset=construction_ds)
 
         try:
             win = widget(
-                guid,
+                dataset_key,
                 *args,
                 self.config,
                 self.threadPool,
@@ -89,7 +89,7 @@ class PlotActionsMixin:
             raise
 
         win._dataset_holder = self.dataset_holder
-        self.add_ds_at(guid, ds=construction_ds)
+        self.add_ds_at(dataset_key, ds=construction_ds)
 
         self.windows.append(win)
 
@@ -159,15 +159,17 @@ class PlotActionsMixin:
 
         """
         self.show_status("Loading selected run...", 0)
+        dataset_key = self._current_dataset_key(guid)
         try:
-            if self.ds is not None and getattr(self.ds, "guid", None) == guid:
+            if self.ds is not None and getattr(self, "_selected_dataset_key", None) == dataset_key:
                 pass
             else:
-                handle = self.dataset_holder.get(guid)
+                handle = self.dataset_holder.get(dataset_key)
                 if handle is None:
-                    self.ds = load_by_guid_read_only(guid)
+                    self.ds = self._load_dataset(dataset_key)
                 else:
                     self.ds = handle.dataset
+                self._selected_dataset_key = dataset_key
         except Exception as err:
             log_exception("Selected run load failed", err, __name__)
             self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
@@ -264,6 +266,7 @@ class PlotActionsMixin:
             return
 
         self.ds = ds
+        self._selected_dataset_key = self._current_dataset_key(ds.guid)
         self.openPlot(params=params)
 
 
@@ -373,7 +376,7 @@ class PlotActionsMixin:
 
 
     @QtCore.pyqtSlot(str)
-    def openPlot(self, guid: str = None, params: list = None, show: bool = True):
+    def openPlot(self, guid: str | DatasetKey = None, params: list = None, show: bool = True):
         """
         Opens plot windows for the selected or requested run.
 
@@ -384,11 +387,18 @@ class PlotActionsMixin:
 
         self.show_status("Opening plots...", 0)
 
+        if isinstance(guid, DatasetKey):
+            dataset_key = guid
+            guid = dataset_key.guid
+        else:
+            target_guid = guid or getattr(self.ds, "guid", "")
+            dataset_key = self._current_dataset_key(target_guid)
+
         try:
-            if not self.ds or (guid and self.ds.guid != guid):
-                handle = self.dataset_holder.get(guid)
+            if not self.ds or getattr(self, "_selected_dataset_key", None) != dataset_key:
+                handle = self.dataset_holder.get(dataset_key)
                 if handle is None:
-                    ds = load_by_guid_read_only(guid)
+                    ds = self._load_dataset(dataset_key)
                 else:
                     ds = handle.dataset
             else:
@@ -413,7 +423,11 @@ class PlotActionsMixin:
 
                 if len(depends_on) == 1:
                     for win in self.windows:
-                        if win.ds == ds and win.param == param and isinstance(win, plot1d):
+                        if (
+                            win._dataset_key == dataset_key
+                            and win.param == param
+                            and isinstance(win, plot1d)
+                        ):
                             skipped += 1
                             skip = True
                             break
@@ -431,7 +445,11 @@ class PlotActionsMixin:
 
                 else:
                     for win in self.windows:
-                        if win.ds == ds and win.param == param and isinstance(win, plot2d):
+                        if (
+                            win._dataset_key == dataset_key
+                            and win.param == param
+                            and isinstance(win, plot2d)
+                        ):
                             skipped += 1
                             skip = True
                             break
@@ -511,13 +529,15 @@ class PlotActionsMixin:
             self.show_status("Select a run before opening a preview plot.", 5000)
             return
 
-        if not self.ds or self.ds.guid != guid:
+        dataset_key = self._current_dataset_key(guid)
+        if not self.ds or getattr(self, "_selected_dataset_key", None) != dataset_key:
             try:
-                handle = self.dataset_holder.get(guid)
+                handle = self.dataset_holder.get(dataset_key)
                 if handle is None:
-                    self.ds = load_by_guid_read_only(guid)
+                    self.ds = self._load_dataset(dataset_key)
                 else:
                     self.ds = handle.dataset
+                self._selected_dataset_key = dataset_key
             except Exception as err:
                 log_exception("Preview plot run load failed", err, __name__)
                 self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
@@ -526,16 +546,16 @@ class PlotActionsMixin:
         self.open_preview_plot(parameter_name)
 
 
-    @QtCore.pyqtSlot(object, str, str)
-    def add_dropped_preview_to_plot(self, target_win, guid, parameter_name):
+    @QtCore.pyqtSlot(object, object, str)
+    def add_dropped_preview_to_plot(self, target_win, source_identity, parameter_name):
         """
         Add a run-table preview trace to the plot it was dropped onto.
 
         """
-        self.add_trace_to_plot(target_win, guid, parameter_name)
+        self.add_trace_to_plot(target_win, source_identity, parameter_name)
 
 
-    def add_trace_to_plot(self, target_win, source_guid, parameter_name, param=None):
+    def add_trace_to_plot(self, target_win, source_identity, parameter_name, param=None):
         """
         Adds a plottable 1D parameter to an existing compatible 1D plot.
 
@@ -544,9 +564,14 @@ class PlotActionsMixin:
             self.show_status("Drop traces onto a compatible line plot.", 5000)
             return False
 
+        if isinstance(source_identity, DatasetKey):
+            source_key = source_identity
+        else:
+            source_key = self._current_dataset_key(source_identity)
+        source_guid = source_key.guid
         if param is None:
             try:
-                param = self._parameter_from_guid(source_guid, parameter_name)
+                param = self._parameter_from_key(source_key, parameter_name)
             except Exception as err:
                 log_exception("Trace source run load failed", err, __name__)
                 self.show_error(
@@ -571,13 +596,13 @@ class PlotActionsMixin:
             )
             return False
 
-        from_win = self._plot_window_for_param(source_guid, param)
+        from_win = self._plot_window_for_param(source_key, param)
         if from_win == target_win:
             self.show_status(f"Skipped {target_win.label}; source and target are the same.", 5000)
             return False
 
         if from_win is None:
-            from_win = self._open_hidden_trace_window(source_guid, param, target_win)
+            from_win = self._open_hidden_trace_window(source_key, param, target_win)
             if from_win is None:
                 return False
 
@@ -604,7 +629,11 @@ class PlotActionsMixin:
 
 
     def _parameter_from_guid(self, guid, parameter_name):
-        ds = self._dataset_for_guid(guid)
+        return self._parameter_from_key(self._current_dataset_key(guid), parameter_name)
+
+
+    def _parameter_from_key(self, dataset_key, parameter_name):
+        ds = self._dataset_for_key(dataset_key)
         return self._measurement_param_by_name(ds, parameter_name)
 
 
@@ -616,31 +645,35 @@ class PlotActionsMixin:
 
 
     def _dataset_for_guid(self, guid):
-        handle = self.dataset_holder.get(guid)
+        return self._dataset_for_key(self._current_dataset_key(guid))
+
+
+    def _dataset_for_key(self, dataset_key):
+        handle = self.dataset_holder.get(dataset_key)
         if handle is not None:
             return handle.dataset
-        return load_by_guid_read_only(guid)
+        return self._load_dataset(dataset_key)
 
 
-    def _plot_window_for_param(self, guid, param):
+    def _plot_window_for_param(self, dataset_key, param):
         for win in self.windows:
             try:
-                if win.ds.guid == guid and win.param.name == param.name:
+                if win._dataset_key == dataset_key and win.param.name == param.name:
                     return win
             except AttributeError:
                 continue
         return None
 
 
-    def _open_hidden_trace_window(self, source_guid, param, target_win):
+    def _open_hidden_trace_window(self, source_key, param, target_win):
         before = set(id(win) for win in self.windows)
-        self.openPlot(guid=source_guid, params=[param], show=False)
+        self.openPlot(guid=source_key, params=[param], show=False)
 
         for win in reversed(self.windows):
             if id(win) in before:
                 continue
             try:
-                if win.ds.guid == source_guid and win.param.name == param.name:
+                if win._dataset_key == source_key and win.param.name == param.name:
                     if win.ds.running and not target_win.monitor.isActive():
                         target_win.monitorIntervalChanged(target_win.spinBox.value())
                         target_win.toolbarRef.show()
@@ -741,29 +774,29 @@ class PlotActionsMixin:
         return "".join(char if char.isalnum() or char in "._-" else "_" for char in filename)
 
 
-    @QtCore.pyqtSlot(str)
-    def add_ds_at(self, guid: str, ds=None):
+    @QtCore.pyqtSlot(object)
+    def add_ds_at(self, dataset_key: DatasetKey, ds=None):
         """
         Tracks a dataset used by one or more plot windows.
 
         """
-        handle = self.dataset_holder.get(guid)
+        handle = self.dataset_holder.get(dataset_key)
         if handle is None:
-            ds = load_by_guid_read_only(guid) if ds is None else ds
-            assert ds.guid == guid
+            ds = self._load_dataset(dataset_key) if ds is None else ds
+            assert ds.guid == dataset_key.guid
 
-            self.dataset_holder[guid] = DatasetHandle(dataset=ds)
+            self.dataset_holder[dataset_key] = DatasetHandle(dataset=ds)
         else:
             handle.retain()
 
 
-    @QtCore.pyqtSlot(str)
-    def remove_ds_at(self, guid: str):
+    @QtCore.pyqtSlot(object)
+    def remove_ds_at(self, dataset_key: DatasetKey):
         """
         Decreases the user count for a cached plot dataset.
 
         """
-        handle = self.dataset_holder.get(guid)
+        handle = self.dataset_holder.get(dataset_key)
         if handle is None:
             self.show_status("Trying to remove dataset that does not exist.", 5000)
             return
@@ -774,14 +807,25 @@ class PlotActionsMixin:
             del_time = self.config.get("runtime_settings.del_grace_period")
 
             if del_time == 0:
-                self.dataset_holder.pop(guid)
+                self.dataset_holder.pop(dataset_key)
 
             elif handle.delete_timer is None:
                 del_timer = QtCore.QTimer()
                 del_timer.setSingleShot(True)
                 handle.delete_timer = del_timer
-                del_timer.timeout.connect(lambda guid=guid: self.dataset_holder.pop(guid, None))
+                del_timer.timeout.connect(
+                    lambda key=dataset_key: self.dataset_holder.pop(key, None)
+                )
                 del_timer.start(int(del_time * 1000))
+
+
+    def _current_dataset_key(self, guid: str) -> DatasetKey:
+        return DatasetKey(self.fileTextbox.text(), guid)
+
+
+    @staticmethod
+    def _load_dataset(dataset_key: DatasetKey):
+        return load_by_guid_read_only(dataset_key.guid, dataset_key.database_path)
 
 
     def post_admin(self):

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -22,6 +22,8 @@ class PlotActionsMixin:
     helpers.
     """
 
+    _selected_dataset_key: DatasetKey | None
+
     @QtCore.pyqtSlot(object)
     def onClose(self, win):
         """

--- a/src/qplot/windows/_plot_export.py
+++ b/src/qplot/windows/_plot_export.py
@@ -14,6 +14,9 @@ from ._preferences import (
     COPY_PLOT_IMAGE_RESOLUTION_SVG,
 )
 
+if TYPE_CHECKING:
+    from ._dataset_handle import DatasetKey
+
 _MAX_EXPORTED_IMAGE_SIZE = 20_000
 _HIGH_DPI_COPY_RESOLUTION = 300
 _INCHES_PER_METER = 39.370_078_740_157_48
@@ -21,6 +24,7 @@ _DpiAxis = Literal["x", "y"]
 
 if TYPE_CHECKING:
     class _PlotExportBase(qtw.QMainWindow):
+        _dataset_key: DatasetKey
         ds: Any
         param: Any
         plot: Any

--- a/src/qplot/windows/_plot_export.py
+++ b/src/qplot/windows/_plot_export.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from PyQt6 import QtCore, QtGui, QtSvg
 from PyQt6 import QtWidgets as qtw
 from pyqtgraph.exporters import ImageExporter
-from qcodes.dataset.sqlite.database import get_DB_location
 
 from qplot.diagnostics import log_exception
 
@@ -166,7 +165,7 @@ class PlotExportMixin(_PlotExportBase):
         filename = self._safe_plot_export_filename(f"run_{run_id}_{param_name}.pdf")
 
         try:
-            database_folder = path.dirname(get_DB_location())
+            database_folder = path.dirname(self._dataset_key.database_path)
         except Exception:
             database_folder = ""
 

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -3,6 +3,7 @@ from typing import Any
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
+from qplot.windows._dataset_handle import DatasetKey
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._widgets import (
     expandingComboBox,
@@ -23,7 +24,7 @@ class sweeper(plotWidget):
     remove_sweep = QtCore.pyqtSignal([int])
     
     def __init__(self,
-                 guid : str, # Had to handle seperately to *args
+                 dataset_key: DatasetKey,  # Had to handle separately to *args
                  sweep_id : int,
                  sweep_indep : str,
                  fixed_indep : str, 
@@ -38,7 +39,7 @@ class sweeper(plotWidget):
         
         self.line: Any = None
         
-        super().__init__(guid, *args, **kargs)
+        super().__init__(dataset_key, *args, **kargs)
         
         
     def initAxes(self):

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -31,7 +31,7 @@ from qplot.diagnostics import log_user_error
 
 from ._commands import create_action
 from ._database_actions import DatabaseActionsMixin
-from ._dataset_handle import DatasetHandle
+from ._dataset_handle import DatasetHandle, DatasetKey
 from ._help import add_help_menu
 from ._plot_actions import PlotActionsMixin
 from ._preferences import (
@@ -126,8 +126,9 @@ class MainWindow(  # type: ignore[misc]
         self.config = config() # Connect to config.json in :/users/<user>/.qplot/
         self.windows = [] # prevent auto delete of windows
         self.ds = None
+        self._selected_dataset_key: DatasetKey | None = None
         self.preview_size = self._configured_preview_size()
-        self.dataset_holder: dict[str, DatasetHandle] = {}
+        self.dataset_holder: dict[DatasetKey, DatasetHandle] = {}
         self.monitor = QtCore.QTimer()
         self.threadPool = QtCore.QThreadPool()
         self.threadPool.setMaxThreadCount(self.config.get("runtime_settings.max_threads"))

--- a/src/qplot/windows/plot1d.py
+++ b/src/qplot/windows/plot1d.py
@@ -27,7 +27,7 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
     
     """
     get_mergables = QtCore.pyqtSignal()
-    remove_dataset = QtCore.pyqtSignal([str])
+    remove_dataset = QtCore.pyqtSignal([object])
     
     def __init__(
             self,

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -34,7 +34,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         refreshPlot
         
     """
-    open_subplot = QtCore.pyqtSignal([object, str, tuple])
+    open_subplot = QtCore.pyqtSignal([object, object, tuple])
     sweep_moved = QtCore.pyqtSignal([int, int])
     close_sweeps_requested = QtCore.pyqtSignal([object, object])
     

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,8 +15,7 @@ from qplot.tools.plot_tools import (
     subtract_mean,
 )
 from qplot.tools.worker import loader
-from qplot.windows import _plotWin as plotwin_module
-from qplot.windows._dataset_handle import DatasetHandle
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plotWin import plotWidget
 
 
@@ -601,9 +600,6 @@ class ToolFunctionTestCase(unittest.TestCase):
         np.testing.assert_array_equal(result["z"], np.array([[-1.0, 1.0], [-1.0, 1.0]]))
 
     def test_plot_window_title_uses_database_basename(self):
-        old_get_db_location = plotwin_module.get_DB_location
-        plotwin_module.get_DB_location = lambda: "/tmp/qplot/example.db"
-
         class Dataset:
             run_id = 12
 
@@ -613,10 +609,8 @@ class ToolFunctionTestCase(unittest.TestCase):
 
         window = plotWidget.__new__(plotWidget)
         window._guid = "guid"
-        window._dataset_holder = {"guid": DatasetHandle(Dataset())}
+        window._dataset_key = DatasetKey("/tmp/qplot/example.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
         window.param = Param()
 
-        try:
-            self.assertTrue(str(window).startswith("example.db | Run ID: 12"))
-        finally:
-            plotwin_module.get_DB_location = old_get_db_location
+        self.assertTrue(str(window).startswith("example.db | Run ID: 12"))

--- a/tests/widgets/test_preview_dragdrop.py
+++ b/tests/widgets/test_preview_dragdrop.py
@@ -3,6 +3,7 @@ import unittest
 from PyQt6 import QtCore
 
 from qplot.windows import main as main_window
+from qplot.windows._dataset_handle import DatasetKey
 from qplot.windows._dragdrop import (
     make_run_preview_mime,
     preview_drop_is_compatible,
@@ -62,6 +63,7 @@ class RunPreviewDragDropTestCase(unittest.TestCase):
         class Window:
             def __init__(self, guid, param, label):
                 self.ds = Dataset(guid)
+                self._dataset_key = DatasetKey("database.db", guid)
                 self.param = param
                 self.label = label
                 self.visible = True
@@ -98,7 +100,7 @@ class RunPreviewDragDropTestCase(unittest.TestCase):
 
         added = harness.add_trace_to_plot(
             target,
-            "source-guid",
+            source._dataset_key,
             "signal",
             param=source_param
             )
@@ -107,5 +109,4 @@ class RunPreviewDragDropTestCase(unittest.TestCase):
         self.assertEqual(target.option_boxes[0].option_box.index, 0)
         self.assertTrue(source.closed)
         self.assertEqual(harness.status_messages, [])
-
 

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -14,8 +14,9 @@ from qplot.datahandling import database as database_module
 from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.windows import _database_actions as database_actions
 from qplot.windows import main as main_window
-from qplot.windows._dataset_handle import DatasetHandle
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plot_actions import PlotActionsMixin
+from qplot.windows._plotWin import plotWidget
 from qplot.windows._run_controls import AUTO_PLOT_KEY
 from qplot.windows._window_controls import (
     CONFIRM_CLOSE_ALL_KEY,
@@ -121,18 +122,19 @@ class DatasetHandleTestCase(unittest.TestCase):
 
         harness = Harness()
         dataset = Dataset()
+        dataset_key = DatasetKey("database.db", "guid")
 
-        harness.add_ds_at("guid", dataset)
-        self.assertIs(harness.dataset_holder["guid"].dataset, dataset)
-        self.assertEqual(harness.dataset_holder["guid"].users, 1)
+        harness.add_ds_at(dataset_key, dataset)
+        self.assertIs(harness.dataset_holder[dataset_key].dataset, dataset)
+        self.assertEqual(harness.dataset_holder[dataset_key].users, 1)
 
-        harness.add_ds_at("guid", dataset)
-        self.assertEqual(harness.dataset_holder["guid"].users, 2)
+        harness.add_ds_at(dataset_key, dataset)
+        self.assertEqual(harness.dataset_holder[dataset_key].users, 2)
 
-        harness.remove_ds_at("guid")
-        self.assertEqual(harness.dataset_holder["guid"].users, 1)
+        harness.remove_ds_at(dataset_key)
+        self.assertEqual(harness.dataset_holder[dataset_key].users, 1)
 
-        harness.remove_ds_at("guid")
+        harness.remove_ds_at(dataset_key)
         self.assertEqual(harness.dataset_holder, {})
 
     def test_failed_plot_construction_preserves_existing_dataset_ownership(self):
@@ -157,32 +159,200 @@ class DatasetHandleTestCase(unittest.TestCase):
                 self.conn = Connection()
 
         class Harness(PlotActionsMixin):
-            def __init__(self, handle):
+            def __init__(self, dataset_key, handle):
                 self.config = object()
-                self.dataset_holder = {"guid": handle}
+                self.dataset_holder = {dataset_key: handle}
                 self.threadPool = object()
                 self.windows = []
 
         def failing_widget(*args, **kwargs):
-            construction_handle = args[-1]["guid"]
+            construction_handle = args[-1][dataset_key]
             construction_handle.cancel_delete_timer()
             raise RuntimeError("plot construction failed")
 
         timer = Timer()
         dataset = Dataset()
+        dataset_key = DatasetKey("database.db", "guid")
         handle = DatasetHandle(dataset, users=0, delete_timer=timer)
-        harness = Harness(handle)
+        harness = Harness(dataset_key, handle)
 
         with self.assertRaisesRegex(RuntimeError, "plot construction failed"):
-            harness.openWin(failing_widget, "guid", show=False)
+            harness.openWin(failing_widget, dataset_key, show=False)
 
-        self.assertEqual(harness.dataset_holder, {"guid": handle})
-        self.assertIs(harness.dataset_holder["guid"].dataset.conn, dataset.conn)
+        self.assertEqual(harness.dataset_holder, {dataset_key: handle})
+        self.assertIs(harness.dataset_holder[dataset_key].dataset.conn, dataset.conn)
         self.assertEqual(handle.users, 0)
         self.assertIs(handle.delete_timer, timer)
         self.assertFalse(timer.stopped)
         self.assertFalse(dataset.conn.closed)
         self.assertEqual(harness.windows, [])
+
+
+class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
+    class Field:
+        def __init__(self, value):
+            self.value = value
+
+        def text(self):
+            return self.value
+
+        def setText(self, value):
+            self.value = value
+
+        def blockSignals(self, _blocked):
+            return False
+
+    class Config:
+        def get(self, key):
+            if key == "runtime_settings.del_grace_period":
+                return 0
+            raise KeyError(key)
+
+    class Dataset:
+        guid = "shared-guid"
+
+        def __init__(self, database_name, run_id=1):
+            self.database_name = database_name
+            self.run_id = run_id
+            self.metadata = {}
+            self.snapshot = None
+
+        def get_parameters(self):
+            return []
+
+    class Param:
+        name = "signal"
+
+    def test_database_path_aliases_produce_the_same_key(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "database.db"
+            database_path.touch()
+
+            direct = DatasetKey(str(database_path), "shared-guid")
+            aliased = DatasetKey(
+                str(database_path.parent / "." / database_path.name),
+                "shared-guid",
+            )
+
+        self.assertEqual(direct, aliased)
+
+    def test_same_guid_in_two_databases_creates_distinct_cache_entries(self):
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.dataset_holder = {}
+        harness.config = self.Config()
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        dataset_a = self.Dataset("A")
+        dataset_b = self.Dataset("B")
+
+        harness.add_ds_at(key_a, dataset_a)
+        harness.add_ds_at(key_b, dataset_b)
+
+        self.assertEqual(len(harness.dataset_holder), 2)
+        self.assertIs(harness.dataset_holder[key_a].dataset, dataset_a)
+        self.assertIs(harness.dataset_holder[key_b].dataset, dataset_b)
+
+    def test_current_database_selection_cannot_return_other_database_dataset(self):
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.fileTextbox = self.Field("database-b.db")
+        harness.run_idBox = self.Field("")
+        harness.infoBox = type("InfoBox", (), {"setInfo": lambda *args, **kwargs: None})()
+        harness.ds = None
+        harness.selected_run_id = None
+        harness.show_status = lambda *args, **kwargs: None
+        harness.show_error = lambda *args, **kwargs: self.fail("selection load failed")
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        dataset_a = self.Dataset("A")
+        dataset_b = self.Dataset("B")
+        harness.dataset_holder = {key_a: DatasetHandle(dataset_a)}
+
+        with patch(
+            "qplot.windows._plot_actions.load_by_guid_read_only",
+            return_value=dataset_b,
+        ) as load_dataset:
+            harness.updateSelected("shared-guid")
+
+        self.assertIs(harness.ds, dataset_b)
+        load_dataset.assert_called_once_with(
+            "shared-guid",
+            DatasetKey("database-b.db", "x").database_path,
+        )
+
+    def test_same_guid_and_parameter_plots_in_different_databases_coexist(self):
+        class PlotWindow:
+            pass
+
+        class SpinBox:
+            def value(self):
+                return 1.0
+
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        param = self.Param()
+        param.depends_on = "x"
+        param.depends_on_ = ("x",)
+        dataset_b = self.Dataset("B")
+        window_a = PlotWindow()
+        window_a._dataset_key = key_a
+        window_a.param = param
+
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.fileTextbox = self.Field("database-b.db")
+        harness.dataset_holder = {key_b: DatasetHandle(dataset_b)}
+        harness.ds = None
+        harness._selected_dataset_key = None
+        harness.windows = [window_a]
+        harness.spinBox = SpinBox()
+        harness.status_messages = []
+        harness.show_status = lambda *args: harness.status_messages.append(args)
+        harness.show_error = lambda *args: self.fail("plot load failed")
+        harness.post_admin = lambda: None
+        opened = []
+        harness.openWin = lambda *args, **kwargs: opened.append((args, kwargs))
+
+        with patch("qplot.windows._plot_actions.plot1d", PlotWindow):
+            harness.openPlot("shared-guid", params=[param], show=False)
+
+        self.assertEqual(len(opened), 1)
+        self.assertIs(opened[0][0][1], dataset_b)
+
+    def test_closing_one_database_plot_keeps_other_database_handle(self):
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.config = self.Config()
+        harness.status_messages = []
+        harness.show_status = lambda message, timeout=5000: harness.status_messages.append(
+            (message, timeout)
+        )
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        handle_a = DatasetHandle(self.Dataset("A"))
+        handle_b = DatasetHandle(self.Dataset("B"))
+        harness.dataset_holder = {key_a: handle_a, key_b: handle_b}
+        window_a = type("Window", (), {"_dataset_key": key_a, "label": "A"})()
+        window_b = type("Window", (), {"_dataset_key": key_b, "label": "B"})()
+        harness.windows = [window_a, window_b]
+        harness.post_admin = lambda: None
+
+        harness.onClose(window_a)
+
+        self.assertNotIn(key_a, harness.dataset_holder)
+        self.assertIs(harness.dataset_holder[key_b], handle_b)
+        self.assertEqual(harness.windows, [window_b])
+
+    def test_database_a_plot_keeps_using_database_a_handle_after_switch(self):
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        dataset_a = self.Dataset("A")
+        dataset_b = self.Dataset("B")
+        window = plotWidget.__new__(plotWidget)
+        window._guid = key_a.guid
+        window._dataset_key = key_a
+        window._dataset_holder = {
+            key_a: DatasetHandle(dataset_a),
+            key_b: DatasetHandle(dataset_b),
+        }
+
+        self.assertIs(window.ds, dataset_a)
 
     def test_failed_plot_construction_does_not_publish_new_dataset(self):
         class Connection:
@@ -204,12 +374,14 @@ class DatasetHandleTestCase(unittest.TestCase):
                 self.dataset_holder = {}
                 self.threadPool = object()
                 self.windows = []
+                self.fileTextbox = DatabaseAwareDatasetCacheTestCase.Field("database.db")
 
         constructor_connections = []
 
         def failing_widget(*args, **kwargs):
             construction_holder = args[-1]
-            constructor_connections.append(construction_holder["guid"].dataset.conn)
+            key = DatasetKey("database.db", "guid")
+            constructor_connections.append(construction_holder[key].dataset.conn)
             raise RuntimeError("plot construction failed")
 
         dataset = Dataset()
@@ -249,6 +421,7 @@ class DatasetHandleTestCase(unittest.TestCase):
 
         dataset = Dataset()
         harness = Harness()
+        dataset_key = DatasetKey("database.db", "guid")
 
         with (
             patch(
@@ -257,7 +430,7 @@ class DatasetHandleTestCase(unittest.TestCase):
             ),
             self.assertRaisesRegex(RuntimeError, "plot construction failed"),
         ):
-            harness.openWin(failing_widget, "guid", show=False)
+            harness.openWin(failing_widget, dataset_key, show=False)
 
         self.assertTrue(dataset.conn.closed)
         self.assertEqual(harness.dataset_holder, {})

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot.windows import _plotWin as plotwin_module
+from qplot.windows._dataset_handle import DatasetKey
 from qplot.windows._plot1d_snap import _nearest_trace_sample
 from qplot.windows._plot1d_traces import (
     TRACE_COLOR_PALETTE,
@@ -700,6 +701,7 @@ class SnapToTraceTestCase(unittest.TestCase):
         class SourceWindow:
             label = "ID:2 voltage"
             _guid = "source-guid"
+            _dataset_key = DatasetKey("database.db", "source-guid")
             visible = False
             ds = Dataset()
             worker = Worker()
@@ -721,8 +723,8 @@ class SnapToTraceTestCase(unittest.TestCase):
             end_wait = EndWait()
 
         class Host(Plot1DTraceMixin, qtw.QMainWindow):
-            make_ds = QtCore.pyqtSignal([str])
-            remove_dataset = QtCore.pyqtSignal([str])
+            make_ds = QtCore.pyqtSignal([object])
+            remove_dataset = QtCore.pyqtSignal([object])
             get_mergables = QtCore.pyqtSignal()
 
         host = Host()
@@ -764,7 +766,7 @@ class SnapToTraceTestCase(unittest.TestCase):
             host.add_line(source.label)
             secondary = host.lines[source.label]
 
-            self.assertEqual(made_datasets, ["source-guid"])
+            self.assertEqual(made_datasets, [source._dataset_key])
             self.assertEqual(host.mergable, [])
             self.assertIsNotNone(host.right_vb)
             self.assertEqual(secondary.side, "right")
@@ -787,7 +789,7 @@ class SnapToTraceTestCase(unittest.TestCase):
             self.assertNotIn(source.label, host.lines)
             self.assertNotIn(secondary, host.right_vb.addedItems)
             self.assertFalse(host.plot.getAxis("right").style["showValues"])
-            self.assertEqual(removed_datasets, ["source-guid"])
+            self.assertEqual(removed_datasets, [source._dataset_key])
             self.assertEqual(picker_updates, [True])
         finally:
             host.deleteLater()

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -6,7 +6,7 @@ from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
 from qplot.tools.heatmap_geometry import HeatmapGeometry
-from qplot.windows._dataset_handle import DatasetHandle
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plotWin import plotWidget
 from qplot.windows.plot2d import _COLORBAR_COLORMAPS, plot2d
 
@@ -76,7 +76,8 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
         window._update_heatmap_geometry()
         window.worker = worker
         window._guid = "guid"
-        window._dataset_holder = {"guid": DatasetHandle(Dataset())}
+        window._dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
         window.param = Param()
         window.end_wait = Signal()
         window._set_param_axis_labels = lambda: None

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -7,7 +7,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot.windows import _plot_refresh as plot_refresh_module
-from qplot.windows._dataset_handle import DatasetHandle
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plot_state import PlotStateOverlay
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._preferences import (
@@ -46,7 +46,8 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         window.monitor = self.Timer()
         window.spinBox = self.SpinBox()
         window._guid = "guid"
-        window._dataset_holder = {"guid": DatasetHandle(self.Dataset())}
+        window._dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(self.Dataset())}
         window.worker = self.Worker(worker_running)
         window.last_ds_len = 0
         window.load_calls = []
@@ -155,7 +156,8 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
 
         window = plotWidget.__new__(plotWidget)
         window._guid = "guid"
-        window._dataset_holder = {"guid": DatasetHandle(Dataset())}
+        window._dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
         window.param = Param()
         window.param_dict = {"x": object(), "y": object(), "signal": object()}
         window.axis_dropdown = {"x": Combo("x"), "y": Combo("y")}
@@ -289,7 +291,8 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         window.line = line
         window.marquee = None
         window._guid = "guid"
-        window._dataset_holder = {"guid": DatasetHandle(Dataset())}
+        window._dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
         window.param = Param()
         window.end_wait = Signal()
         window._set_param_axis_labels = lambda: None


### PR DESCRIPTION
## Summary

- introduce an immutable dataset key containing a canonical database path and GUID
- use database-aware identity throughout selection, plotting, preview/export, subplot, trace, reference-counting, and delayed-cleanup flows
- keep plot windows bound to their originating database after the committed database changes
- allow identical GUID/parameter plots from different databases to coexist
- preserve the existing transactional database-switch behavior

## Root cause

`MainWindow.dataset_holder` and plot identity lookups were keyed only by dataset GUID. A copied database can retain GUIDs while containing different data, so switching databases could reuse a handle and dataset opened from the previous database.

## Impact

Dataset handles are now isolated per canonical database path and GUID. Existing plots remain usable across database switches, while selections and newly opened plots resolve against the currently committed database. The separate plot-open connection-ownership bug is intentionally out of scope.

## Validation

- regression and reference-counting tests: 11 passed
- affected plot and preview tests: 269 passed
- complete test suite: 385 passed
- Ruff: passed
- `git diff --check`: passed
- qPlot runtime smoke test: initialized successfully and remained running