### PR TITLE
Display failed QCoDeS run status correctly

### DIFF
--- a/src/qplot/windows/_widgets/_run_formatting.py
+++ b/src/qplot/windows/_widgets/_run_formatting.py
@@ -9,6 +9,16 @@ def run_tooltip_text(metadata):
     """
     sweep = format_parameter_list_html(metadata.get("sweep_parameters"))
     measure = format_parameter_list_html(metadata.get("measure_parameters"))
+    status = html.escape(format_run_status(metadata))
+    exception_row = ""
+    if run_failed(metadata):
+        summary = html.escape(measurement_exception_summary(metadata))
+        exception_row = (
+            "<tr>"
+            "<td style='padding:0 0.5em 0 0'>Exception</td>"
+            f"<td style='padding:0'>{summary}</td>"
+            "</tr>"
+            )
 
     return (
         "<table style='margin:0; border-spacing:0; border-collapse:collapse'>"
@@ -20,6 +30,11 @@ def run_tooltip_text(metadata):
         "<td style='padding:0 0.5em 0 0'>Measure</td>"
         f"<td nowrap='nowrap' style='padding:0; white-space:nowrap'>({measure})</td>"
         "</tr>"
+        "<tr>"
+        "<td style='padding:0 0.5em 0 0'>Status</td>"
+        f"<td style='padding:0'>{status}</td>"
+        "</tr>"
+        f"{exception_row}"
         "</table>"
         )
 
@@ -27,11 +42,15 @@ def run_tooltip_text(metadata):
 def run_tooltip_plain_text(metadata):
     sweep = format_parameter_list(metadata.get("sweep_parameters"))
     measure = format_parameter_list(metadata.get("measure_parameters"))
-
-    return "\n".join([
+    lines = [
         f"{'Sweep':<7}({sweep})",
         f"Measure ({measure})",
-        ])
+        f"Status  {format_run_status(metadata)}",
+        ]
+    if run_failed(metadata):
+        lines.append(f"Exception {measurement_exception_summary(metadata)}")
+
+    return "\n".join(lines)
 
 
 def format_parameter_list(parameters):
@@ -52,12 +71,34 @@ def run_is_complete(metadata):
 
 def run_was_interrupted(metadata):
     exception = metadata.get("measurement_exception")
-    return bool(exception and "KeyboardInterrupt" in str(exception))
+    return exception is not None and "KeyboardInterrupt" in str(exception).strip()
+
+
+def run_failed(metadata):
+    exception = metadata.get("measurement_exception")
+    return bool(
+        exception is not None
+        and str(exception).strip()
+        and not run_was_interrupted(metadata)
+        )
+
+
+def measurement_exception_summary(metadata, maximum_length=200):
+    exception = str(metadata.get("measurement_exception") or "")
+    summary = next(
+        (line.strip() for line in reversed(exception.splitlines()) if line.strip()),
+        "",
+        )
+    if len(summary) > maximum_length:
+        return f"{summary[:maximum_length - 1]}…"
+    return summary
 
 
 def format_run_status(metadata):
     if run_was_interrupted(metadata):
         return f"Interrupted ({format_interrupted_progress_percent(metadata)})"
+    if run_failed(metadata):
+        return f"Failed ({format_interrupted_progress_percent(metadata)})"
     if run_is_complete(metadata):
         return "Complete"
     return f"Incomplete ({format_progress_percent(metadata)})"
@@ -115,7 +156,7 @@ def format_interrupted_progress_percent(metadata):
 
 
 def complete_cell_sort_value(metadata):
-    if run_was_interrupted(metadata):
+    if run_was_interrupted(metadata) or run_failed(metadata):
         return interrupted_progress_percent_value(metadata)
     if run_is_complete(metadata):
         return 100
@@ -124,7 +165,10 @@ def complete_cell_sort_value(metadata):
 
 def format_complete_cell(metadata):
     if run_was_interrupted(metadata):
-        return format_interrupted_progress_percent(metadata)
+        return "Interrupted"
+
+    if run_failed(metadata):
+        return "Failed"
 
     if run_is_complete(metadata):
         return "✓"

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -38,6 +38,7 @@ from ._run_formatting import (  # noqa: F401
     format_timestamp,
     measured_parameter_count,
     progress_percent_value,
+    run_failed,
     run_is_complete,
     run_tooltip_plain_text,
     run_tooltip_text,
@@ -72,11 +73,11 @@ class RunList(qtw.QTreeWidget):
     
     """
     
-    cols = ['ID', 'Measurements', 'Setpoints', 'Started', 'Complete', 'Duration', 'Size']
+    cols = ['ID', 'Measurements', 'Setpoints', 'Started', 'Status', 'Duration', 'Size']
     column_widths = {
         "ID": 40,
         "Measurements": 104,
-        "Complete": 86,
+        "Status": 86,
         "Duration": 96,
         "Size": 72,
         }
