### PR TITLE
Fix beta plot and lifecycle regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ installation commands and release validation, see `docs/distribution.md`.
 
 - Keep 1D traces from different databases distinct when their run IDs and
   parameter names match.
+- Keep multiple cuts from the same heatmap distinct and visibly numbered when
+  they are added to a 1D plot.
 - Ignore empty or entirely non-finite heatmap data when autoscaling the
   colorbar.
 - Keep colorbar interaction rounding finite and positive for constant-valued

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
-No changes yet.
+### Fixed
+
+- Keep 1D traces from different databases distinct when their run IDs and
+  parameter names match.
+- Ignore empty or entirely non-finite heatmap data when autoscaling the
+  colorbar.
+- Keep colorbar interaction rounding finite and positive for constant-valued
+  heatmaps.
+- Stop polling completed runs whose database row has no completion timestamp.
+- Prevent stale preview workers from clearing current-database worker state.
+- Return a scalar completion timestamp, or `None`, from `has_finished`.
+- Preserve the inherited Qt `layout()`, `width()`, `height()`, `x()`, and `y()`
+  methods on qPlot windows.
 
 ## 1.5.0-b2 - 2026-08-01
 

--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -780,7 +780,7 @@ def get_run_status(guid):
         conn.close()
 
 
-def has_finished(guid):
+def has_finished(guid) -> float | None:
     """
     Checks if specific run (by guid) has finished running.
     If the run with guid has finished, returns the completed time. 
@@ -793,9 +793,9 @@ def has_finished(guid):
 
     Returns
     -------
-    completed_timestamp : list[float, None]
-        Result of the SQL query. Either completed_timestamp as a unix time float
-        or None if no entry is found.
+    completed_timestamp : float | None
+        The completion timestamp as a Unix-time float. Returns None when the
+        run is present but unfinished, or when no matching run exists.
 
     """
     conn = qcodes_read_only_connection(get_DB_location())
@@ -810,8 +810,9 @@ def has_finished(guid):
           WHERE guid=?
           LIMIT 1
         """, (guid, ))
-        value = cursor.fetchall()
-
-        return value[0]
+        row = cursor.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
     finally:
         conn.close()

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -21,6 +21,17 @@ class DatasetKey:
         object.__setattr__(self, "guid", str(self.guid))
 
 
+@dataclass(frozen=True, slots=True)
+class TraceKey:
+    """Identifies one measured parameter in one database-backed dataset."""
+
+    dataset_key: DatasetKey
+    parameter_name: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parameter_name", str(self.parameter_name))
+
+
 @dataclass
 class DatasetHandle:
     """

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -23,13 +23,16 @@ class DatasetKey:
 
 @dataclass(frozen=True, slots=True)
 class TraceKey:
-    """Identifies one measured parameter in one database-backed dataset."""
+    """Identifies one trace source in one database-backed dataset."""
 
     dataset_key: DatasetKey
     parameter_name: str
+    sweep_id: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "parameter_name", str(self.parameter_name))
+        if self.sweep_id is not None:
+            object.__setattr__(self, "sweep_id", int(self.sweep_id))
 
 
 @dataclass

--- a/src/qplot/windows/_plot1d_snap.py
+++ b/src/qplot/windows/_plot1d_snap.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         toolbarCo_ord: qtw.QToolBar
         snap_to_trace_action: QtGui.QAction | None
         trace_label: qtw.QLabel | None
-        lines: dict[str, Any]
+        lines: dict[Any, Any]
         pos_labels: dict[str, qtw.QLabel]
         plot: Any
         right_vb: Any
@@ -255,7 +255,14 @@ class Plot1DSnapMixin(_Plot1DSnapBase):
         self.trace_label.setText(
             f"Snapped to run {run_id}, trace {trace}, point {point_number}."
             )
-        self.trace_label.setToolTip(str(label))
+        line = self.lines.get(label)
+        display_label = getattr(self, "_trace_display_label", None)
+        if callable(display_label):
+            label_text = display_label(label, line)
+        else:
+            source = getattr(line, "from_win", None)
+            label_text = str(getattr(source, "label", label))
+        self.trace_label.setToolTip(label_text)
         self.trace_label.adjustSize()
         self.trace_label.updateGeometry()
         self.toolbarCo_ord.updateGeometry()

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
         label: str
         line: Any
         lineScroll: qtw.QScrollArea
-        lines: dict[str, Any]
+        lines: dict[Any, Any]
         make_ds: Any
         mergable: Any
         option_boxes: list[Any]
@@ -81,23 +81,23 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
 
     """Trace controls and secondary-axis handling for 1D plot windows."""
 
-    _trace_styles: dict[str, _TraceStyle]
-    _trace_controls: dict[str, Any]
+    _trace_styles: dict[Any, _TraceStyle]
+    _trace_controls: dict[Any, Any]
     _trace_appearance_dialog: "_TraceAppearanceDialog | None"
 
-    def _ensure_trace_styles(self) -> dict[str, _TraceStyle]:
+    def _ensure_trace_styles(self) -> dict[Any, _TraceStyle]:
         styles = self.__dict__.get("_trace_styles")
         if not isinstance(styles, dict):
             styles = {}
             self.__dict__["_trace_styles"] = styles
-        return cast(dict[str, Plot1DTraceMixin._TraceStyle], styles)
+        return cast(dict[Any, Plot1DTraceMixin._TraceStyle], styles)
 
-    def _ensure_trace_controls(self) -> dict[str, Any]:
+    def _ensure_trace_controls(self) -> dict[Any, Any]:
         controls = self.__dict__.get("_trace_controls")
         if not isinstance(controls, dict):
             controls = {}
             self.__dict__["_trace_controls"] = controls
-        return cast(dict[str, Any], controls)
+        return cast(dict[Any, Any], controls)
 
     def _initial_trace_style(self, order: int = 0) -> _TraceStyle:
         style = self._TraceStyle(order=order)
@@ -105,6 +105,37 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         style.dots_color = style.line_color
         style.markers_color = style.line_color
         return style
