### PR TITLE
Prepare 1.5.0-b2 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,63 @@ installation commands and release validation, see `docs/distribution.md`.
 
 No changes yet.
 
+## 1.5.0-b2 - 2026-08-01
+
+### Highlights
+
+- Database changes, plot opening, and background plot refreshes now preserve
+  the last successfully committed state when newer work fails or becomes stale.
+- The run table now distinguishes successful, interrupted, failed, and still
+  unfinished measurements.
+- Existing QCoDeS and last-used databases now populate their run data correctly
+  when qPlot starts.
+
+### Changed
+
+- Database switching now keeps the committed database visible and active until
+  the requested database has loaded successfully.
+- Dataset identity now includes database provenance as well as GUID, allowing
+  copied databases that contain matching GUIDs to coexist safely.
+
+### Fixed
+
+- Prevent cancellation, failure, and stale database-load callbacks from
+  replacing the committed database.
+- Retry transient cloud-provider timeout and cancellation errors while a
+  database placeholder is being downloaded, within the existing overall load
+  timeout.
+- Prevent plot-opening failures from closing selected, cached, or
+  already-published dataset connections; transient connections are still
+  cleaned up when construction fails.
+- Prevent superseded plot workers from replacing newer plot data or showing
+  stale successes, failures, status messages, or error dialogs.
+- Show completed keyboard interruptions as interrupted and completed
+  measurement exceptions as failed, while retaining distinct successful and
+  unfinished run states.
+- Load run data for an explicit startup database, a valid last-used database,
+  or an existing QCoDeS database through the normal startup loading path.
+
+### Known Limitations
+
+- Derivative operations currently retain the original displayed labels and
+  units.
+- Operation validation and failure handling can skip invalid operations or
+  leave a partially applied operation pipeline.
+- Large-dataset performance has not yet been comprehensively benchmarked.
+- Restore Defaults in Preferences applies immediately, so Cancel does not
+  restore the previous preferences.
+- `qplot-cfg` does not correctly support every empty-string or empty-list
+  update.
+- Closed plots may occasionally remain in Add to Plot choices until the list is
+  refreshed.
+
 ## 1.5.0-b1 - 2026-07-31
 
 
 ### Highlights
 
-- Bugs identified by GPT-5.6 Sol have all been fixed.
+- This beta introduced spatial heatmap aggregation and geometry improvements,
+  together with targeted database, plot-opening, operation, and trace fixes.
 - As a result, thumbnails and previews now work properly.
 - Handling large datasets remains slow and I have not benchmarked this against Ben Wordsworth's original version.
 - I have also not tested this version thoroughly, which is why it's still a beta.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ automatically when qPlot is installed.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b1`; it is documented below but is not used for the default install.
+is `1.5.0-b2`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -44,7 +44,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b1
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b2
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,13 +27,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.0-b1`. The package metadata uses the PEP 440 normal
-form `1.5.0b1`; the GitHub release tag should be `v1.5.0-b1`.
+The current beta is `1.5.0-b2`. The package metadata uses the PEP 440 normal
+form `1.5.0b2`; the GitHub release tag should be `v1.5.0-b2`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b1
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b2
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b1`, even if the Git tag includes a separator,
-   such as `v1.5.0-b1`.
+   package form, such as `1.5.0b2`, even if the Git tag includes a separator,
+   such as `v1.5.0-b2`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b1"
+version = "1.5.0b2"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]


### PR DESCRIPTION
## Summary

Prepare qPlot 1.5.0-b2 as the next beta release. This updates package metadata, beta installation documentation, distribution examples, and the changelog while keeping 1.4.0 as the default stable install.

## User-facing changes

- Database switching keeps the committed database active until the replacement loads successfully; cancelled, failed, and stale callbacks cannot replace it.
- Dataset identity includes database provenance as well as GUID, so copied databases with matching GUIDs can coexist.
- Plot-opening failures no longer close selected, cached, or already-published dataset connections.
- Superseded plot workers cannot overwrite newer plot data, statuses, errors, or dialogs.
- The run table distinguishes successful, interrupted, failed, and unfinished measurements.
- Existing QCoDeS and last-used databases populate their run data correctly at startup.
- Transient cloud-provider timeout/cancellation errors are retried within the existing overall database-load timeout.

## Known limitations

- Derivative operations retain the original displayed labels and units.
- Operation validation/failure handling can skip invalid operations or leave a partially applied operation pipeline.
- Large-dataset performance has not been comprehensively benchmarked.
- Restore Defaults in Preferences applies immediately, so Cancel does not restore the previous preferences.
- `qplot-cfg` does not correctly support every empty-string or empty-list update.
- Closed plots may occasionally remain in Add to Plot choices until the list is refreshed.

## Validation

- [x] `.venv-mac/bin/python -m ruff check .` — passed: all checks passed.
- [x] `.venv-mac/bin/python -m mypy` — passed: no issues found in 60 source files.
- [x] `.venv-mac/bin/python -m pytest` — passed: 411 tests passed in 27.75 s.
- [x] `.venv-mac/bin/python -m build` — passed: built `qplot-1.5.0b2.tar.gz` and `qplot-1.5.0b2-py3-none-any.whl`.
- [x] `.venv-mac/bin/python -m twine check dist/*` — passed for the b2 wheel and sdist (and the pre-existing a1 artifacts).
- [x] Clean-install wheel smoke test — passed in a fresh temporary virtual environment with no editable install or source-tree `PYTHONPATH`: import succeeded; `qplot.__version__` and `qplot-cfg -version` both reported `1.5.0b2`; packaged `qplot/configuration/config_schema.json` loaded and parsed.
- [x] Runtime smoke: `.venv-mac/bin/python -m qplot` — passed: startup logged qPlot 1.5.0b2, the saved database loaded 29 runs in 0.25 s, and the event loop exited cleanly with code 0. macOS denied automated window-title/screenshot access, so visual window inspection was not independently captured.
- [x] `git diff --check` — passed.
- [x] Active-version consistency search — only the historical `1.5.0-b1` changelog heading remains; current metadata and installation commands use b2.

Exact clean-install wheel: `qplot-1.5.0b2-py3-none-any.whl`

Wheel SHA-256: `cb132aa1eb68138cc40357d9cc56c4e0fe0e78dbaa76c46d81cbc34ab75761dc`

## Post-merge release checklist

- [ ] Create and push tag `v1.5.0-b2` from the reviewed merge commit.
- [ ] Create the GitHub prerelease from `v1.5.0-b2` using the reviewed release notes.
- [ ] Confirm the tagged install path works.

No tag or GitHub release has been created, and nothing has been published to PyPI.