@@ -89,7 +90,7 @@ class RunList(qtw.QTreeWidget):
         "Measurements": 96,
         "Setpoints": 100,
         "Started": 128,
-        "Complete": 78,
+        "Status": 78,
         "Duration": 84,
         "Size": 58,
         }
@@ -98,7 +99,7 @@ class RunList(qtw.QTreeWidget):
         "Measurements": 84,
         "Setpoints": 80,
         "Started": 84,
-        "Complete": 72,
+        "Status": 72,
         "Duration": 68,
         "Size": 50,
         }
@@ -107,7 +108,7 @@ class RunList(qtw.QTreeWidget):
         "Started",
         "Duration",
         "Size",
-        "Complete",
+        "Status",
         "Setpoints",
         "ID",
         )
@@ -117,7 +118,7 @@ class RunList(qtw.QTreeWidget):
         "Duration",
         "Size",
         "Measurements",
-        "Complete",
+        "Status",
         "ID",
         )
     compact_shrink_order = (
@@ -125,7 +126,7 @@ class RunList(qtw.QTreeWidget):
         "Started",
         "Measurements",
         "Duration",
-        "Complete",
+        "Status",
         "Size",
         "ID",
         )
@@ -214,7 +215,7 @@ class RunList(qtw.QTreeWidget):
             arr.append("") #measured previews; count remains the hidden sort key
             arr.append(format_point_count(metadata)) #points
             arr.append(format_timestamp(metadata["run_timestamp"])) #started
-            arr.append(format_complete_cell(metadata)) #complete
+            arr.append(format_complete_cell(metadata)) #status
             arr.append(format_time_taken_seconds(metadata)) #duration
             arr.append(format_storage_size(metadata.get("storage_bytes"))) #size
 
@@ -231,7 +232,7 @@ class RunList(qtw.QTreeWidget):
                     QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
                     )
             item.setTextAlignment(
-                self.cols.index("Complete"),
+                self.cols.index("Status"),
                 QtCore.Qt.AlignmentFlag.AlignCenter
                 )
             item.setTextAlignment(
@@ -260,7 +261,7 @@ class RunList(qtw.QTreeWidget):
                 metadata.get("run_timestamp")
                 )
             item.setData(
-                self.cols.index("Complete"),
+                self.cols.index("Status"),
                 QtCore.Qt.ItemDataRole.UserRole,
                 complete_cell_sort_value(metadata)
                 )
@@ -354,7 +355,7 @@ class RunList(qtw.QTreeWidget):
             or metadata.get("result_count"),
             )
 
