### PR TITLE
Show timestamp-less runs and correct beta docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ Config keys use dotted paths in code and in `qplot-cfg`, for example
 | Key | Type | Default | Validation | Purpose |
 | --- | --- | --- | --- | --- |
 | `GUI.plot_frame_fraction` | number | `0.47` | `0 < value < 1` | Fraction of a plot window used for the plot frame. |
-| `GUI.main_frame_size` | integer array | `[600, 700]` | exactly 2 items | Initial main-window width and height. |
+| `GUI.main_frame_size` | integer array | `[780, 700]` | exactly 2 items | Initial main-window width and height. |
 | `GUI.preview_size` | integer | `200` | `50 <= value <= 1000` | Preview thumbnail size in pixels. |
 | `file.default_load_path` | string | `""` | any string | Default folder for selecting database files. |
 | `file.last_file_path` | string | `""` | any string | Last database file opened by the application. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -184,8 +184,7 @@ Heatmaps add color-scale controls and 1D cut extraction.
 
 Color-scale controls:
 
-* Right-click the plot and choose `Autoscale Color`, or use the color autoscale
-  button.
+* Right-click the plot and choose `Autoscale Color`, or press `C`.
 * Double-click the color scale bar to open the color scaling dialog.
 * Drag one color-scale handle to adjust a limit.
 * Drag between handles to slide the range.

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -303,13 +303,6 @@ class DatabaseActionsMixin:
 
         if newRuns:
             self.RunList.maxRunId = max(self.RunList.maxRunId, max(newRuns))
-            # Failed initialisations without a timestamp remain hidden, but
-            # still advance the cursor so later valid runs can be discovered.
-            newRuns = {
-                run_id: metadata
-                for run_id, metadata in newRuns.items()
-                if metadata.get("run_timestamp")
-                }
 
         if not newRuns:
             self._sync_empty_state()

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -205,16 +205,10 @@ class RunList(qtw.QTreeWidget):
             append_to_watching = False
             arr = [str(run_id)] # Run ID
             
-            # Skip values missing 'run_timestamp', this only happens on a run 
-            # which failed to initialise and has no data. Also breaks app...
-            if not metadata["run_timestamp"]:
-                continue
-            # Add data display to array
-
             measurement_count = measured_parameter_count(metadata)
             arr.append("") #measured previews; count remains the hidden sort key
             arr.append(format_point_count(metadata)) #points
-            arr.append(format_timestamp(metadata["run_timestamp"])) #started
+            arr.append(format_timestamp(metadata.get("run_timestamp"))) #started
             arr.append(format_complete_cell(metadata)) #status
             arr.append(format_time_taken_seconds(metadata)) #duration
             arr.append(format_storage_size(metadata.get("storage_bytes"))) #size

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -12,14 +12,22 @@ from qplot.windows._widgets.preview import (
 
 
 class RunListTooltipTestCase(unittest.TestCase):
-    def test_add_runs_advances_run_id_cursor_past_missing_timestamp(self):
+    def test_add_runs_displays_run_with_missing_timestamp(self):
         old_isfile = treeWidgets.isfile
         treeWidgets.isfile = lambda _: False
 
         try:
             run_list = treeWidgets.RunList()
             run_list.addRuns({
-                2: {"run_timestamp": None},
+                2: {
+                    "run_timestamp": None,
+                    "completed_timestamp": None,
+                    "is_completed": False,
+                    "guid": "guid-2",
+                    "sweep_parameters": [],
+                    "measure_parameters": [],
+                    "result_count": 0,
+                    },
                 3: {
                     "run_timestamp": 100.0,
                     "completed_timestamp": 110.0,
@@ -32,7 +40,16 @@ class RunListTooltipTestCase(unittest.TestCase):
                 })
 
             self.assertEqual(run_list.maxRunId, 3)
-            self.assertEqual(run_list.topLevelItemCount(), 1)
+            self.assertEqual(run_list.topLevelItemCount(), 2)
+            missing_timestamp_item = next(
+                run_list.topLevelItem(index)
+                for index in range(run_list.topLevelItemCount())
+                if run_list.topLevelItem(index).guid == "guid-2"
+                )
+            self.assertEqual(
+                missing_timestamp_item.text(run_list.cols.index("Started")),
+                "unknown",
+                )
         finally:
             treeWidgets.isfile = old_isfile
 

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -2248,16 +2248,19 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
         self.assertEqual(seen_last_run_ids, [10])
         self.assertTrue(harness.RunList.checked_watching)
         self.assertEqual(harness.RunList.maxRunId, 13)
-        expected_runs = {12: new_runs[12], 13: new_runs[13]}
+        expected_runs = new_runs
         self.assertEqual(harness.RunList.added_runs, expected_runs)
         self.assertEqual(harness.infoBox.preview.added_runs, expected_runs)
         self.assertEqual(harness.sync_count, 1)
-        self.assertEqual(harness.plotted_guids, ["guid-12", "guid-13"])
+        self.assertEqual(
+            harness.plotted_guids,
+            ["guid-11", "guid-12", "guid-13"],
+            )
         self.assertEqual(
             harness.status_messages,
             [
                 ("Checking for new runs...", 0),
-                ("Found 2 new runs.", 5000),
+                ("Found 3 new runs.", 5000),
                 ],
             )
 


### PR DESCRIPTION
## Changes

- display runs that have no start timestamp instead of filtering them out
- show `unknown` in the Started column for those runs
- keep timestamp-less runs in incremental refresh and auto-plot flows
- correct the documented main-window default from `[600, 700]` to `[780, 700]`
- replace the removed heatmap autoscale-button instruction with the `C` shortcut

## Why

Runs with incomplete or unusual metadata were invisible even though the database query discovered them. Two documentation entries described behavior that no longer matched the beta.

## Impact

Users can now see and inspect every discovered run. A timestamp-less new run also follows the same auto-plot preference as other new runs.

## Root cause

Both the refresh controller and run-list widget independently filtered falsey `run_timestamp` values. Documentation had not been updated alongside the window-size and heatmap-control changes.

## Checks

- `.venv-mac/bin/python -m pytest -q` — 411 passed, 5 subtests passed
- `.venv-mac/bin/python -m ruff check .`
- mypy check for the changed run-list module
- `.venv-mac/bin/python -m pip check`
- launched `.venv-mac/bin/python -m qplot` successfully