+
+    @staticmethod
+    def _window_trace_key(window: Any) -> Any:
+        """Return a database-aware identity, with labels as a legacy fallback."""
+
+        return getattr(window, "_trace_key", getattr(window, "label", None))
+
+    def _stored_trace_key(self, key: Any, line: Any) -> Any:
+        """Return the source identity represented by one stored plot line."""
+
+        if line is self.__dict__.get("line"):
+            return getattr(self, "_trace_key", key)
+        from_win = getattr(line, "from_win", None)
+        return self._window_trace_key(from_win) if from_win is not None else key
+
+    def _has_trace_window(self, window: Any) -> bool:
+        """Return whether ``window`` is already represented on this plot."""
+
+        trace_key = self._window_trace_key(window)
+        return any(
+            self._stored_trace_key(stored_key, line) == trace_key
+            for stored_key, line in self.__dict__.get("lines", {}).items()
+            )
+
+    def _trace_display_label(self, key: Any, line: Any) -> str:
+        """Return the unchanged user-facing label for an internally keyed trace."""
+
+        if line is self.__dict__.get("line"):
+            return self.label
+        from_win = getattr(line, "from_win", None)
+        return str(getattr(from_win, "label", key))
 
     def _register_main_line(self) -> None:
         """
@@ -138,7 +169,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     def _set_main_line_color(self, color: Any) -> None:
         self._set_trace_line_color(self.label, color)
 
-    def _set_trace_line_color(self, label: str, color: Any) -> None:
+    def _set_trace_line_color(self, label: Any, color: Any) -> None:
         style = self._ensure_trace_styles().setdefault(
             label,
             self._initial_trace_style(),
@@ -146,7 +177,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         style.line_color = color.name() if hasattr(color, "name") else str(color)
         self._apply_trace_style(label, self.__dict__.get("lines", {}).get(label))
 
-    def _set_trace_y_axis(self, label: str, side: str) -> None:
+    def _set_trace_y_axis(self, label: Any, side: str) -> None:
         style = self._ensure_trace_styles().setdefault(
             label,
             self._initial_trace_style(),
@@ -154,7 +185,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         style.y_axis = "Right" if side.lower() == "right" else "Left"
         self._apply_trace_style(label, self.__dict__.get("lines", {}).get(label))
 
-    def _sync_trace_control(self, label: str) -> None:
+    def _sync_trace_control(self, label: Any) -> None:
         control = self._ensure_trace_controls().get(label)
         style = self._ensure_trace_styles().get(label)
         if control is None or style is None:
@@ -269,11 +300,28 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         if options is not None:
             new_option = picker_1d(self, self.config, options)
         else:
-            new_option = picker_1d(self, self.config, [item.label for item in self.mergable])
+            labels = [item.label for item in self.mergable]
+            trace_keys = [self._window_trace_key(item) for item in self.mergable]
+            new_option = picker_1d(
+                self,
+                self.config,
+                labels,
+                item_data=trace_keys,
+                )
         
         # Connect Slots
-        new_option.itemSelected.connect(lambda label: self.add_line(label))
-        new_option.closed.connect(self.remove_line)
+        new_option.itemSelected.connect(
+            lambda label, option=new_option: self.add_line(
+                label,
+                option.option_box.currentData(),
+                )
+            )
+        new_option.closed.connect(
+            lambda label, option=new_option: self.remove_line(
+                label,
+                getattr(option, "_trace_key", option.option_box.currentData()),
+                )
+            )
         
         # Adjust apperance
         cols = self.config.theme.colors
@@ -305,14 +353,21 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         
         # Only add options which are not already being plotted
         if self.option_boxes:
-            box_texts = [box.option_box.currentText() for box in self.option_boxes]
+            selected_keys = {
+                getattr(box, "_trace_key", box.option_box.currentData())
+                for box in self.option_boxes
+                if box.option_box.currentIndex() >= 0
+                }
             available = [
-                item.label for item in self.mergable
-                if item.label not in box_texts
+                item for item in self.mergable
+                if self._window_trace_key(item) not in selected_keys
                 ]
             for box in self.option_boxes:
                 if box.option_box.isEnabled():
-                    box.reset_box(available)
+                    box.reset_box(
+                        [item.label for item in available],
+                        item_data=[self._window_trace_key(item) for item in available],
+                        )
 
 
     def refresh_secondary_lines(self) -> None:
@@ -334,7 +389,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     
     
     @QtCore.pyqtSlot(str)
-    def add_line(self, label: str) -> None:
+    def add_line(self, label: str, trace_key: Any = None) -> None:
         """
         Produces a secondary plot based on user selection in dropdown menus
         
@@ -346,6 +401,8 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         ----------
         label : str
             The label of the chosen plot.
+        trace_key : object, optional
+            Database-aware source identity supplied by the picker.
 
         Returns
         -------
@@ -355,9 +412,18 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         
         win = None
         
-        # Find selected window from open windows.
-        for item in self.mergable:
-            if item.label == label:
+        # Find the exact selected window. Labels remain display-only and may be
+        # shared by copied runs opened from different databases.
+        if trace_key is not None:
+            for item in self.mergable:
+                if self._window_trace_key(item) == trace_key:
+                    win = item
+                    self.mergable.remove(item)
+                    break
+        if win is None:
+            for item in self.mergable:
+                if item.label != label:
+                    continue
                 win = item
                 self.mergable.remove(item)
                 break
@@ -392,28 +458,33 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         # Create and track new line
         self.make_ds.emit(win._dataset_key)
         subplot = subplot1d(self, win)
-        self.lines[label] = subplot
+        trace_key = self._window_trace_key(win)
+        self.lines[trace_key] = subplot
         
         self.plot.getAxis('right').setStyle(showValues=True)
         
         # Connect box options to line
         selected_box = None
         for box in self.option_boxes:
