### PR TITLE
Fix operation pipeline correctness

### DIFF
--- a/src/qplot/tools/operation_registry.py
+++ b/src/qplot/tools/operation_registry.py
@@ -22,6 +22,27 @@ class OperationSpec:
     func: Callable
     input_type: object
     default: object = ""
+    derivative_axis: str | None = None
+
+
+@dataclass(frozen=True)
+class OperationCall:
+    """A configured operation and the metadata needed after it succeeds."""
+
+    name: str
+    func: Callable
+    derivative_axis: str | None = None
+
+    def __call__(self, data):
+        return self.func(data)
+
+
+class OperationValidationError(ValueError):
+    """Raised when an enabled operation has missing or invalid input."""
+
+
+class OperationExecutionError(RuntimeError):
+    """Raised when an operation pipeline cannot be completed atomically."""
 
 
 COMMON_OPERATION_SPECS = (
@@ -31,13 +52,28 @@ COMMON_OPERATION_SPECS = (
 
 PLOT_OPERATION_SPECS = {
     "plot1d": (
-        OperationSpec("dy/dx", lambda data: differentiate("x", data), None),
+        OperationSpec(
+            "dy/dx",
+            lambda data: differentiate("x", data),
+            None,
+            derivative_axis="x",
+            ),
         ),
     "plot2d": (
         OperationSpec("Subtract Row Mean", lambda data: subtract_mean("x", data), None),
         OperationSpec("Subtract Column Mean", lambda data: subtract_mean("y", data), None),
-        OperationSpec("dz/dx", lambda data: differentiate("x", data), None),
-        OperationSpec("dz/dy", lambda data: differentiate("y", data), None),
+        OperationSpec(
+            "dz/dx",
+            lambda data: differentiate("x", data),
+            None,
+            derivative_axis="x",
+            ),
+        OperationSpec(
+            "dz/dy",
+            lambda data: differentiate("y", data),
+            None,
+            derivative_axis="y",
+            ),
         OperationSpec(
             "Fill Below",
             lambda value, data: fill_heatmap("below", data, max_depth=value),
@@ -54,8 +90,18 @@ PLOT_OPERATION_SPECS = {
     "sweeper": (
         OperationSpec("Subtract Cut Mean", lambda data: subtract_mean("x", data), None),
         OperationSpec("Subtract Fixed Mean", lambda data: subtract_mean("y", data), None),
-        OperationSpec("Differentiate Cut", lambda data: differentiate("x", data), None),
-        OperationSpec("Differentiate Fixed", lambda data: differentiate("y", data), None),
+        OperationSpec(
+            "Differentiate Cut",
+            lambda data: differentiate("x", data),
+            None,
+            derivative_axis="x",
+            ),
+        OperationSpec(
+            "Differentiate Fixed",
+            lambda data: differentiate("y", data),
+            None,
+            derivative_axis="y",
+            ),
         ),
     }
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -1,4 +1,5 @@
 import math
+from copy import copy
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -20,6 +21,7 @@ from qplot.datahandling.readonly import (
     sqlite_read_only_connection,
 )
 from qplot.diagnostics import log_exception
+from qplot.tools.operation_registry import OperationExecutionError
 
 from . import data2matrix
 from .heatmap_geometry import canonicalize_heatmap_data
@@ -89,6 +91,7 @@ class loader(QtCore.QRunnable):
         self.cache = cache
         self.table_name = cache_table_name(cache)
         self.param = param
+        self.display_param = copy(param)
         self.param_dict = param_dict
         
         self.axes_dict = axes
@@ -192,22 +195,23 @@ class loader(QtCore.QRunnable):
             self.emitter.finished.emit(False) # False: Failed
             return
 
-        # Run additional operations
-        results = self.do_operations()
-
-        # Update based on operations
-        if results is not None:
-            (
-                self.axis_data["x"],
-                self.axis_data["y"]
-            ) = results[:2]
-            if hasattr(self, "dataGrid"):
-                self.dataGrid = results[2]
-
         try:
+            # Operations are an ordered, atomic pipeline. Large heatmaps are
+            # reduced for display only after this pipeline has completed.
+            results = self.do_operations()
+            if results is not None:
+                (
+                    self.axis_data["x"],
+                    self.axis_data["y"]
+                ) = results[:2]
+                if hasattr(self, "dataGrid"):
+                    self.dataGrid = results[2]
+                self._apply_operation_metadata()
+
+            self._aggregate_operated_heatmap_if_needed()
             self._canonicalize_heatmap()
         except Exception as err:
-            log_exception("Invalid heatmap geometry", err, __name__)
+            log_exception("Plot processing failed", err, __name__)
             self.emitter.errorOccurred.emit(err)
             self.emitter.finished.emit(False)
             return
@@ -239,6 +243,12 @@ class loader(QtCore.QRunnable):
 
     def _should_use_sql_heatmap(self):
         if len(getattr(self.param, "depends_on_", ())) <= 1:
+            return False
+
+        # SQL heatmap loading aggregates before Python operations. When the
+        # user has selected operations, preserve their semantics by loading
+        # the raw grid and reducing it only after the pipeline succeeds.
+        if getattr(self, "operations", None):
             return False
 
         if self.force_sql_heatmap:
@@ -691,7 +701,15 @@ class loader(QtCore.QRunnable):
         return x_data[finite], y_data[finite], z_data[finite]
 
 
-    def _heatmap_grid_from_arrays(self, x_data, y_data, z_data):
+    def _heatmap_grid_from_arrays(
+            self,
+            x_data,
+            y_data,
+            z_data,
+            *,
+            max_cells=MAX_SQL_HEATMAP_GRID_CELLS,
+            ):
+        max_cells = max(1, int(max_cells))
         if z_data.size == 0:
             self._heatmap_grid_info = {
                 "unique_x_count": 0,
@@ -701,7 +719,7 @@ class loader(QtCore.QRunnable):
                 "grid_rows": 0,
                 "grid_cell_count": 0,
                 "grid_binned": False,
-                "grid_cell_limit": MAX_SQL_HEATMAP_GRID_CELLS,
+                "grid_cell_limit": max_cells,
                 "empty_bins_filled": False,
                 }
             return (
@@ -736,7 +754,7 @@ class loader(QtCore.QRunnable):
 
         if (
                 not getattr(self, "sampled_heatmap_source", False)
-                and exact_cells <= MAX_SQL_HEATMAP_GRID_CELLS
+                and exact_cells <= max_cells
                 ):
             x_axis, y_axis, data_grid = self._unique_heatmap_grid(
                 x_data,
@@ -756,12 +774,11 @@ class loader(QtCore.QRunnable):
                 "grid_rows": int(unique_y.size),
                 "grid_cell_count": int(exact_cells),
                 "grid_binned": False,
-                "grid_cell_limit": MAX_SQL_HEATMAP_GRID_CELLS,
+                "grid_cell_limit": max_cells,
                 "empty_bins_filled": False,
                 }
             return x_axis, y_axis, data_grid
 
-        max_cells = MAX_SQL_HEATMAP_GRID_CELLS
         fill_empty = False
         if getattr(self, "sampled_heatmap_source", False):
             max_cells = min(
@@ -1236,21 +1253,19 @@ class loader(QtCore.QRunnable):
         """
         Runs through all functions in self.operations and performs those on the
         data.
-        Copies data to allow a fall
+        Work is performed on copies so a failure cannot return partial output.
 
         Returns
         -------
         data_dict["x"], data_dict["y"], data_dict["z"] : np.ndarray
             The updated data after all operations have been performed
         None : NoneType
-            No operations to be perform or all failed.
+            No operations to perform.
     
         """
         operations = self.operations
         if len(operations) == 0:
             return None
-        
-        one_succeeded = False
         
         data_dict = {
             "x" : self.axis_data["x"].copy(),
@@ -1258,21 +1273,109 @@ class loader(QtCore.QRunnable):
             "z" : self.dataGrid.copy() if hasattr(self, "dataGrid") else None # Only give dataGrid if it exists
             }
         
-        for func in operations:
+        for operation in operations:
             try:
-                results = func(data_dict)
+                results = operation(data_dict)
                 for key in results.keys():
                     data_dict[key] = results[key]
-                one_succeeded = True
-                
             except Exception as err:
-                log_exception("Plot operation failed", err, __name__)
-                self.emitter.errorOccurred.emit(err)
-                
-        if one_succeeded:
-            return data_dict["x"], data_dict["y"], data_dict["z"]
-        else: # If all failed, go back to before operations data
-            return None
+                name = getattr(operation, "name", None)
+                description = f' "{name}"' if name else ""
+                raise OperationExecutionError(
+                    f"Operation{description} failed: {err}"
+                    ) from err
+
+        return data_dict["x"], data_dict["y"], data_dict["z"]
+
+
+    def _apply_operation_metadata(self):
+        """Update the dependent-variable label and unit after derivatives."""
+
+        for operation in self.operations:
+            axis_name = getattr(operation, "derivative_axis", None)
+            if axis_name not in ("x", "y"):
+                continue
+
+            axis_param = self.axis_param[axis_name]
+            value_label = (
+                getattr(self.display_param, "label", "")
+                or getattr(self.display_param, "name", "")
+                )
+            axis_label = (
+                getattr(axis_param, "label", "")
+                or getattr(axis_param, "name", axis_name)
+                )
+            self.display_param.label = f"d({value_label})/d({axis_label})"
+
+            value_unit = getattr(self.display_param, "unit", "")
+            axis_unit = getattr(axis_param, "unit", "")
+            if value_unit and axis_unit:
+                self.display_param.unit = f"{value_unit}/{axis_unit}"
+            elif axis_unit:
+                self.display_param.unit = f"1/{axis_unit}"
+
+        if len(getattr(self.param, "depends_on_", ())) == 1:
+            self.axis_param["y"] = self.display_param
+
+
+    def _aggregate_operated_heatmap_if_needed(self):
+        """Reduce an operated raw heatmap to the configured display limit."""
+
+        if not self.operations or not hasattr(self, "dataGrid"):
+            return
+
+        data_grid = np.asarray(self.dataGrid, dtype=float)
+        if data_grid.size <= self.max_full_heatmap_points:
+            return
+
+        x_axis = np.asarray(self.axis_data["x"], dtype=float)
+        y_axis = np.asarray(self.axis_data["y"], dtype=float)
+        if data_grid.shape != (y_axis.size, x_axis.size):
+            raise ValueError(
+                "Operated heatmap dimensions do not match its coordinate axes."
+                )
+
+        source_rows, source_columns = data_grid.shape
+        self.heatmap_source_grid_shape = (source_rows, source_columns)
+        self.heatmap_source_axis_ranges = {
+            "x": (float(np.nanmin(x_axis)), float(np.nanmax(x_axis))),
+            "y": (float(np.nanmin(y_axis)), float(np.nanmax(y_axis))),
+            }
+        x_data = np.tile(x_axis, y_axis.size)
+        y_data = np.repeat(y_axis, x_axis.size)
+        z_data = data_grid.reshape(-1)
+        finite = np.isfinite(x_data) & np.isfinite(y_data) & np.isfinite(z_data)
+        x_data = x_data[finite]
+        y_data = y_data[finite]
+        z_data = z_data[finite]
+
+        max_cells = min(
+            self.max_full_heatmap_points,
+            MAX_SQL_HEATMAP_GRID_CELLS,
+            )
+        x_axis, y_axis, data_grid = self._heatmap_grid_from_arrays(
+            x_data,
+            y_data,
+            z_data,
+            max_cells=max_cells,
+            )
+        source_count = int(source_rows * source_columns)
+        self._heatmap_aggregated_source_rows = int(z_data.size)
+        self._heatmap_source_info = {
+            "row_count": source_count,
+            "estimated_range_rows": source_count,
+            "sampled": False,
+            "aggregated": True,
+            "sample_limit": None,
+            "sample_stride": None,
+            "strategy": "operations, then spatial mean",
+            "axis_ranges": self.heatmap_source_axis_ranges,
+            }
+        self.axis_data["x"] = x_axis
+        self.axis_data["y"] = y_axis
+        self.dataGrid = data_grid
+        self.loaded_point_count = int(data_grid.size)
+        self.heatmap_downsample_info = self._heatmap_downsample_info()
 
         
 class _emitter(QtCore.QObject):

--- a/src/qplot/windows/_plot2d_colorbar.py
+++ b/src/qplot/windows/_plot2d_colorbar.py
@@ -150,7 +150,7 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
         return scale
 
     def _set_colorbar_scaled_label(self, bar, scale):
-        param = self.__dict__.get("param")
+        param = self.__dict__.get("display_param", self.__dict__.get("param"))
         if param is None or not hasattr(bar, "setLabel"):
             return
 

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -12,6 +12,7 @@ from qplot.datahandling.qcodes_cache import (
 )
 from qplot.diagnostics import log_exception
 from qplot.tools import loader
+from qplot.tools.operation_registry import OperationValidationError
 
 if TYPE_CHECKING:
     class _PlotRefreshBase(qtw.QMainWindow):
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
         axis_param: dict[str, Any]
         config: Any
         dataGrid: Any
+        display_param: Any
         ds: Any
         end_wait: Any
         last_ds_len: int
@@ -72,7 +74,7 @@ class PlotRefreshMixin(_PlotRefreshBase):
             heatmap_axis_ranges: dict[str, tuple[float, float]] | None = None,
             heatmap_full_axis_ranges: dict[str, tuple[float, float]] | None = None,
             status_message: str | None = None,
-            ) -> None:
+            ) -> bool:
         """
         Produces a worker for loading/refreshing the dataset.
         Then adds the worker to the threadPool queue to work.
@@ -87,13 +89,25 @@ class PlotRefreshMixin(_PlotRefreshBase):
             worker has finished its task. The default is False.
 
         """
+        try:
+            operations = self.oper_widget.get_data()
+        except OperationValidationError as error:
+            message = str(error)
+            self.show_status(message, 10_000)
+            self.show_plot_state(
+                "Operations not applied",
+                message,
+                kind="error",
+                )
+            return False
+
         worker: Any = loader(
             self.ds.cache,
             self.param,
             self.param_dict,
             self.axis_options,
             read_data=True,
-            operations=self.oper_widget.get_data(),
+            operations=operations,
             force_sql_heatmap=force_sql_heatmap,
             max_full_heatmap_points=self.config.get(
                 "runtime_settings.max_full_heatmap_points"
@@ -148,6 +162,8 @@ class PlotRefreshMixin(_PlotRefreshBase):
         if wait_on_thread:
             hold_up.exec()  # The actual place the code waits for self.end_wait.emit
             self.end_wait.disconnect(hold_up.quit)
+
+        return True
 
 
     @QtCore.pyqtSlot()
@@ -262,6 +278,7 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 "x": worker.axis_param["x"],
                 "y": worker.axis_param["y"],
                 }
+            self.display_param = getattr(worker, "display_param", self.param)
 
             # For 2d plots
             if hasattr(worker, "dataGrid"):

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -139,7 +139,7 @@ class sweeper(plotWidget):
         self.fixed_indep_data = self.axis_data["y"]
         
         # Get correct row and param for y data
-        self.axis_param["y"] = self.param
+        self.axis_param["y"] = getattr(self, "display_param", self.param)
         
         # Set-up fixed axis picker and slide
         # Match range to index of fixed param data

--- a/src/qplot/windows/_widgets/operations.py
+++ b/src/qplot/windows/_widgets/operations.py
@@ -9,7 +9,11 @@ from PyQt6 import (
     QtWidgets as qtw,
 )
 
-from qplot.tools.operation_registry import operation_specs_for
+from qplot.tools.operation_registry import (
+    OperationCall,
+    OperationValidationError,
+    operation_specs_for,
+)
 
 from .dropbox import expandingComboBox
 
@@ -113,6 +117,7 @@ class operations_options_base(qtw.QWidget):
         func: OperationFunc,
         input_type: OperationInputType,
         default: object = "",
+        derivative_axis: str | None = None,
         ) -> None:
         """
         Adds an option to the list_options with a tickbox.
@@ -141,6 +146,7 @@ class operations_options_base(qtw.QWidget):
     
         # create item to add to active box. This data is fetched by self.get_data()
         row.operation_row = rowItem(name, func, input_type, default=default)
+        row.operation_row.derivative_axis = derivative_axis
         row.input.stateChanged.connect(lambda state: 
                     self.add_or_remove_operation(state, row.operation_row)
                     )
@@ -190,6 +196,7 @@ class operations_options_base(qtw.QWidget):
                 spec.func,
                 cast(OperationInputType, spec.input_type),
                 spec.default,
+                spec.derivative_axis,
                 )
         self.list_options.adjustSize()
             
@@ -201,7 +208,7 @@ class operations_options_base(qtw.QWidget):
             item.input.setChecked(False)
             
     
-    def get_data(self) -> list[OperationFunc]:
+    def get_data(self) -> list[OperationCall]:
         """
         Returns the function of the items in the active operation listWidget
         (self.list_order) from top to bottom. Also adds the user input to the
@@ -213,7 +220,7 @@ class operations_options_base(qtw.QWidget):
             List of functions to be performed on the data during refresh.
 
         """
-        operations: list[OperationFunc] = []
+        operations: list[OperationCall] = []
         for i in range(self.list_order.count()):
             item = cast(rowItem, self.list_order.item(i))
             if item.isHidden():
@@ -225,26 +232,36 @@ class operations_options_base(qtw.QWidget):
                     and input_widget.text()
                     and not input_widget.hasAcceptableInput()
                     ):
-                continue
+                raise OperationValidationError(
+                    f'{item.label}: enter a valid value.'
+                    )
 
             try:
                 output = item.output()
-            except (TypeError, ValueError, OverflowError):
-                continue
+            except (TypeError, ValueError, OverflowError) as error:
+                raise OperationValidationError(
+                    f'{item.label}: enter a valid value.'
+                    ) from error
 
             if output == "": # Data not entered
                 if hasattr(input_widget, "placeholderText"):
                     output = cast(Any, input_widget).placeholderText()
                     if output == "": # still blank
-                        continue
+                        raise OperationValidationError(
+                            f'{item.label}: a value is required.'
+                            )
                     
                     if isinstance(item.input_type, type):
                         try:
                             output = item.input_type(output)
-                        except (TypeError, ValueError, OverflowError):
-                            continue
+                        except (TypeError, ValueError, OverflowError) as error:
+                            raise OperationValidationError(
+                                f'{item.label}: enter a valid value.'
+                                ) from error
                 else:
-                    continue
+                    raise OperationValidationError(
+                        f'{item.label}: a value is required.'
+                        )
             
             if output is None: # No input requried
                 func = item.func
@@ -252,7 +269,11 @@ class operations_options_base(qtw.QWidget):
                 # Some weird internal python stuff causes issues with lambda in loops
                 func = func_with_input(item.func, output) 
                 
-            operations.append(func)
+            operations.append(OperationCall(
+                item.label,
+                func,
+                getattr(item, "derivative_axis", None),
+                ))
         return operations
  
     
@@ -311,6 +332,7 @@ class rowItem(qtw.QListWidgetItem):
         super().__init__()
         
         self.func: OperationFunc
+        self.derivative_axis: str | None = None
         if callable(func):
             self.func = func
         elif func is not None:

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -235,6 +235,9 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 else:
                     self._set_colorbar_levels(*self._colorbar_manual_levels)
 
+            # The dependent-variable label may have changed when an operation
+            # such as differentiation was added or removed.
+            self._sync_colorbar_axis_scaling()
             if autoLevels:
                 self.__dict__["_colorbar_manual_levels"] = None
                 self.scaleColorbar()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,6 +8,7 @@ import qplot.tools.worker as worker_module
 from qplot.configuration.scripts import try_as_num
 from qplot.tools.general import data2matrix
 from qplot.tools.heatmap_geometry import HeatmapGeometry
+from qplot.tools.operation_registry import OperationCall
 from qplot.tools.plot_tools import (
     differentiate,
     fill_heatmap,
@@ -554,18 +555,7 @@ class ToolFunctionTestCase(unittest.TestCase):
             ]),
         )
 
-    def test_worker_operations_continue_after_one_operation_fails(self):
-        class Signal:
-            def __init__(self):
-                self.values = []
-
-            def emit(self, value):
-                self.values.append(value)
-
-        class Emitter:
-            def __init__(self):
-                self.errorOccurred = Signal()
-
+    def test_worker_operation_pipeline_fails_atomically(self):
         def failing_operation(_data):
             raise ValueError("bad operation")
 
@@ -579,14 +569,67 @@ class ToolFunctionTestCase(unittest.TestCase):
             lambda data: {"y": data["y"] * 2},
             lambda data: {"x": data["x"] + 10},
             ]
-        worker.emitter = Emitter()
+        with self.assertRaisesRegex(RuntimeError, "bad operation"):
+            loader.do_operations(worker)
 
-        result = loader.do_operations(worker)
+        np.testing.assert_array_equal(worker.axis_data["x"], [1.0, 2.0])
+        np.testing.assert_array_equal(worker.axis_data["y"], [3.0, 4.0])
 
-        self.assertEqual(len(worker.emitter.errorOccurred.values), 1)
-        np.testing.assert_array_equal(result[0], np.array([11.0, 12.0]))
-        np.testing.assert_array_equal(result[1], np.array([6.0, 8.0]))
-        self.assertIsNone(result[2])
+    def test_large_heatmap_with_operations_does_not_aggregate_in_sql(self):
+        worker = self._sql_heatmap_worker(None)
+        worker.max_full_heatmap_points = 10
+        worker.operations = [lambda data: data]
+
+        self.assertFalse(loader._should_use_sql_heatmap(worker))
+
+    def test_derivative_operation_updates_dependent_label_and_unit(self):
+        class Param:
+            def __init__(self, name, label, unit, depends_on=()):
+                self.name = name
+                self.label = label
+                self.unit = unit
+                self.depends_on_ = depends_on
+
+        worker = loader.__new__(loader)
+        worker.param = Param("current", "Current", "A", ("gate",))
+        worker.display_param = Param("current", "Current", "A", ("gate",))
+        worker.axis_param = {
+            "x": Param("gate", "Gate voltage", "V"),
+            "y": worker.param,
+            }
+        worker.operations = [
+            OperationCall("dy/dx", lambda data: data, derivative_axis="x"),
+            ]
+
+        loader._apply_operation_metadata(worker)
+
+        self.assertEqual(worker.display_param.label, "d(Current)/d(Gate voltage)")
+        self.assertEqual(worker.display_param.unit, "A/V")
+        self.assertIs(worker.axis_param["y"], worker.display_param)
+
+    def test_operated_heatmap_is_aggregated_after_operations(self):
+        worker = self._sql_heatmap_worker(None)
+        worker.operations = [
+            lambda data: {"z": np.gradient(data["z"], data["x"], axis=1)},
+            ]
+        worker.axis_data = {
+            "x": np.array([0.0, 1.0, 2.0, 3.0]),
+            "y": np.array([0.0]),
+            }
+        worker.dataGrid = np.array([[0.0, 1.0, 4.0, 9.0]])
+        worker.max_full_heatmap_points = 2
+        worker.sampled_heatmap_source = False
+        worker.aggregated_heatmap_source = False
+
+        results = loader.do_operations(worker)
+        worker.dataGrid = results[2]
+        loader._aggregate_operated_heatmap_if_needed(worker)
+
+        np.testing.assert_allclose(worker.dataGrid, [[1.5, 4.5]])
+        self.assertEqual(
+            worker.heatmap_downsample_info["source_aggregation_strategy"],
+            "operations, then spatial mean",
+            )
 
     def test_subtract_mean_operates_by_axis(self):
         data = {

--- a/tests/widgets/test_operations.py
+++ b/tests/widgets/test_operations.py
@@ -4,7 +4,7 @@ import numpy as np
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
-from qplot.tools.operation_registry import operation_specs_for
+from qplot.tools.operation_registry import OperationValidationError, operation_specs_for
 from qplot.windows._widgets.operations import (
     operations_options_1d,
     operations_options_2d,
@@ -55,29 +55,20 @@ class OperationsPanelTestCase(unittest.TestCase):
         self.assertIn("Subtract Row Mean", names)
         self.assertIn("Fill Below", names)
 
-    def test_invalid_integer_operation_input_does_not_raise_from_callback(self):
+    def test_invalid_integer_operation_input_is_reported(self):
         main, widget = self._panel(operations_options_2d)
         try:
             option = self._option(widget, "Fill Below")
             option.input.setChecked(True)
             operation = option.operation_row
             operation.input.setText("1.5")
-            callback_errors = []
-            callback_results = []
-
-            def refresh_callback():
-                try:
-                    callback_results.append(widget.get_data())
-                except Exception as error:
-                    callback_errors.append(error)
-
-            widget.apply_but.clicked.connect(refresh_callback)
-            widget.apply_but.click()
-
             self.assertIsInstance(operation.input.validator(), QtGui.QIntValidator)
             self.assertFalse(operation.input.hasAcceptableInput())
-            self.assertEqual(callback_errors, [])
-            self.assertEqual(callback_results, [[]])
+            with self.assertRaisesRegex(
+                    OperationValidationError,
+                    "Fill Below: enter a valid value",
+                    ):
+                widget.get_data()
         finally:
             main.deleteLater()
 
@@ -91,6 +82,7 @@ class OperationsPanelTestCase(unittest.TestCase):
             operations = widget.get_data()
 
             self.assertEqual(len(operations), 1)
+            self.assertEqual(operations[0].name, "Limit Maximum")
             result = operations[0]({
                 "x": np.array([0.0, 1.0]),
                 "y": np.array([5.0, 15.0]),

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -1867,6 +1867,27 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
             )
         self.assertNotIn("(x", window.bar.getAxis("right").labelString())
 
+    def test_colorbar_label_uses_operation_display_parameter(self):
+        class SourceParam:
+            label = "Current"
+            unit = "A"
+
+        class DisplayParam:
+            label = "d(Current)/d(Gate voltage)"
+            unit = "A/V"
+
+        window = plot2d.__new__(plot2d)
+        window.param = SourceParam()
+        window.display_param = DisplayParam()
+        window.bar = pg.ColorBarItem(values=(-1.0, 1.0))
+
+        window._set_colorbar_tick_formatter()
+
+        self.assertIn(
+            "d(Current)/d(Gate voltage) (A/V)",
+            window.bar.getAxis("right").labelString(),
+            )
+
     def test_colorbar_label_reads_downwards(self):
         class Param:
             label = "Gate v2"

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -6,6 +6,7 @@ import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
+from qplot.tools.operation_registry import OperationValidationError
 from qplot.windows import _plot_refresh as plot_refresh_module
 from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plot_state import PlotStateOverlay
@@ -75,6 +76,26 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.load_calls, ["load"])
         self.assertEqual(window.last_ds_len, 10)
         self.assertEqual(window.restart_intervals, [0.2])
+
+    def test_invalid_operation_input_stops_load_with_visible_feedback(self):
+        class Operations:
+            def get_data(self):
+                raise OperationValidationError("Fill Below: enter a valid value.")
+
+        window = plotWidget.__new__(plotWidget)
+        window.oper_widget = Operations()
+        window.statuses = []
+        window.plot_states = []
+        window.show_status = lambda *args: window.statuses.append(args)
+        window.show_plot_state = lambda *args, **kwargs: window.plot_states.append(
+            (args, kwargs)
+            )
+
+        result = plotWidget.load_data(window)
+
+        self.assertFalse(result)
+        self.assertIn("Fill Below", window.statuses[-1][0])
+        self.assertEqual(window.plot_states[-1][0][0], "Operations not applied")
 
     def test_load_data_uses_sampled_sql_and_wires_originating_worker(self):
         class Signal:


### PR DESCRIPTION
## Changes

- report invalid or missing operation inputs instead of silently dropping them
- make ordered operation pipelines atomic so failures cannot produce partial output
- update derivative labels and units on plot axes and heatmap colorbars
- apply large-heatmap operations to raw data before spatial aggregation

## Why

The beta could silently omit invalid operations, continue after processing failures, display stale physical units after differentiation, and aggregate large heatmaps before applying the requested operation order.

## Impact

Operation failures now leave the existing plot intact and show an actionable error. Operated large heatmaps may temporarily use more memory because correctness requires loading the raw grid before reducing it for display.

## Root cause

UI validation used `continue` for invalid rows, worker exceptions were caught per operation, display metadata was not carried through processing, and the direct SQL heatmap path aggregated before Python operations.

## Checks

- `.venv-mac/bin/python -m pytest -q` — 416 passed, 5 subtests passed
- `.venv-mac/bin/python -m ruff check .`
- targeted mypy checks for changed typed modules
- `.venv-mac/bin/python -m pip check`
- launched `.venv-mac/bin/python -m qplot` successfully