### PR TITLE
Fix stale plot worker callbacks

### DIFF
--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -127,8 +127,15 @@ class PlotRefreshMixin(_PlotRefreshBase):
             lambda finished, worker=worker: self.refreshPlot(finished, worker=worker)
             )
         # Error event handling
-        worker.emitter.errorOccurred.connect(self.err_raiser)
-        worker.emitter.printer.connect(self.worker_printer)
+        worker.emitter.errorOccurred.connect(
+            lambda err, worker=worker: self.err_raiser(err, worker=worker)
+            )
+        worker.emitter.printer.connect(
+            lambda message, worker=worker: self.worker_printer(
+                message,
+                worker=worker,
+                )
+            )
 
         if wait_on_thread:  # Force freeze main thread
             hold_up = QtCore.QEventLoop()
@@ -213,22 +220,21 @@ class PlotRefreshMixin(_PlotRefreshBase):
             is not ran.
 
         """
+        if worker is None:
+            worker = self.worker
+
+        if worker is not self.worker:
+            worker.running = False
+            return False
+
         try:
             if not finished:  # error in worker
-                if worker is not None:
-                    worker.running = False
+                worker.running = False
                 self.show_plot_state(
                     "Plot load failed",
                     "Check the status bar or diagnostic log for details.",
                     kind="error",
                     )
-                return False
-
-            if worker is None:
-                worker = self.worker
-
-            if worker is not self.worker:
-                worker.running = False
                 return False
 
             # Update qcodes dataset variables if db read happened
@@ -303,11 +309,15 @@ class PlotRefreshMixin(_PlotRefreshBase):
             return None
 
         finally:  # Allow code to move on from wait_on_thread
-            self.end_wait.emit()
+            if worker is self.worker:
+                self.end_wait.emit()
 
 
     @QtCore.pyqtSlot(Exception)
-    def err_raiser(self, err: Exception) -> None:
+    def err_raiser(self, err: Exception, worker: Any | None = None) -> None:
+        if worker is not None and worker is not self.worker:
+            return
+
         message = f"{type(err).__name__}: {err}"
         log_exception("Plot worker error", err, __name__)
         self.show_status(f"Worker error: {message}", 10_000)
@@ -321,7 +331,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
 
     @QtCore.pyqtSlot(str)
-    def worker_printer(self, fstr: str) -> None:
+    def worker_printer(self, fstr: str, worker: Any | None = None) -> None:
+        if worker is not None and worker is not self.worker:
+            return
+
         # Worker print() often does not work, so done through event handlers
         self.show_status(fstr, 5000)
         print(fstr)

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -76,7 +76,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.last_ds_len, 10)
         self.assertEqual(window.restart_intervals, [0.2])
 
-    def test_load_data_uses_sampled_sql_before_completed_cache_prep(self):
+    def test_load_data_uses_sampled_sql_and_wires_originating_worker(self):
         class Signal:
             def __init__(self):
                 self.slots = []
@@ -170,9 +170,18 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         window.show_plot_state = lambda *args, **kwargs: window.plot_states.append(
             (args, kwargs)
             )
-        window.refreshPlot = lambda *_args, **_kwargs: None
-        window.err_raiser = lambda *_args, **_kwargs: None
-        window.worker_printer = lambda *_args, **_kwargs: None
+        window.refresh_calls = []
+        window.error_calls = []
+        window.printer_calls = []
+        window.refreshPlot = lambda finished, *, worker: window.refresh_calls.append(
+            (finished, worker)
+            )
+        window.err_raiser = lambda err, *, worker: window.error_calls.append(
+            (err, worker)
+            )
+        window.worker_printer = lambda message, *, worker: window.printer_calls.append(
+            (message, worker)
+            )
 
         old_loader = plot_refresh_module.loader
         old_prep = plot_refresh_module.load_param_data_from_db_prep
@@ -197,6 +206,135 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(worker.operations, ["operation"])
         self.assertEqual(window.worker, worker)
         self.assertIn("Loading data for signal", window.show_statuses[-1][0])
+
+        error = RuntimeError("failed")
+        worker.emitter.finished.slots[0](True)
+        worker.emitter.errorOccurred.slots[0](error)
+        worker.emitter.printer.slots[0]("working")
+
+        self.assertEqual(window.refresh_calls, [(True, worker)])
+        self.assertEqual(window.error_calls, [(error, worker)])
+        self.assertEqual(window.printer_calls, [("working", worker)])
+
+
+class PlotWorkerCallbackTestCase(unittest.TestCase):
+    class Signal:
+        def __init__(self):
+            self.emitted = 0
+
+        def emit(self):
+            self.emitted += 1
+
+    class Worker:
+        def __init__(self):
+            self.running = True
+
+    def _window(self):
+        window = plotWidget.__new__(plotWidget)
+        window.worker = self.Worker()
+        window.end_wait = self.Signal()
+        window.statuses = []
+        window.plot_states = []
+        window.errors = []
+        window.show_status = lambda *args: window.statuses.append(args)
+        window.show_plot_state = lambda *args, **kwargs: window.plot_states.append(
+            (args, kwargs)
+            )
+        window.show_error = lambda *args: window.errors.append(args)
+        window._last_error_text = None
+        return window
+
+    def test_stale_successful_worker_cannot_mutate_current_plot_state(self):
+        window = self._window()
+        stale_worker = self.Worker()
+        stale_worker.read_data = True
+        window.axis_data = {"x": ["current x"], "y": ["current y"]}
+        window.axis_param = {"x": "current x param", "y": "current y param"}
+        cache_updates = []
+        old_update_cache = plot_refresh_module.update_cache_parameter_data
+        plot_refresh_module.update_cache_parameter_data = (
+            lambda *args: cache_updates.append(args)
+            )
+        try:
+            result = plotWidget.refreshPlot(window, True, worker=stale_worker)
+        finally:
+            plot_refresh_module.update_cache_parameter_data = old_update_cache
+
+        self.assertFalse(result)
+        self.assertFalse(stale_worker.running)
+        self.assertEqual(
+            window.axis_data,
+            {"x": ["current x"], "y": ["current y"]},
+            )
+        self.assertEqual(
+            window.axis_param,
+            {"x": "current x param", "y": "current y param"},
+            )
+        self.assertEqual(cache_updates, [])
+        self.assertEqual(window.statuses, [])
+        self.assertEqual(window.plot_states, [])
+
+    def test_stale_failed_worker_cannot_show_error_overlay(self):
+        window = self._window()
+        stale_worker = self.Worker()
+
+        result = plotWidget.refreshPlot(window, False, worker=stale_worker)
+
+        self.assertFalse(result)
+        self.assertFalse(stale_worker.running)
+        self.assertEqual(window.plot_states, [])
+
+    def test_stale_error_signal_cannot_change_current_error_state(self):
+        window = self._window()
+        window._last_error_text = "current error"
+        stale_worker = self.Worker()
+
+        plotWidget.err_raiser(
+            window,
+            RuntimeError("stale error"),
+            worker=stale_worker,
+            )
+
+        self.assertEqual(window.statuses, [])
+        self.assertEqual(window.plot_states, [])
+        self.assertEqual(window.errors, [])
+        self.assertEqual(window._last_error_text, "current error")
+
+    def test_stale_printer_signal_cannot_overwrite_current_status(self):
+        window = self._window()
+
+        plotWidget.worker_printer(
+            window,
+            "stale status",
+            worker=self.Worker(),
+            )
+
+        self.assertEqual(window.statuses, [])
+
+    def test_stale_completion_cannot_release_current_worker_wait(self):
+        window = self._window()
+
+        plotWidget.refreshPlot(window, True, worker=self.Worker())
+
+        self.assertEqual(window.end_wait.emitted, 0)
+
+    def test_current_worker_failure_reports_error_and_releases_wait(self):
+        window = self._window()
+        error = RuntimeError("current error")
+
+        plotWidget.err_raiser(window, error, worker=window.worker)
+        result = plotWidget.refreshPlot(window, False, worker=window.worker)
+
+        self.assertFalse(result)
+        self.assertFalse(window.worker.running)
+        self.assertIn("Worker error: RuntimeError: current error", window.statuses[-1][0])
+        self.assertEqual(window.plot_states[-1][0][0], "Plot load failed")
+        self.assertEqual(
+            window.errors,
+            [("Plot Error", "A plot worker failed.", "RuntimeError: current error")],
+            )
+        self.assertEqual(window._last_error_text, "RuntimeError: current error")
+        self.assertEqual(window.end_wait.emitted, 1)
 
 
 class PlotStateOverlayTestCase(unittest.TestCase):
@@ -243,6 +381,7 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         window = plotWidget.__new__(plotWidget)
         worker = Worker()
         states = []
+        window.worker = worker
         window.end_wait = Signal()
         window.show_plot_state = lambda *args, **kwargs: states.append((args, kwargs))
 


### PR DESCRIPTION
## Summary

- bind the originating worker into finished, error, and printer callbacks
- reject superseded-worker callbacks before they can mutate plot data, cache, overlays, status, dialogs, or error state
- prevent stale completions from releasing the current worker's synchronous wait
- add regression coverage for stale success, failure, error, printer, wait, current failure, and callback wiring

## Root cause

A forced refresh can replace `self.worker` while the previous worker is still running. Successful completions had a partial identity check, but failed completions were handled before that check and error/printer callbacks did not retain their originating worker. As a result, callbacks from the superseded worker could overwrite the newer plot's state.

## Impact

Current-worker success and failure behavior remains unchanged. Forced refresh continues to supersede active workers, while stale callbacks are ignored apart from allowing the stale worker to be marked no longer running. Existing 1D, 2D, sweeper, subplot, and large-heatmap paths remain intact.

## Verification

- `.venv-mac/bin/python -m pytest tests/windows/test_plot_window.py tests/windows/test_plot1d.py tests/windows/test_plot2d.py -q` — 133 passed, 2 subtests passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m pytest -q` — 396 passed, 2 subtests passed
- `.venv-mac/bin/python -m qplot` — runtime smoke launch passed
- `git diff --check` — passed