-            if label == box.option_box.currentText():
+            box_key = box.option_box.currentData()
+            if box_key == trace_key or (
+                    box_key is None and label == box.option_box.currentText()
+                    ):
                 
                 box.color_box.selectedColor.connect(
-                    lambda color, trace_label=label: self._set_trace_line_color(
-                        trace_label,
+                    lambda color, selected_key=trace_key: self._set_trace_line_color(
+                        selected_key,
                         color,
                         )
                     )
                 
                 box.axis_side.currentTextChanged.connect(
-                    lambda side, trace_label=label: self._set_trace_y_axis(
-                        trace_label,
+                    lambda side, selected_key=trace_key: self._set_trace_y_axis(
+                        selected_key,
                         side,
                         )
                     )
+                box._trace_key = trace_key
                 selected_box = box
                 break
         
@@ -421,11 +492,11 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         assert selected_box is not None
         
         styles = self._ensure_trace_styles()
-        style = styles.setdefault(label, self._initial_trace_style(order=len(styles)))
+        style = styles.setdefault(trace_key, self._initial_trace_style(order=len(styles)))
         style.line_color = selected_box.color_box.color().name()
         style.y_axis = "Right" if selected_box.axis_side.currentText().lower() == "right" else "Left"
-        self._ensure_trace_controls()[label] = selected_box
-        self._apply_trace_style(label, subplot)
+        self._ensure_trace_controls()[trace_key] = selected_box
+        self._apply_trace_style(trace_key, subplot)
         
     
     @QtCore.pyqtSlot(bool)
@@ -441,7 +512,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         
     
     @QtCore.pyqtSlot(str)
-    def remove_line(self, label: str) -> None:
+    def remove_line(self, label: str, trace_key: Any = None) -> None:
         """
         Deletes line connect to box widget.
 
@@ -449,22 +520,31 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         ----------
         label : str
             The label of the chosen plot.
+        trace_key : object, optional
+            Database-aware identity of the trace to remove.
             
         """
         # Find box and remove box
         side = None
+        selected_key = trace_key
         for option in self.option_boxes:
-            if option.option_box.currentText() == label:
-                side = option.axis_side.currentText()
-                self.option_boxes.remove(option)
-                break
+            option_key = getattr(option, "_trace_key", option.option_box.currentData())
+            if selected_key is not None and option_key != selected_key:
+                continue
+            if selected_key is None and option.option_box.currentText() != label:
+                continue
+            selected_key = option_key if option_key is not None else label
+            side = option.axis_side.currentText()
+            self.option_boxes.remove(option)
+            break
         assert side is not None
+        assert selected_key is not None
         
         # Remove line from viewbox
-        line = self.lines[label]
-        self.lines.pop(label)
-        self._trace_styles.pop(label, None)
-        self._ensure_trace_controls().pop(label, None)
+        line = self.lines[selected_key]
+        self.lines.pop(selected_key)
+        self._trace_styles.pop(selected_key, None)
+        self._ensure_trace_controls().pop(selected_key, None)
         # Fetch correct viewbox to remove from
         vb = self.plot if side.lower() == "left" else self.right_vb
         vb.removeItem(line)
@@ -525,14 +605,14 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         if dialog is not None:
             dialog.refresh_theme()
 
-    def _trace_measurement_name(self, label: str, line: Any) -> str:
-        if label == self.label:
+    def _trace_measurement_name(self, label: Any, line: Any) -> str:
+        if line is self.__dict__.get("line"):
             return self.param.name
         from_win = getattr(line, "from_win", None)
         param = getattr(from_win, "param", None)
         return getattr(param, "name", str(label))
 
-    def _apply_trace_style(self, label: str, line: Any) -> None:
+    def _apply_trace_style(self, label: Any, line: Any) -> None:
         styles = self._ensure_trace_styles()
         style = styles.setdefault(label, self._initial_trace_style(order=len(styles)))
         self._sync_trace_control(label)
@@ -617,13 +697,13 @@ class _TraceTableWidget(qtw.QTableWidget):
         if not index.isValid():
             return
 
-        label = self.dialog._label_for_row(index.row())
-        mime_data = self.dialog._trace_mime_data(label)
+        trace_key = self.dialog._trace_key_for_row(index.row())
+        mime_data = self.dialog._trace_mime_data(trace_key)
         if mime_data is None:
             super().startDrag(supported_actions)
             return
 
-        style = self.dialog.owner._trace_styles.get(label)
+        style = self.dialog.owner._trace_styles.get(trace_key)
         drag = QtGui.QDrag(self)
         drag.setMimeData(mime_data)
         if style is not None:
@@ -1222,12 +1302,13 @@ class _TraceAppearanceDialog(qtw.QDialog):
         self.table.blockSignals(True)
         self.table.setRowCount(0)
         try:
-            for row, (label, line) in enumerate(self.owner.lines.items()):
+            for row, (trace_key, line) in enumerate(self.owner.lines.items()):
                 self.table.insertRow(row)
+                label = self.owner._trace_display_label(trace_key, line)
                 trace_id = label.split()[0].replace("ID:", "") if label.startswith("ID:") else str(row + 1)
-                measurement = self.owner._trace_measurement_name(label, line)
+                measurement = self.owner._trace_measurement_name(trace_key, line)
                 style = self.owner._trace_styles.setdefault(
-                    label,
+                    trace_key,
                     self.owner._initial_trace_style(order=row),
                     )
 
@@ -1260,10 +1341,10 @@ class _TraceAppearanceDialog(qtw.QDialog):
 
                 label_item = self.table.item(row, self._COL_ID)
                 if label_item is not None:
-                    label_item.setData(QtCore.Qt.ItemDataRole.UserRole, label)
+                    label_item.setData(QtCore.Qt.ItemDataRole.UserRole, trace_key)
                     label_item.setToolTip(label)
                 self.table.setRowHeight(row, 28)
-                if label in selected:
+                if trace_key in selected:
                     self.table.selectRow(row)
         finally:
             self.table.blockSignals(False)
@@ -1323,8 +1404,8 @@ class _TraceAppearanceDialog(qtw.QDialog):
             return []
         return sorted({idx.row() for idx in selection_model.selectedRows()})
 
-    def _selected_labels(self) -> list[str]:
-        labels: list[str] = []
+    def _selected_labels(self) -> list[Any]:
+        labels: list[Any] = []
         selection_model = self.table.selectionModel()
         if selection_model is None:
             return labels
@@ -1334,15 +1415,19 @@ class _TraceAppearanceDialog(qtw.QDialog):
                 labels.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
         return labels
 
-    def _label_for_row(self, row: int) -> str:
+    def _trace_key_for_row(self, row: int) -> Any:
         item = self.table.item(row, self._COL_ID)
         if item is None:
-            return ""
-        return str(item.data(QtCore.Qt.ItemDataRole.UserRole) or "")
+            return None
+        return item.data(QtCore.Qt.ItemDataRole.UserRole)
 
-    def _trace_mime_data(self, label: str) -> QtCore.QMimeData | None:
+    def _trace_mime_data(self, label: Any) -> QtCore.QMimeData | None:
         line = self.owner.lines.get(label)
-        source = self.owner if label == self.owner.label else getattr(line, "from_win", None)
+        source = (
+            self.owner
+            if line is self.owner.__dict__.get("line")
+            else getattr(line, "from_win", None)
+            )
         if source is None:
             return None
 

--- a/src/qplot/windows/_plot2d_colorbar.py
+++ b/src/qplot/windows/_plot2d_colorbar.py
@@ -57,15 +57,49 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
         Return finite min/max levels from the current heatmap data.
 
         """
+        data_range = self._finite_data_colorbar_range()
+        if data_range is None:
+            return None
+
+        vmin, vmax = data_range
+        if vmin >= vmax:
+            return None
+
+        return vmin, vmax
+
+    def _finite_data_colorbar_range(self):
+        """Return the finite data range without reducing an empty array."""
+
         data = getattr(self, "dataGrid", None)
         if data is None:
             return None
 
-        vmin, vmax = np.nanmin(data), np.nanmax(data)
-        if not np.isfinite(vmin) or not np.isfinite(vmax) or vmin >= vmax:
+        values = np.asarray(data)
+        finite_values = values[np.isfinite(values)]
+        if finite_values.size == 0:
             return None
 
-        return float(vmin), float(vmax)
+        return float(np.min(finite_values)), float(np.max(finite_values))
+
+    def _data_colorbar_rounding(self):
+        """Return a finite, positive colorbar interaction step."""
+
+        data_range = self._finite_data_colorbar_range()
+        if data_range is None:
+            return 1e-5
+
+        vmin, vmax = data_range
+        span = vmax - vmin
+        if not np.isfinite(span) or span <= 0:
+            span = max(abs(vmin), abs(vmax))
+        if not np.isfinite(span) or span <= 0:
+            span = 1.0
+
+        rounding = span / 1e5
+        minimum_rounding = np.finfo(float).tiny
+        if not np.isfinite(rounding) or rounding < minimum_rounding:
+            return float(minimum_rounding)
+        return float(rounding)
 
     def _set_colorbar_levels(self, vmin, vmax):
         """

--- a/src/qplot/windows/_plot2d_sweeps.py
+++ b/src/qplot/windows/_plot2d_sweeps.py
@@ -1,3 +1,4 @@
+from itertools import count
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy.typing as npt
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
         param: Any
         plot: Any
         rotate: bool | None
-        sweep_id: int
         sweep_lines: dict[int, Any]
         sweep_moved: Any
 
@@ -41,8 +41,17 @@ else:
         pass
 
 
+_SWEEP_ID_COUNTER = count()
+
+
 class Plot2DSweepMixin(_Plot2DSweepBase):
     """Sweep and cut interactions for 2D heatmap plot windows."""
+
+    @staticmethod
+    def _reserve_sweep_id() -> int:
+        """Return an application-session-unique identity for a heatmap cut."""
+
+        return next(_SWEEP_ID_COUNTER)
 
     def openSweep(self, side: str) -> None:
         """
@@ -81,20 +90,20 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         else:
             raise KeyError(f"Invalid sweep side, {side=}, must be 'v' or 'h'.")
             
+        sweep_id = self._reserve_sweep_id()
+
         # Emit to Main window to open new window
         self.open_subplot.emit(
                 sweeper,
                 self._dataset_key,
                 (
-                self.sweep_id,
+                sweep_id,
                 sweep_var,
                 fixed_var,
                 fixed_index,
                 self.param
                 )
             )
-        # Update interal id for multiple sweeps
-        self.sweep_id += 1
         
 
     @QtCore.pyqtSlot(int, str, str, int, object)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -18,7 +18,7 @@ from ._commands import (
     create_action,
     toolbar_toggle_command_spec,
 )
-from ._dataset_handle import DatasetKey
+from ._dataset_handle import DatasetKey, TraceKey
 from ._dragdrop import (
     preview_drop_is_compatible,
     run_preview_payload_from_mime,
@@ -202,6 +202,7 @@ class plotWidget(
             set_parameter_complete(self.param, False)
         self.name = str(self)
         self.label = f"ID:{self.ds.run_id} {self.param.name}"
+        self._trace_key = TraceKey(self._dataset_key, self.param.name)
         self.monitor = QtCore.QTimer()
         self.threadPool = threadPool
         self.last_ds_len = self.ds.number_of_results
@@ -212,7 +213,7 @@ class plotWidget(
         self.show_status("Working, please wait", 0)
         
         ### WIDGETS
-        self.layout = qtw.QVBoxLayout()
+        self._window_layout = qtw.QVBoxLayout()
         
         self.widget = pg.GraphicsLayoutWidget()
         self.plot_state_overlay = PlotStateOverlay(self.widget)
@@ -231,7 +232,7 @@ class plotWidget(
         self.vb.setParent(self.plot)
         self.vb.set_marquee_owner(self)
         self._init_marquee()
-        self.layout.addWidget(self.widget)
+        self._window_layout.addWidget(self.widget)
         
         ### CORE INIT FUNCTIONS
         self.initAxes()
@@ -256,12 +257,12 @@ class plotWidget(
             screenrect = qtw.QApplication.primaryScreen().availableGeometry()
             sizeFrac = self.config.get("GUI.plot_frame_fraction")
     
-            self.width = int(sizeFrac * screenrect.width())
-            self.height = int(sizeFrac * screenrect.height())
-            self.resize(self.width, self.height)
+            initial_width = int(sizeFrac * screenrect.width())
+            initial_height = int(sizeFrac * screenrect.height())
+            self.resize(initial_width, initial_height)
             
             w = qtw.QFrame()
-            w.setLayout(self.layout)
+            w.setLayout(self._window_layout)
             self.setCentralWidget(w)
         
         #start refresh cycle if live

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -13,6 +13,15 @@ from .plot1d import plot1d
 from .plot2d import plot2d
 
 
+def _plot_has_trace_window(target, candidate):
+    """Return whether a source window is already represented on a 1D plot."""
+
+    checker = getattr(target, "_has_trace_window", None)
+    if callable(checker):
+        return checker(candidate)
+    return candidate.label in target.lines
+
+
 class PlotActionsMixin:
     """
     Plot launching, preview plotting, CSV export, and plot dataset tracking.
@@ -117,17 +126,19 @@ class PlotActionsMixin:
         if show:
             win.update_theme(self.config)
 
-            win.move(self.x, self.y)
+            win.move(self._next_plot_x, self._next_plot_y)
             win.show()
 
             tolerance = 30
-            self.x += win.width
-            if self.x + win.width - tolerance > self.screenrect.right():
-                self.x = self.screenrect.left()
-                self.y += win.height
+            plot_width = win.width()
+            plot_height = win.height()
+            self._next_plot_x += plot_width
+            if self._next_plot_x + plot_width - tolerance > self.screenrect.right():
+                self._next_plot_x = self.screenrect.left()
+                self._next_plot_y += plot_height
 
-                if self.y + win.height - tolerance > self.screenrect.bottom():
-                    self.y = self.screenrect.top()
+                if self._next_plot_y + plot_height - tolerance > self.screenrect.bottom():
+                    self._next_plot_y = self.screenrect.top()
 
 
     @QtCore.pyqtSlot(object, object)
@@ -622,7 +633,11 @@ class PlotActionsMixin:
             target_win.add_option_box()
             box = target_win.option_boxes[-1]
 
-        index = box.option_box.findText(from_win.label)
+        source_trace_key = getattr(from_win, "_trace_key", from_win.label)
+        find_data = getattr(box.option_box, "findData", None)
+        index = find_data(source_trace_key) if callable(find_data) else -1
+        if index < 0:
+            index = box.option_box.findText(from_win.label)
         if index < 0:
             self.show_status(
                 f"Cannot add {parameter_name}; it is already shown or incompatible.",
@@ -857,14 +872,14 @@ class PlotActionsMixin:
         for item in self.windows:
             try:
                 if item.param.depends_on == win.param.depends_on:
-                    if item.label not in win.lines.keys():
+                    if not _plot_has_trace_window(win, item):
                         wins.append(item)
 
                 elif (
                     item.__class__.__name__ == "sweeper"
                     and item.axis_options["x"] == win.param.depends_on
                 ):
-                    if item.label not in win.lines.keys():
+                    if not _plot_has_trace_window(win, item):
                         wins.append(item)
             except AttributeError:
                 continue

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -3,7 +3,7 @@ from typing import Any
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
-from qplot.windows._dataset_handle import DatasetKey
+from qplot.windows._dataset_handle import DatasetKey, TraceKey
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._widgets import (
     expandingComboBox,
@@ -42,11 +42,24 @@ class sweeper(plotWidget):
         super().__init__(dataset_key, *args, **kargs)
         
         
+    def _set_cut_trace_identity(self) -> None:
+        """Give this cut a unique internal key and a distinguishable label."""
+
+        self.label = f"{self.label} [cut {self.sweep_id + 1}]"
+        self._trace_key = TraceKey(
+            self._dataset_key,
+            self.param.name,
+            sweep_id=self.sweep_id,
+            )
+
+
     def initAxes(self):
         """
         Adds to left toolbar to allow for sweep parameter control
 
         """
+        self._set_cut_trace_identity()
+
         # Got back to default before line picker
         super().initAxes()
         

--- a/src/qplot/windows/_widgets/_run_formatting.py
+++ b/src/qplot/windows/_widgets/_run_formatting.py
@@ -193,7 +193,9 @@ def time_taken_seconds(metadata):
     completed = metadata.get("completed_timestamp")
     if completed:
         end = completed
-    elif not run_is_complete(metadata) and metadata.get("database_modified_timestamp"):
+    elif run_is_complete(metadata):
+        return None
+    elif metadata.get("database_modified_timestamp"):
         end = metadata.get("database_modified_timestamp")
     else:
         end = datetime.now().timestamp()

--- a/src/qplot/windows/_widgets/dropbox.py
+++ b/src/qplot/windows/_widgets/dropbox.py
@@ -23,7 +23,7 @@ class picker_1d(qtw.QWidget):
     del_but_width = 15
     color_box_width = 75
     
-    def __init__(self, main, cfg, items, *args, **kargs):
+    def __init__(self, main, cfg, items, *args, item_data=None, **kargs):
         super().__init__()
         
         layout = qtw.QVBoxLayout(self)
@@ -36,7 +36,7 @@ class picker_1d(qtw.QWidget):
         # Selection box
         self.option_box = expandingComboBox(*args, **kargs)
         self.option_box.setSizePolicy(qtw.QSizePolicy.Policy.Expanding, qtw.QSizePolicy.Policy.Fixed)
-        self.reset_box(items)
+        self.reset_box(items, item_data=item_data)
         self.option_box.currentIndexChanged.connect(self.selectedOption)
         row_1.addWidget(self.option_box)
         
@@ -69,7 +69,7 @@ class picker_1d(qtw.QWidget):
         layout.addLayout(row_2)
         
     
-    def reset_box(self, items):
+    def reset_box(self, items, item_data=None):
         """
         Resets the widget to default and sets selectable items
 
@@ -77,6 +77,9 @@ class picker_1d(qtw.QWidget):
         ----------
         items : list[str]
             List of items that the user can select from
+        item_data : list[object], optional
+            Stable internal identities corresponding to ``items``. When omitted,
+            the displayed text is also used as the identity.
 
         """
         self.option_box.blockSignals(True)
@@ -84,7 +87,9 @@ class picker_1d(qtw.QWidget):
         # Reset selection
         self.option_box.clear()
         if items:
-            self.option_box.addItems(items)
+            identities = items if item_data is None else item_data
+            for label, identity in zip(items, identities, strict=True):
+                self.option_box.addItem(label, userData=identity)
         
         # Reset display
         self.option_box.setEditable(True)

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -59,7 +59,7 @@ class PreviewTab(qtw.QWidget):
         self.cache = {}
         self.errors = {}
         self.queue = {}
-        self.active = set()
+        self.active: set[tuple[int, str]] = set()
         self.metadata_signatures = {}
         self._start_scheduled = False
 
@@ -309,7 +309,7 @@ class PreviewTab(qtw.QWidget):
             return
         if guid in self.errors:
             return
-        if guid in self.active and not allow_active:
+        if (self.generation, guid) in self.active and not allow_active:
             return
         if guid not in self.run_metadata:
             return
@@ -333,7 +333,10 @@ class PreviewTab(qtw.QWidget):
 
 
     def _start_next(self):
-        if self.active or not self.queue:
+        if any(
+                generation == self.generation
+                for generation, _guid in self.active
+                ) or not self.queue:
             return
 
         guid = max(
@@ -344,7 +347,7 @@ class PreviewTab(qtw.QWidget):
                 ),
         )
         self.queue.pop(guid, None)
-        self.active.add(guid)
+        self.active.add((self.generation, guid))
         self.previewGenerationChanged.emit(guid, True)
 
         worker = PreviewWorker(
@@ -360,9 +363,10 @@ class PreviewTab(qtw.QWidget):
 
     @QtCore.pyqtSlot(int, str, object, object)
     def _worker_finished(self, generation, guid, previews, error):
-        was_active = guid in self.active
-        self.active.discard(guid)
-        if was_active:
+        active_key = (generation, guid)
+        was_active = active_key in self.active
+        self.active.discard(active_key)
+        if was_active and generation == self.generation:
             self.previewGenerationChanged.emit(guid, False)
 
         if generation != self.generation:

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -619,6 +619,9 @@ class RunList(qtw.QTreeWidget):
                     "database_modified_timestamp"
                     ]
 
+            if status.get("is_completed") is not None:
+                run.run_metadata["is_completed"] = bool(status["is_completed"])
+
             if status.get("result_count") is not None:
                 run.run_metadata["result_count"] = status["result_count"]
                 if not run.run_metadata.get("expected_results"):
@@ -664,11 +667,11 @@ class RunList(qtw.QTreeWidget):
                 run.setText(storage_col, format_storage_size(status["storage_bytes"]))
                 run.setData(storage_col, QtCore.Qt.ItemDataRole.UserRole, status["storage_bytes"])
 
-            finished = status.get("completed_timestamp")
+            completed_timestamp = status.get("completed_timestamp")
+            if completed_timestamp is not None:
+                run.run_metadata["completed_timestamp"] = completed_timestamp
 
-            if finished:
-                run.run_metadata["completed_timestamp"] = finished
-                run.run_metadata["is_completed"] = status.get("is_completed", True)
+            if run_is_complete(run.run_metadata):
                 complete_col = self.cols.index("Status")
                 run.setText(complete_col, format_complete_cell(run.run_metadata))
                 run.setData(

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -147,8 +147,8 @@ class MainWindow(  # type: ignore[misc]
         self._database_expensive_detail_generation = 0
         self._database_expensive_detail_active = False
         self._database_expensive_detail_worker = None
-        self.x = 0
-        self.y = 0
+        self._next_plot_x = 0
+        self._next_plot_y = 0
         self.localLastFile = None
         self.startup_database_path = startup_database_path
         
@@ -188,8 +188,8 @@ class MainWindow(  # type: ignore[misc]
         # Get user's window dimensions to control new window position
         primary_screen = cast(QtGui.QScreen, qtw.QApplication.primaryScreen())
         self.screenrect = primary_screen.availableGeometry()
-        self.x = self.screenrect.left() 
-        self.y = self.screenrect.top()
+        self._next_plot_x = self.screenrect.left()
+        self._next_plot_y = self.screenrect.top()
         
         # Try to bring window to top 
         self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.WindowStaysOnTopHint)

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -44,7 +44,6 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             **kargs: Any,
             ) -> None:
         super().__init__(*args, **kargs)
-        self.sweep_id = 0
         self.sweep_lines: dict[int, Any] = {}
         self.active_sweep_line_id = None
         self.__dict__["rotate"] = None # FOR SUBPLOT CURSOR

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -224,9 +224,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 self.bar = self.plot.addColorBar(
                     self._heatmap_colorbar_items(),
                     colorMap=self._colorbar_colormap(),
-                    rounding=(
-                        np.nanmax(self.dataGrid) - np.nanmin(self.dataGrid)
-                        ) / 1e5,  # Add 10,000 colours
+                    rounding=self._data_colorbar_rounding(),
                     colorMapMenu=False,
                     )
                 self._set_colorbar_tick_formatter()

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -12,8 +12,8 @@ class RunSizeTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = os.path.join(temp_dir, "runs.db")
             conn = sqlite3.connect(database_path)
+            cursor = conn.cursor()
             try:
-                cursor = conn.cursor()
                 cursor.execute(
                     "CREATE TABLE runs (guid TEXT, completed_timestamp REAL)"
                     )
@@ -26,6 +26,7 @@ class RunSizeTestCase(unittest.TestCase):
                     )
                 conn.commit()
             finally:
+                cursor.close()
                 conn.close()
 
             old_connection = readSQL.qcodes_read_only_connection

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -8,6 +8,37 @@ from qplot.datahandling import readSQL
 
 
 class RunSizeTestCase(unittest.TestCase):
+    def test_has_finished_returns_optional_timestamp_scalar(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "runs.db")
+            conn = sqlite3.connect(database_path)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "CREATE TABLE runs (guid TEXT, completed_timestamp REAL)"
+                    )
+                cursor.executemany(
+                    "INSERT INTO runs VALUES (?, ?)",
+                    [
+                        ("finished-guid", 123.5),
+                        ("unfinished-guid", None),
+                        ],
+                    )
+                conn.commit()
+            finally:
+                conn.close()
+
+            old_connection = readSQL.qcodes_read_only_connection
+            readSQL.qcodes_read_only_connection = (
+                lambda _database_path: sqlite3.connect(database_path)
+                )
+            try:
+                self.assertEqual(readSQL.has_finished("finished-guid"), 123.5)
+                self.assertIsNone(readSQL.has_finished("unfinished-guid"))
+                self.assertIsNone(readSQL.has_finished("missing-guid"))
+            finally:
+                readSQL.qcodes_read_only_connection = old_connection
+
     def test_find_new_runs_uses_run_id_when_timestamps_are_missing_or_equal(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = os.path.join(temp_dir, "runs.db")

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -673,6 +673,48 @@ class RunDetailsTabsTestCase(unittest.TestCase):
 
         self.assertIn(("guid-2", False), generation_changes)
 
+    def test_stale_preview_callback_keeps_current_generation_active(self):
+        preview = PreviewTab(preview_size=100)
+        preview._schedule_start_next = lambda: None
+        generation_changes = []
+        started_workers = []
+        preview.previewGenerationChanged.connect(
+            lambda *args: generation_changes.append(args)
+            )
+
+        class ThreadPool:
+            def start(self, worker):
+                started_workers.append(worker)
+
+        preview.thread_pool = ThreadPool()
+        runs = {1: {"guid": "shared-guid", "run_timestamp": 100.0}}
+
+        preview.set_database_runs("old.db", runs)
+        preview._start_next()
+        stale_generation = preview.generation
+
+        preview.set_database_runs("current.db", runs)
+        preview._start_next()
+        current_generation = preview.generation
+
+        preview._worker_finished(stale_generation, "shared-guid", [], None)
+
+        self.assertEqual(len(started_workers), 2)
+        self.assertEqual(
+            preview.active,
+            {(current_generation, "shared-guid")},
+            )
+        self.assertEqual(
+            generation_changes,
+            [("shared-guid", True), ("shared-guid", True)],
+            )
+
+        preview._start_next = lambda: None
+        preview._worker_finished(current_generation, "shared-guid", [], None)
+
+        self.assertEqual(preview.active, set())
+        self.assertEqual(generation_changes[-1], ("shared-guid", False))
+
     def test_preview_tab_prioritizes_selected_then_visible_then_remaining_runs(self):
         preview = PreviewTab(preview_size=100)
         preview._start_next = lambda: None

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -864,6 +864,53 @@ class RunListTooltipTestCase(unittest.TestCase):
             treeWidgets.isfile = old_isfile
             treeWidgets.get_run_status = old_get_run_status
 
+    def test_check_watching_stops_completed_run_without_completion_timestamp(self):
+        old_isfile = treeWidgets.isfile
+        old_get_run_status = treeWidgets.get_run_status
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": None,
+                    "is_completed": False,
+                    "guid": "completed-guid",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 10,
+                    "setpoint_count": 100,
+                    "expected_results": 100,
+                    }
+                })
+            item = run_list.topLevelItem(0)
+
+            treeWidgets.get_run_status = lambda guid: {
+                "completed_timestamp": None,
+                "is_completed": True,
+                "result_count": 100,
+                "database_modified_timestamp": 120.0,
+                }
+
+            updated_runs = run_list.checkWatching()
+
+            self.assertEqual(run_list.watching, [])
+            self.assertTrue(updated_runs[1]["is_completed"])
+            self.assertIsNone(updated_runs[1]["completed_timestamp"])
+            self.assertEqual(
+                item.text(run_list.cols.index("Status")),
+                "✓",
+                )
+            self.assertEqual(
+                item.text(run_list.cols.index("Duration")),
+                "unknown",
+                )
+            self.assertIn("Complete</td>", item.toolTip(0))
+        finally:
+            treeWidgets.isfile = old_isfile
+            treeWidgets.get_run_status = old_get_run_status
+
     def test_run_table_measurement_previews_use_preview_metadata(self):
         old_isfile = treeWidgets.isfile
         treeWidgets.isfile = lambda _: False

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -499,6 +499,51 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
 
         self.assertEqual(candidates, [source])
 