-        complete_col = self.cols.index("Complete")
+        complete_col = self.cols.index("Status")
         item.setText(complete_col, format_complete_cell(metadata))
         item.setData(
             complete_col,
@@ -630,7 +631,7 @@ class RunList(qtw.QTreeWidget):
                     points_col = self.cols.index("Setpoints")
                     run.setText(points_col, format_point_count(run.run_metadata))
                     run.setData(points_col, QtCore.Qt.ItemDataRole.UserRole, status["result_count"])
-                complete_col = self.cols.index("Complete")
+                complete_col = self.cols.index("Status")
                 run.setText(complete_col, format_complete_cell(run.run_metadata))
                 run.setData(
                     complete_col,
@@ -655,7 +656,7 @@ class RunList(qtw.QTreeWidget):
                 completion_metadata_changed = True
 
             if completion_metadata_changed:
-                complete_col = self.cols.index("Complete")
+                complete_col = self.cols.index("Status")
                 run.setText(complete_col, format_complete_cell(run.run_metadata))
                 run.setData(
                     complete_col,
@@ -674,7 +675,7 @@ class RunList(qtw.QTreeWidget):
             if finished:
                 run.run_metadata["completed_timestamp"] = finished
                 run.run_metadata["is_completed"] = status.get("is_completed", True)
-                complete_col = self.cols.index("Complete")
+                complete_col = self.cols.index("Status")
                 run.setText(complete_col, format_complete_cell(run.run_metadata))
                 run.setData(
                     complete_col,

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -48,7 +48,7 @@ class RunListTooltipTestCase(unittest.TestCase):
             })
 
         self.assertTrue(tooltip.startswith("<table"))
-        self.assertEqual(tooltip.count("<tr>"), 2)
+        self.assertEqual(tooltip.count("<tr>"), 3)
         self.assertIn("<td style='padding:0 0.5em 0 0'>Sweep</td>", tooltip)
         self.assertIn(
             "<td nowrap='nowrap' style='padding:0; white-space:nowrap'>"
@@ -61,6 +61,8 @@ class RunListTooltipTestCase(unittest.TestCase):
             "(dmm_v1,&nbsp;dmm_v2)</td>",
             tooltip
             )
+        self.assertIn("Status</td>", tooltip)
+        self.assertIn("Incomplete (25.0%)</td>", tooltip)
         self.assertNotIn("Duration", tooltip)
 
     def test_format_point_count_summarises_multidimensional_sweeps(self):
@@ -139,7 +141,7 @@ class RunListTooltipTestCase(unittest.TestCase):
 
         self.assertEqual(
             treeWidgets.format_complete_cell(metadata),
-            "40.00%"
+            "Interrupted"
             )
         self.assertEqual(
             treeWidgets.format_run_status(metadata),
@@ -147,17 +149,82 @@ class RunListTooltipTestCase(unittest.TestCase):
             )
         self.assertEqual(treeWidgets.complete_cell_sort_value(metadata), 40.0)
 
-    def test_non_keyboard_measurement_exception_still_uses_completed_tick(self):
+    def test_completed_non_keyboard_measurement_exception_is_failed(self):
+        metadata = {
+            "completed_timestamp": 12_345.6,
+            "is_completed": True,
+            "measurement_exception": "Traceback...\nValueError: bad value\n",
+            "result_count": 40,
+            "setpoint_count": 100,
+            }
+
+        self.assertEqual(treeWidgets.format_complete_cell(metadata), "Failed")
+        self.assertEqual(treeWidgets.format_run_status(metadata), "Failed (40.00%)")
+        self.assertEqual(treeWidgets.complete_cell_sort_value(metadata), 40.0)
+
+    def test_completed_run_without_exception_still_uses_tick(self):
         self.assertEqual(
             treeWidgets.format_complete_cell({
                 "completed_timestamp": 12_345.6,
                 "is_completed": True,
-                "measurement_exception": "Traceback...\nValueError: bad value\n",
-                "result_count": 40,
-                "setpoint_count": 100,
                 }),
-            "✓"
+            "✓",
             )
+
+    def test_empty_measurement_exceptions_are_not_failures(self):
+        for exception in (None, "", " \n\t "):
+            with self.subTest(exception=exception):
+                metadata = {
+                    "completed_timestamp": 12_345.6,
+                    "is_completed": True,
+                    "measurement_exception": exception,
+                    }
+                self.assertFalse(treeWidgets.run_failed(metadata))
+                self.assertEqual(treeWidgets.format_complete_cell(metadata), "✓")
+
+    def test_exception_state_takes_precedence_over_completed_state(self):
+        base_metadata = {
+            "completed_timestamp": 12_345.6,
+            "is_completed": True,
+            }
+
+        self.assertEqual(
+            treeWidgets.format_complete_cell({
+                **base_metadata,
+                "measurement_exception": "KeyboardInterrupt",
+                }),
+            "Interrupted",
+            )
+        self.assertEqual(
+            treeWidgets.format_complete_cell({
+                **base_metadata,
+                "measurement_exception": "ValueError: bad value",
+                }),
+            "Failed",
+            )
+
+    def test_failed_run_tooltip_has_escaped_concise_exception(self):
+        metadata = {
+            "completed_timestamp": 12_345.6,
+            "is_completed": True,
+            "measurement_exception": (
+                "Traceback (most recent call last):\n"
+                "  internal implementation detail\n"
+                "ValueError: x < 2 & y > 1\n"
+                ),
+            "result_count": 40,
+            "setpoint_count": 100,
+            }
+
+        tooltip = treeWidgets.run_tooltip_text(metadata)
+        self.assertIn("Failed (40.00%)", tooltip)
+        self.assertIn("ValueError: x &lt; 2 &amp; y &gt; 1", tooltip)
+        self.assertNotIn("internal implementation detail", tooltip)
+
+        plain_text = treeWidgets.run_tooltip_plain_text(metadata)
+        self.assertIn("Status  Failed (40.00%)", plain_text)
+        self.assertIn("Exception ValueError: x < 2 & y > 1", plain_text)
+        self.assertNotIn("internal implementation detail", plain_text)
 
     def test_duration_uses_commas(self):
         self.assertEqual(
@@ -501,7 +568,7 @@ class RunListTooltipTestCase(unittest.TestCase):
 
             self.assertEqual(
                 [run_list.headerItem().text(col) for col in range(run_list.columnCount())],
-                ["ID", "Measurements", "Setpoints", "Started", "Complete", "Duration", "Size"]
+                ["ID", "Measurements", "Setpoints", "Started", "Status", "Duration", "Size"]
                 )
             self.assertIsInstance(
                 run_list.itemDelegateForColumn(2),
@@ -578,7 +645,8 @@ class RunListTooltipTestCase(unittest.TestCase):
                 )
             self.assertIn("Measure</td>", items["unfinished-guid"].toolTip(0))
             self.assertIn("(y)</td>", items["unfinished-guid"].toolTip(0))
-            self.assertNotIn("Complete", items["finished-guid"].toolTip(0))
+            self.assertIn("Status</td>", items["finished-guid"].toolTip(0))
+            self.assertIn("Complete</td>", items["finished-guid"].toolTip(0))
 
             run_list.sortItems(1, QtCore.Qt.SortOrder.DescendingOrder)
             self.assertEqual(
@@ -625,7 +693,7 @@ class RunListTooltipTestCase(unittest.TestCase):
             self.assertIs(run_list.topLevelItem(0), item)
             self.assertEqual(updated[1]["result_count"], 10)
             self.assertEqual(item.text(run_list.cols.index("Setpoints")), "10")
-            self.assertEqual(item.text(run_list.cols.index("Complete")), "✓")
+            self.assertEqual(item.text(run_list.cols.index("Status")), "✓")
             self.assertEqual(item.text(run_list.cols.index("Duration")), "10.0 s")
             self.assertEqual(item.text(run_list.cols.index("Size")), "2.0 KB")
             self.assertEqual(run_list.watching, [])
@@ -713,11 +781,11 @@ class RunListTooltipTestCase(unittest.TestCase):
             updated_runs = run_list.checkWatching()
 
             self.assertEqual(
-                item.text(run_list.cols.index("Complete")),
-                "40.00%"
+                item.text(run_list.cols.index("Status")),
+                "Interrupted"
                 )
             self.assertEqual(
-                item.data(run_list.cols.index("Complete"), QtCore.Qt.ItemDataRole.UserRole),
+                item.data(run_list.cols.index("Status"), QtCore.Qt.ItemDataRole.UserRole),
                 40.0
                 )
             self.assertEqual(run_list.watching, [])
@@ -725,6 +793,56 @@ class RunListTooltipTestCase(unittest.TestCase):
                 updated_runs[1]["measurement_exception"],
                 "Traceback...\nKeyboardInterrupt\n"
                 )
+        finally:
+            treeWidgets.isfile = old_isfile
+            treeWidgets.get_run_status = old_get_run_status
+
+    def test_check_watching_updates_finished_failed_run(self):
+        old_isfile = treeWidgets.isfile
+        old_get_run_status = treeWidgets.get_run_status
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": None,
+                    "is_completed": False,
+                    "guid": "failed-guid",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 10,
+                    "setpoint_count": 100,
+                    "expected_results": 100,
+                    }
+                })
+            item = run_list.topLevelItem(0)
+
+            treeWidgets.get_run_status = lambda guid: {
+                "completed_timestamp": 120.0,
+                "is_completed": True,
+                "result_count": 40,
+                "measurement_exception": "Traceback...\nValueError: bad <value>\n",
+                "database_modified_timestamp": 120.0,
+                }
+
+            updated_runs = run_list.checkWatching()
+
+            status_col = run_list.cols.index("Status")
+            self.assertEqual(item.text(status_col), "Failed")
+            self.assertEqual(
+                item.data(status_col, QtCore.Qt.ItemDataRole.UserRole),
+                40.0,
+                )
+            self.assertEqual(run_list.watching, [])
+            self.assertEqual(
+                updated_runs[1]["measurement_exception"],
+                "Traceback...\nValueError: bad <value>\n",
+                )
+            self.assertIn("Status</td>", item.toolTip(0))
+            self.assertIn("Failed (40.00%)", item.toolTip(0))
+            self.assertIn("ValueError: bad &lt;value&gt;", item.toolTip(0))
         finally:
             treeWidgets.isfile = old_isfile
             treeWidgets.get_run_status = old_get_run_status


### PR DESCRIPTION
## What changed

- classify non-empty measurement exceptions as `Interrupted` for `KeyboardInterrupt` and `Failed` otherwise, before considering completion metadata
- rename the run-list `Complete` column to `Status` and keep compact textual cell values with progress-backed sorting
- add detailed status and a bounded, HTML-escaped final exception line to run tooltips
- keep initial loading, background metadata refreshes, and live watching updates on the same formatting path
- add regression coverage for status precedence, empty exceptions, sorting, tooltips, live transitions, and the renamed header

## Why

Completed QCoDeS runs with non-KeyboardInterrupt measurement exceptions were shown with the successful completion tick because completion metadata was checked without recognizing general measurement failures. This misrepresented failed measurements as successful.

## Impact

Failed and interrupted runs are now readable as text in the run table, while successful and unfinished runs retain their existing displays. Monitoring, auto-plot behavior, `run_is_complete`, and QCoDeS completion metadata are unchanged.

## Validation

- `.venv-mac/bin/python -m pytest tests/widgets/test_run_list.py` — 31 passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m pytest` — 401 passed
- `.venv-mac/bin/python -m qplot` — GUI initialized successfully; manually stopped after smoke check