### PR TITLE
Fix refresh, preferences, and stale UI state

### DIFF
--- a/src/qplot/configuration/config.py
+++ b/src/qplot/configuration/config.py
@@ -149,38 +149,43 @@ class config:
             Either due to incorrect typing or trying to add a new value.
 
         """
-        keys = key.split(".")
+        self.update_many({key: value})
 
-        # Create copy to prevent unwanted changes to file
-        config = deepcopy(self.config)
 
-        target = config
-        for part in keys[:-1]:
-            try:
-                target = target[part]
-            except KeyError as err:
+    def update_many(self, values):
+        """Validate and persist several values as one configuration update."""
+
+        updated_config = deepcopy(self.config)
+        for key, value in values.items():
+            keys = key.split(".")
+            target = updated_config
+            for part in keys[:-1]:
+                try:
+                    target = target[part]
+                except KeyError as err:
+                    raise KeyError(
+                        f"Key: {key}, not found. Please ensure you use a dot (.) seperated key"
+                    ) from err
+
+                if not isinstance(target, dict):
+                    raise KeyError(
+                        f"Key: {key}, cannot be updated because {part} is not a section"
+                    )
+
+            if keys[-1] not in target:
                 raise KeyError(
                     f"Key: {key}, not found. Please ensure you use a dot (.) seperated key"
-                ) from err
-
-            if not isinstance(target, dict):
-                raise KeyError(
-                    f"Key: {key}, cannot be updated because {part} is not a section"
                 )
+            target[keys[-1]] = value
 
-        if keys[-1] not in target:
-            raise KeyError(
-                f"Key: {key}, not found. Please ensure you use a dot (.) seperated key"
-            )
-
-        target[keys[-1]] = value
-        
-        # Check update is allowed by schema
-        jsonschema.validate(config, self.schema)
-        
-        # Update config file
-        self.config = config
-        self.save_config(self.default_file)
+        jsonschema.validate(updated_config, self.schema)
+        previous_config = self.config
+        self.config = updated_config
+        try:
+            self.save_config(self.default_file)
+        except Exception:
+            self.config = previous_config
+            raise
     
     
     def load_config(self, path: str):

--- a/src/qplot/configuration/scripts.py
+++ b/src/qplot/configuration/scripts.py
@@ -115,10 +115,13 @@ class sysHandle:
         self.config.get(key)
 
         convrt_value: object
-        if value[0] == "[" or value[0] == "(":
-            convrt_value = value[1:-1].split(",")
-            for itr in range(len(convrt_value)):
-                convrt_value[itr] = try_as_num(convrt_value[itr])
+        if value.startswith(("[", "(")):
+            list_value = value[1:-1].strip()
+            convrt_value = (
+                []
+                if not list_value
+                else [try_as_num(item) for item in list_value.split(",")]
+                )
         else:
             if value.lower() == "true":
                 convrt_value = True

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -300,15 +300,19 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             Updates internal save of plots which can be added.
 
         """
-        if wins:
+        if wins is not None:
             self.mergable = wins
         
         # Only add options which are not already being plotted
-        if self.option_boxes and self.mergable:
+        if self.option_boxes:
             box_texts = [box.option_box.currentText() for box in self.option_boxes]
+            available = [
+                item.label for item in self.mergable
+                if item.label not in box_texts
+                ]
             for box in self.option_boxes:
                 if box.option_box.isEnabled():
-                    self.option_boxes[-1].reset_box([item.label for item in self.mergable if item.label not in box_texts])
+                    box.reset_box(available)
 
 
     def refresh_secondary_lines(self) -> None:

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -101,6 +101,7 @@ class PlotRefreshMixin(_PlotRefreshBase):
             heatmap_axis_ranges=heatmap_axis_ranges,
             heatmap_full_axis_ranges=heatmap_full_axis_ranges,
             )
+        worker.dataset_length_at_start = self.ds.number_of_results
 
         use_sql_heatmap = force_sql_heatmap
         if not use_sql_heatmap and not cache_is_live(self.ds.cache):
@@ -165,7 +166,6 @@ class PlotRefreshMixin(_PlotRefreshBase):
         """
         self.monitor.stop()
         retry = False
-        skipped_busy_worker = False
         current_ds_len = self.ds.number_of_results
 
         try:
@@ -179,17 +179,12 @@ class PlotRefreshMixin(_PlotRefreshBase):
             if current_ds_len != self.last_ds_len or force:
                 if self.worker.running:  # No need to run if already updating
                     if not force:
-                        skipped_busy_worker = True
                         return
 
                 # The actual refresh line
                 self.load_data()
 
         finally:  # Ran after return or otherwise
-
-            # number_of_results Uses SQL check so can be used regardless of loader progress
-            if not skipped_busy_worker:
-                self.last_ds_len = current_ds_len
 
             # restart monitor
             if self.ds.running or retry:
@@ -298,6 +293,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
                     f"in {elapsed:.2f} seconds",
                     5000,
                     )
+            dataset_length = getattr(worker, "dataset_length_at_start", None)
+            if dataset_length is None:
+                dataset_length = self.ds.number_of_results
+            self.last_ds_len = dataset_length
             self.hide_plot_state()
             return True
 

--- a/src/qplot/windows/_preferences.py
+++ b/src/qplot/windows/_preferences.py
@@ -404,9 +404,13 @@ class PreferencesDialog(qtw.QDialog):
 
         """
         try:
-            for key, value in self.preference_values().items():
-                if self.config.get(key) != value:
-                    self.config.update(key, value)
+            changed_values = {
+                key: value
+                for key, value in self.preference_values().items()
+                if self.config.get(key) != value
+                }
+            if changed_values:
+                self.config.update_many(changed_values)
         except Exception as err:
             qtw.QMessageBox.critical(
                 self,
@@ -434,7 +438,7 @@ class PreferencesDialog(qtw.QDialog):
             return False
 
         self.set_preference_values(self.default_preference_values())
-        return self.apply_preferences()
+        return True
 
     def choose_default_load_path(self):
         current_path = self.defaultLoadPathEdit.text().strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 
+from jsonschema import ValidationError
 from PyQt6 import QtWidgets as qtw
 
 import qplot.__main__ as qplot_main
@@ -58,6 +59,18 @@ class TemporaryConfigTestCase(unittest.TestCase):
         with self.assertRaises(KeyError):
             cfg.update("user_preference.missing", True)
 
+    def test_config_update_many_is_atomic_when_a_value_is_invalid(self):
+        cfg = config()
+
+        with self.assertRaises(ValidationError):
+            cfg.update_many({
+                "user_preference.theme": "dark",
+                "GUI.preview_size": 1,
+                })
+
+        self.assertEqual(cfg.get("user_preference.theme"), "light")
+        self.assertEqual(config().get("user_preference.theme"), "light")
+
     def test_config_cli_set_value_converts_values(self):
         with redirect_stdout(io.StringIO()):
             sysHandle("-set_value", "user_preference.theme", "dark")
@@ -66,6 +79,8 @@ class TemporaryConfigTestCase(unittest.TestCase):
             sysHandle("-set_value", "user_preference.mouse_mode", "rect")
             sysHandle("-set_value", "GUI.main_frame_size", "[900, 600]")
             sysHandle("-set_value", "GUI.preview_size", "300")
+            sysHandle("-set_value", "file.default_load_path", "")
+            sysHandle("-set_value", "file.recent_file_paths", "[]")
 
         cfg = config()
         self.assertEqual(cfg.get("user_preference.theme"), "dark")
@@ -74,6 +89,8 @@ class TemporaryConfigTestCase(unittest.TestCase):
         self.assertEqual(cfg.get("user_preference.mouse_mode"), "rect")
         self.assertEqual(cfg.get("GUI.main_frame_size"), [900, 600])
         self.assertEqual(cfg.get("GUI.preview_size"), 300)
+        self.assertEqual(cfg.get("file.default_load_path"), "")
+        self.assertEqual(cfg.get("file.recent_file_paths"), [])
 
     def test_config_load_adds_new_defaults_to_existing_file(self):
         cfg = config()

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -27,6 +27,32 @@ class SnapToTraceTestCase(unittest.TestCase):
             _nearest_trace_sample([0.0, np.nan, np.inf], [np.nan, 1.0, 2.0], 0.0)
             )
 
+    def test_empty_window_update_clears_stale_add_to_plot_choices(self):
+        class Combo:
+            def isEnabled(self):
+                return True
+
+            def currentText(self):
+                return "closed plot"
+
+        class Box:
+            def __init__(self):
+                self.option_box = Combo()
+                self.resets = []
+
+            def reset_box(self, items):
+                self.resets.append(items)
+
+        host = Plot1DTraceMixin.__new__(Plot1DTraceMixin)
+        box = Box()
+        host.mergable = [object()]
+        host.option_boxes = [box]
+
+        host.update_line_picker([])
+
+        self.assertEqual(host.mergable, [])
+        self.assertEqual(box.resets, [[]])
+
     def test_nearest_trace_sample_preserves_original_point_number(self):
         sample = _nearest_trace_sample(
             [0.0, 1.0, 2.0],

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -67,13 +67,13 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.last_ds_len, 0)
         self.assertEqual(window.restart_intervals, [0.2])
 
-    def test_refresh_records_row_count_when_worker_is_started(self):
+    def test_refresh_keeps_row_count_pending_until_worker_succeeds(self):
         window = self._window(worker_running=False)
 
         plotWidget.refreshWindow(window)
 
         self.assertEqual(window.load_calls, ["load"])
-        self.assertEqual(window.last_ds_len, 10)
+        self.assertEqual(window.last_ds_len, 0)
         self.assertEqual(window.restart_intervals, [0.2])
 
     def test_load_data_uses_sampled_sql_and_wires_originating_worker(self):