+    def test_sibling_heatmap_cuts_remain_distinct_merge_candidates(self):
+        dataset_key = DatasetKey("database.db", "guid")
+
+        target_param = self.Param()
+        target_param.name = "line_signal"
+        target_param.depends_on = "gate"
+        target = plot1d.__new__(plot1d)
+        target._trace_key = TraceKey(dataset_key, target_param.name)
+        target.param = target_param
+        target.label = "ID:1 line_signal"
+        target.line = object()
+
+        heatmap_param = self.Param()
+        heatmap_param.name = "heatmap_signal"
+        heatmap_param.depends_on = "gate, field"
+
+        class sweeper:
+            def __init__(self, sweep_id):
+                self._trace_key = TraceKey(
+                    dataset_key,
+                    heatmap_param.name,
+                    sweep_id=sweep_id,
+                    )
+                self.param = heatmap_param
+                self.label = f"ID:1 heatmap_signal [cut {sweep_id + 1}]"
+                self.axis_options = {"x": target_param.depends_on}
+
+        first_cut = sweeper(0)
+        second_cut = sweeper(1)
+        first_line = type("Line", (), {"from_win": first_cut})()
+        target.lines = {
+            target.label: target.line,
+            first_cut._trace_key: first_line,
+            }
+        candidates = []
+        target.update_line_picker = lambda wins: candidates.extend(wins)
+
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.windows = [target, first_cut, second_cut]
+
+        harness.get_1d_wins(target)
+
+        self.assertNotEqual(first_cut._trace_key, second_cut._trace_key)
+        self.assertEqual(candidates, [second_cut])
+
     def test_closing_one_database_plot_keeps_other_database_handle(self):
         harness = type("Harness", (PlotActionsMixin,), {})()
         harness.config = self.Config()

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -15,7 +15,7 @@ from qplot.datahandling import database as database_module
 from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.windows import _database_actions as database_actions
 from qplot.windows import main as main_window