@@ -127,6 +127,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
 
         class Dataset:
             cache = Cache()
+            number_of_results = 42
 
         class Param:
             name = "signal"
@@ -215,6 +216,15 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.refresh_calls, [(True, worker)])
         self.assertEqual(window.error_calls, [(error, worker)])
         self.assertEqual(window.printer_calls, [("working", worker)])
+
+    def test_failed_pending_refresh_is_retried(self):
+        window = self._window(worker_running=False)
+
+        plotWidget.refreshWindow(window)
+        plotWidget.refreshWindow(window)
+
+        self.assertEqual(window.load_calls, ["load", "load"])
+        self.assertEqual(window.last_ds_len, 0)
 
 
 class PlotWorkerCallbackTestCase(unittest.TestCase):
@@ -321,6 +331,8 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
     def test_current_worker_failure_reports_error_and_releases_wait(self):
         window = self._window()
         error = RuntimeError("current error")
+        window.last_ds_len = 3
+        window.worker.dataset_length_at_start = 10
 
         plotWidget.err_raiser(window, error, worker=window.worker)
         result = plotWidget.refreshPlot(window, False, worker=window.worker)
@@ -335,6 +347,7 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
             )
         self.assertEqual(window._last_error_text, "RuntimeError: current error")
         self.assertEqual(window.end_wait.emitted, 1)
+        self.assertEqual(window.last_ds_len, 3)
 
 
 class PlotStateOverlayTestCase(unittest.TestCase):
@@ -411,6 +424,7 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         class Worker:
             read_data = False
             running = True
+            dataset_length_at_start = 5
             axis_data = {"x": [], "y": []}
             axis_param = {"x": object(), "y": object()}
             started_at = 0
@@ -442,6 +456,7 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         plot1d.refreshPlot(window, True, worker=worker)
 
         self.assertFalse(worker.running)
+        self.assertEqual(window.last_ds_len, 5)
         self.assertEqual(window.end_wait.emitted, 1)
         self.assertEqual(line.calls[-1], (([], []), {}))
         self.assertIn("Waiting for plottable data", statuses[-1][0])

--- a/tests/windows/test_preferences.py
+++ b/tests/windows/test_preferences.py
@@ -47,6 +47,10 @@ class FakeConfig:
         self.updates.append((key, value))
         self.values[key] = value
 
+    def update_many(self, values):
+        self.updates.extend(values.items())
+        self.values.update(values)
+
     def _schema_for_defaults(self):
         schema = {"properties": {}}
         for key, value in self.defaults.items():
@@ -189,7 +193,7 @@ class PreferencesDialogTestCase(unittest.TestCase):
 
             self.assertTrue(dialog.restore_defaults())
 
-            self.assertEqual(cfg.values, cfg.defaults)
+            self.assertNotEqual(cfg.values, cfg.defaults)
             self.assertEqual(dialog.themeCombo.currentData(), "light")
             self.assertEqual(dialog.previewSizeSpin.value(), 200)
             self.assertEqual(dialog.mouseModeCombo.currentData(), "pan")
@@ -205,6 +209,10 @@ class PreferencesDialogTestCase(unittest.TestCase):
             self.assertEqual(dialog.maxFullHeatmapPointsSpin.value(), 2_000_000)
             self.assertEqual(dialog.delGracePeriodSpin.value(), 10.0)
             self.assertEqual(dialog.cloudSyncTimeoutSpin.value(), 120.0)
+            self.assertEqual(applied, [])
+
+            self.assertTrue(dialog.apply_preferences())
+            self.assertEqual(cfg.values, cfg.defaults)
             self.assertEqual(applied, [True])
         finally:
             qtw.QMessageBox.question = old_question


### PR DESCRIPTION
## Changes

- retain the last successfully loaded dataset length until a refresh completes
- retry pending data after worker failures
- stage Restore Defaults in Preferences until Apply or OK
- validate and persist multi-key preference changes as one transaction
- clear stale closed-window choices from the 1D “Add to Plot” picker
- accept empty strings and empty lists in `qplot-cfg -set_value`

## Why

The beta could suppress retries after a failed refresh, commit defaults despite Cancel, leave part of a preference batch saved, offer closed plots as trace sources, and crash or misparse valid empty CLI values.

## Impact

Configuration writes now validate the complete proposed state before one save. Existing one-key `config.update` callers retain the same API.

## Root cause

Refresh bookkeeping advanced at worker start; Preferences wrote each changed key separately and Restore Defaults called Apply directly; an empty compatible-window list was treated as “no update”; and the CLI parser indexed/split empty values unconditionally.

## Checks

- `.venv-mac/bin/python -m pytest -q` — 414 passed, 5 subtests passed
- `.venv-mac/bin/python -m ruff check .`
- targeted mypy checks for changed typed modules
- `.venv-mac/bin/python -m pip check`
- launched `.venv-mac/bin/python -m qplot` successfully