-from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey, TraceKey
 from qplot.windows._plot_actions import PlotActionsMixin
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._run_controls import AUTO_PLOT_KEY
@@ -27,6 +27,7 @@ from qplot.windows._window_controls import (
     add_restore_defaults_option,
     ask_confirmation_with_dont_ask_again,
 )
+from qplot.windows.plot1d import plot1d
 
 
 class MeasurementExportDataFrameTestCase(unittest.TestCase):
@@ -468,6 +469,35 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
 
         self.assertEqual(len(opened), 1)
         self.assertIs(opened[0][0][1], dataset_b)
+
+    def test_same_label_plot_from_another_database_is_a_merge_candidate(self):
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        param_a = self.Param()
+        param_a.depends_on = "x"
+        param_b = self.Param()
+        param_b.depends_on = "x"
+
+        target = plot1d.__new__(plot1d)
+        target._trace_key = TraceKey(key_a, param_a.name)
+        target.param = param_a
+        target.label = "ID:1 signal"
+        target.line = object()
+        target.lines = {target.label: target.line}
+        candidates = []
+        target.update_line_picker = lambda wins: candidates.extend(wins)
+
+        source = plot1d.__new__(plot1d)
+        source._trace_key = TraceKey(key_b, param_b.name)
+        source.param = param_b
+        source.label = target.label
+
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.windows = [target, source]
+
+        harness.get_1d_wins(target)
+
+        self.assertEqual(candidates, [source])
 
     def test_closing_one_database_plot_keeps_other_database_handle(self):
         harness = type("Harness", (PlotActionsMixin,), {})()

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -7,7 +7,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot.windows import _plotWin as plotwin_module
-from qplot.windows._dataset_handle import DatasetKey
+from qplot.windows._dataset_handle import DatasetKey, TraceKey
 from qplot.windows._plot1d_snap import _nearest_trace_sample
 from qplot.windows._plot1d_traces import (
     TRACE_COLOR_PALETTE,
@@ -32,6 +32,12 @@ class SnapToTraceTestCase(unittest.TestCase):
             def isEnabled(self):
                 return True
 
+            def currentData(self):
+                return "closed plot"
+
+            def currentIndex(self):
+                return 0
+
             def currentText(self):
                 return "closed plot"
 
@@ -40,7 +46,7 @@ class SnapToTraceTestCase(unittest.TestCase):
                 self.option_box = Combo()
                 self.resets = []
 
-            def reset_box(self, items):
+            def reset_box(self, items, item_data=None):
                 self.resets.append(items)
 
         host = Plot1DTraceMixin.__new__(Plot1DTraceMixin)
@@ -273,6 +279,39 @@ class SnapToTraceTestCase(unittest.TestCase):
         finally:
             action.deleteLater()
             widget.deleteLater()
+
+    def test_snap_report_keeps_cross_database_trace_display_label(self):
+        class Dataset:
+            run_id = 1
+
+        class Param:
+            name = "voltage"
+
+        class Source:
+            label = "ID:1 voltage"
+            ds = Dataset()
+            param = Param()
+
+        class Line:
+            from_win = Source()
+
+        trace_key = TraceKey(
+            DatasetKey("database-b.db", "shared-guid"),
+            "voltage",
+            )
+        window = plot1d.__new__(plot1d)
+        window.line = object()
+        window.lines = {trace_key: Line()}
+        window.trace_label = qtw.QLabel()
+        window.toolbarCo_ord = qtw.QToolBar()
+
+        window._show_snap_report(trace_key, 2)
+
+        self.assertEqual(
+            window.trace_label.text(),
+            "Snapped to run 1, trace voltage, point 2.",
+            )
+        self.assertEqual(window.trace_label.toolTip(), Source.label)
 
     def test_register_main_line_defers_until_line_exists(self):
         window = plot1d.__new__(plot1d)
@@ -707,7 +746,7 @@ class SnapToTraceTestCase(unittest.TestCase):
 
         self.assertIs(window.lines["main"], line)
 
-    def test_add_and_remove_secondary_trace_manages_right_axis(self):
+    def test_same_label_cross_database_trace_does_not_replace_main_line(self):
         class Theme:
             colors = [
                 QtGui.QColor("#008000"),
@@ -725,9 +764,10 @@ class SnapToTraceTestCase(unittest.TestCase):
             running = False
 
         class SourceWindow:
-            label = "ID:2 voltage"
-            _guid = "source-guid"
-            _dataset_key = DatasetKey("database.db", "source-guid")
+            label = "ID:1 voltage"
+            _guid = "shared-guid"
+            _dataset_key = DatasetKey("database-b.db", "shared-guid")
+            _trace_key = TraceKey(_dataset_key, "voltage")
             visible = False
             ds = Dataset()
             worker = Worker()
@@ -776,24 +816,33 @@ class SnapToTraceTestCase(unittest.TestCase):
             host.box_count = 1
             host.right_vb = None
             host.line = host.plot.plot(x=[0.0, 1.0], y=[1.0, 2.0])
-            host.lines = {"main": host.line}
+            host.label = source.label
+            host._dataset_key = DatasetKey("database-a.db", "shared-guid")
+            host._trace_key = TraceKey(host._dataset_key, "voltage")
+            host.lines = {host.label: host.line}
             host.axis_options = {"x": "gate", "y": "current"}
             host.mergable = [source]
             host.make_ds.connect(made_datasets.append)
             host.remove_dataset.connect(removed_datasets.append)
             host.get_mergables.connect(lambda: picker_updates.append(True))
 
-            selected_box = picker_1d(host, host.config, [source.label])
+            selected_box = picker_1d(
+                host,
+                host.config,
+                [source.label],
+                item_data=[source._trace_key],
+                )
             selected_box.option_box.setCurrentIndex(0)
             selected_box.axis_side.setCurrentText("Right")
             selected_box.color_box.setColor(host.config.theme.colors[1])
             host.option_boxes = [selected_box]
 
-            host.add_line(source.label)
-            secondary = host.lines[source.label]
+            host.add_line(source.label, source._trace_key)
+            secondary = host.lines[source._trace_key]
 
             self.assertEqual(made_datasets, [source._dataset_key])
             self.assertEqual(host.mergable, [])
+            self.assertIs(host.lines[host.label], host.line)
             self.assertIsNotNone(host.right_vb)
             self.assertEqual(secondary.side, "right")
             self.assertIn(secondary, host.right_vb.addedItems)
@@ -804,15 +853,16 @@ class SnapToTraceTestCase(unittest.TestCase):
             selected_box.color_box.selectedColor.emit(QtGui.QColor("#123456"))
             selected_box.axis_side.setCurrentText("Left")
 
-            style = host._trace_styles[source.label]
+            style = host._trace_styles[source._trace_key]
             self.assertEqual(style.line_color, "#123456")
             self.assertEqual(style.y_axis, "Left")
             self.assertEqual(secondary.opts["pen"].color().name(), style.line_color)
             self.assertEqual(secondary.side, "left")
 
-            host.remove_line(source.label)
+            host.remove_line(source.label, source._trace_key)
 
-            self.assertNotIn(source.label, host.lines)
+            self.assertNotIn(source._trace_key, host.lines)
+            self.assertIs(host.lines[host.label], host.line)
             self.assertNotIn(secondary, host.right_vb.addedItems)
             self.assertFalse(host.plot.getAxis("right").style["showValues"])
             self.assertEqual(removed_datasets, [source._dataset_key])

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -1402,6 +1402,39 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         self.assertTrue(window.relevel_refresh.checked)
         self.assertEqual(window.bar.values, (0.0, 40.0))
 
+    def test_colorbar_autoscale_ignores_empty_and_all_nonfinite_data(self):
+        for data in (
+                np.array([]),
+                np.array([[np.nan, np.inf, -np.inf]]),
+                ):
+            with self.subTest(data=data):
+                window = plot2d.__new__(plot2d)
+                window.bar = self.Colorbar()
+                window.bar.values = (10.0, 20.0)
+                window._colorbar_manual_levels = (10.0, 20.0)
+                window.dataGrid = data
+
+                window.scaleColorbar()
+
+                self.assertEqual(window.bar.values, (10.0, 20.0))
+                self.assertEqual(window._colorbar_manual_levels, (10.0, 20.0))
+
+    def test_constant_heatmap_uses_positive_finite_colorbar_rounding(self):
+        window = plot2d.__new__(plot2d)
+
+        for value in (0.0, 7.5, -7.5, np.nextafter(0.0, 1.0)):
+            with self.subTest(value=value):
+                window.dataGrid = np.full((2, 2), value)
+
+                rounding = window._data_colorbar_rounding()
+
+                self.assertTrue(np.isfinite(rounding))
+                self.assertGreaterEqual(rounding, np.finfo(float).tiny)
+
+                bar = pg.ColorBarItem(values=(0.0, 1.0), rounding=rounding)
+                bar._regionChanging()
+                self.assertTrue(np.isfinite(bar.values).all())
+
     def test_outside_colorbar_drag_widens_levels_about_midpoint(self):
         for start_y, drag_y in ((40.0, 24.0), (210.0, 226.0)):
             with self.subTest(start_y=start_y):

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -6,12 +6,55 @@ from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
 from qplot.tools.heatmap_geometry import HeatmapGeometry
-from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey, TraceKey
+from qplot.windows._plot2d_sweeps import Plot2DSweepMixin
 from qplot.windows._plotWin import plotWidget
+from qplot.windows._subplots.subplot2d import sweeper
 from qplot.windows.plot2d import _COLORBAR_COLORMAPS, plot2d
 
 
 class Plot2dLiveRefreshTestCase(unittest.TestCase):
+    def test_heatmap_cut_identity_includes_unique_id_and_visible_number(self):
+        cut = sweeper.__new__(sweeper)
+        cut.label = "ID:1 heatmap_signal"
+        cut.sweep_id = 4
+        cut._dataset_key = DatasetKey("database.db", "guid")
+        cut.param = type("Param", (), {"name": "heatmap_signal"})()
+
+        cut._set_cut_trace_identity()
+
+        self.assertEqual(cut.label, "ID:1 heatmap_signal [cut 5]")
+        self.assertEqual(
+            cut._trace_key,
+            TraceKey(cut._dataset_key, "heatmap_signal", sweep_id=4),
+            )
+
+    def test_heatmap_instances_emit_distinct_cut_ids(self):
+        class Signal:
+            def __init__(self):
+                self.emissions = []
+
+            def emit(self, *args):
+                self.emissions.append(args)
+
+        class Window(Plot2DSweepMixin):
+            def __init__(self):
+                self.z_index = [2, 3]
+                self.axis_options = {"x": "gate", "y": "field"}
+                self.open_subplot = Signal()
+                self._dataset_key = DatasetKey("database.db", "guid")
+                self.param = object()
+
+        first = Window()
+        second = Window()
+
+        first.openSweep("v")
+        second.openSweep("h")
+
+        first_cut_id = first.open_subplot.emissions[0][2][0]
+        second_cut_id = second.open_subplot.emissions[0][2][0]
+        self.assertNotEqual(first_cut_id, second_cut_id)
+
     def test_large_heatmap_range_controls_cover_axis_and_auto_actions(self):
         class Signal:
             def __init__(self):

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -114,7 +114,7 @@ def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
         line_dataset = load_by_id(line_run_id)
         line_param = dependent_parameter(line_dataset, 1)
         window.ds = line_dataset
-        window.openPlot(params=[line_param], show=False)
+        window.openPlot(params=[line_param], show=True)
         line_window = window.windows[-1]
         wait_for(
             lambda: (
@@ -126,6 +126,11 @@ def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
         assert line_window.axis_data["x"].size == 11
         assert line_window.axis_data["y"].size == 11
         assert np.isfinite(line_window.axis_data["y"]).all()
+        assert isinstance(window.x(), int)
+        assert isinstance(window.y(), int)
+        assert line_window.layout() is not None
+        assert line_window.width() > 0
+        assert line_window.height() > 0
 
         heatmap_dataset = load_by_id(heatmap_run_id)
         heatmap_param = dependent_parameter(heatmap_dataset, 2)


### PR DESCRIPTION
## Summary

- make 1D trace identity database-aware while preserving existing display labels
- give heatmap cuts application-session-unique identities and visibly numbered labels
- safely handle empty, non-finite, constant, and subnormal heatmap color ranges
- stop polling completed runs that lack a completion timestamp
- prevent stale preview callbacks from clearing current-generation activity
- make `has_finished()` return a scalar timestamp or `None`
- restore inherited Qt geometry/layout methods that were shadowed by instance fields
- add focused regressions for every fix and record them in the changelog

## Why

This addresses the seven concrete defects identified during the project-wide beta audit, plus the follow-up collision found when multiple cuts from one heatmap parameter were merged into a 1D plot.

The root causes were overloaded display labels used as trace identity, cut IDs that restarted for each heatmap, unchecked numeric reduction/rounding edge cases, inconsistent completion predicates, generation-insensitive worker bookkeeping, an incorrect SQL row return contract, and application fields named after inherited Qt methods.

## User impact

Plots from copied or separate databases can coexist safely even when run IDs and parameter names match. Multiple cuts from one heatmap can also coexist on a 1D plot without selecting the wrong cut, hiding valid choices, overwriting trace bookkeeping, or leaking dataset ownership. Cut choices are visibly numbered.

Heatmap autoscaling and colorbar interaction no longer fail on empty or constant data. Completed runs and preview workers settle correctly, and normal Qt window APIs remain callable.

## Validation

- `.venv-mac/bin/python -m pytest`: 429 passed, 73% branch coverage
- `.venv-mac/bin/python -m ruff check .`: passed
- `.venv-mac/bin/python -m mypy`: passed across 60 source files
- isolated sdist and wheel build: passed
- Twine checks for both artifacts: passed
- built-wheel import and packaged-schema smoke test: passed
- isolated offscreen qPlot startup: reached the event loop without an application error

## Scope

Bugfix-only. No version bump, dependency change, release publication, or unrelated UX/refactoring work is included.