### PR TITLE
Fix remaining beta trace and lifecycle bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,22 @@ installation commands and release validation, see `docs/distribution.md`.
   parameter names match.
 - Keep multiple cuts from the same heatmap distinct and visibly numbered when
   they are added to a 1D plot.
+- Refresh merged heatmap cuts as they move, clear them when their sweep axis is
+  incompatible, and avoid offering unsupported cut drag-and-drop.
+- Keep reordered and removed secondary traces safe during refresh, cleanup,
+  legacy picker selection, and Trace Appearance updates.
+- Preserve explicit database provenance while opening plots, and select the
+  exact same-label trace during cross-database drops without closing a visible
+  source window.
 - Ignore empty or entirely non-finite heatmap data when autoscaling the
   colorbar.
+- Give constant-valued heatmaps an accurate finite color scale, including at
+  floating-point extremes.
 - Keep colorbar interaction rounding finite and positive for constant-valued
   heatmaps.
 - Stop polling completed runs whose database row has no completion timestamp.
+- Detect live-plot completion even when no final data row is added, and ignore
+  late worker callbacks after their last dataset owner closes.
 - Prevent stale preview workers from clearing current-database worker state.
 - Return a scalar completion timestamp, or `None`, from `has_finished`.
 - Preserve the inherited Qt `layout()`, `width()`, `height()`, `x()`, and `y()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ installation commands and release validation, see `docs/distribution.md`.
 - Keep multiple cuts from the same heatmap distinct and visibly numbered when
   they are added to a 1D plot.
 - Refresh merged heatmap cuts as they move, clear them when their sweep axis is
-  incompatible, and avoid offering unsupported cut drag-and-drop.
+  incompatible, update Add to Plot choices when that axis changes, and handle
+  empty cut data without wedging its refresh worker.
+- Keep ordinary merged live traces updating after their source window closes,
+  while sharing and releasing hidden-source polling safely across target plots.
+- Release line and cut workers after rendering failures, and roll back failed
+  secondary-trace construction without leaking dataset ownership.
 - Keep reordered and removed secondary traces safe during refresh, cleanup,
   legacy picker selection, and Trace Appearance updates.
 - Preserve explicit database provenance while opening plots, and select the
@@ -24,11 +29,15 @@ installation commands and release validation, see `docs/distribution.md`.
   colorbar.
 - Give constant-valued heatmaps an accurate finite color scale, including at
   floating-point extremes.
-- Keep colorbar interaction rounding finite and positive for constant-valued
-  heatmaps.
+- Keep colorbar interaction rounding finite, positive, and synchronized with
+  changing levels, including constant and extreme-valued heatmaps.
 - Stop polling completed runs whose database row has no completion timestamp.
 - Detect live-plot completion even when no final data row is added, and ignore
   late worker callbacks after their last dataset owner closes.
+- Restart live polling after transient result-count failures, and prevent stale
+  closed-window callbacks from releasing the current worker's waiter.
+- Keep right-axis values synchronized with the traces that actually use them,
+  and make the mutually exclusive dot and marker controls behave consistently.
 - Prevent stale preview workers from clearing current-database worker state.
 - Return a scalar completion timestamp, or `None`, from `has_finished`.
 - Preserve the inherited Qt `layout()`, `width()`, `height()`, `x()`, and `y()`

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -149,6 +149,23 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             if line is not None and line is not main_line
             ]
 
+    def _sync_right_axis_visibility(self) -> None:
+        """Show right-axis values exactly when a secondary trace uses them."""
+
+        plot = self.__dict__.get("plot")
+        if plot is None:
+            return
+
+        main_line = self.__dict__.get("line")
+        styles = self._ensure_trace_styles()
+        show_values = any(
+            line is not None
+            and line is not main_line
+            and styles.get(key, self._initial_trace_style()).y_axis == "Right"
+            for key, line in self.__dict__.get("lines", {}).items()
+            )
+        plot.getAxis("right").setStyle(showValues=show_values)
+
     def _trace_display_label(self, key: Any, line: Any) -> str:
         """Return the unchanged user-facing label for an internally keyed trace."""
 
@@ -202,6 +219,10 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             label,
             self._initial_trace_style(),
             )
+        if self.__dict__.get("lines", {}).get(label) is self.__dict__.get("line"):
+            style.y_axis = "Left"
+            self._sync_trace_control(label)
+            return
         style.y_axis = "Right" if side.lower() == "right" else "Left"
         self._apply_trace_style(label, self.__dict__.get("lines", {}).get(label))
 
@@ -403,9 +424,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
                 and from_win.ds.running
                 and not from_win.monitor.isActive()
                 ):
-                from_win.spinBox.setValue(self.spinBox.value())
-                from_win.monitor.start(int(self.spinBox.value() * 1000))
-                self.spinBox.valueChanged.connect(line.from_win.spinBox.setValue)
+                from_win.monitorIntervalChanged(from_win.spinBox.value())
     
     
     @QtCore.pyqtSlot(str)
@@ -472,16 +491,30 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
                 )
             self.vb.autoRange_triggered.connect(self.right_vb.autoRange)
             
-        # Produce new box to allow another selection
-        self.add_option_box()
-        
         # Create and track new line
         self.make_ds.emit(win._dataset_key)
-        subplot = subplot1d(self, win)
         trace_key = self._window_trace_key(win)
+        try:
+            subplot = subplot1d(self, win)
+        except Exception:
+            self.remove_dataset.emit(win._dataset_key)
+            self.mergable.append(win)
+            for box in self.option_boxes:
+                if not self._picker_matches_trace(box, trace_key, label):
+                    continue
+                box.option_box.setEnabled(True)
+                box.del_box.setEnabled(False)
+                box.reset_box(
+                    [item.label for item in self.mergable],
+                    item_data=[self._window_trace_key(item) for item in self.mergable],
+                    )
+                break
+            raise
+
+        # Produce a new empty box for the next selection only after the line
+        # has been constructed successfully.
+        self.add_option_box()
         self.lines[trace_key] = subplot
-        
-        self.plot.getAxis('right').setStyle(showValues=True)
         
         # Connect box options to line
         selected_box = None
@@ -528,8 +561,13 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             if callable(disconnect_source_updates):
                 disconnect_source_updates()
             self.remove_dataset.emit(line.from_win._dataset_key)
-            if not line.from_win.visible:
-                line.from_win.monitor.stop()
+
+        main_line = self.__dict__.get("line")
+        self.lines = {
+            key: line
+            for key, line in self.__dict__.get("lines", {}).items()
+            if line is main_line
+            }
                 
             
         super().closeEvent(event)
@@ -580,17 +618,10 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         vb = self.plot if side.lower() == "left" else self.right_vb
         vb.removeItem(line)
 
-        if not any(
-                getattr(line, "side", "left") == "right"
-                for line in self.lines.values()
-                ):
-            self.plot.getAxis('right').setStyle(showValues=False)
+        self._sync_right_axis_visibility()
         
         # Remove track of window
         self.remove_dataset.emit(line.from_win._dataset_key)
-        # Stop refresh monitor for line if needed
-        if not line.from_win.visible:
-            line.from_win.monitor.stop()
         
         # Update box options
         self.get_mergables.emit()
@@ -649,6 +680,8 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     def _apply_trace_style(self, label: Any, line: Any) -> None:
         styles = self._ensure_trace_styles()
         style = styles.setdefault(label, self._initial_trace_style(order=len(styles)))
+        if style.dots_enabled and style.markers_enabled:
+            style.dots_enabled = False
         self._sync_trace_control(label)
         if line is None:
             return
@@ -679,6 +712,8 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         current_side = getattr(line, "side", "left")
         if hasattr(line, "set_side") and current_side != target_side:
             line.set_side(target_side)
+
+        self._sync_right_axis_visibility()
 
         z = style.order
         set_z = getattr(line, "setZValue", None)
@@ -1043,6 +1078,8 @@ class _TraceAppearanceDialog(qtw.QDialog):
             *self._dots_controls,
             *self._marker_controls,
             ]
+        self.dots_enable.toggled.connect(self._dots_enabled_changed)
+        self.marker_enable.toggled.connect(self._markers_enabled_changed)
         for _widget, signal in [
             (self.line_enable, self.line_enable.toggled), (self.line_color, self.line_color.currentIndexChanged),
             (self.line_width, self.line_width.valueChanged), (self.line_style, self.line_style.currentIndexChanged),
@@ -1054,6 +1091,28 @@ class _TraceAppearanceDialog(qtw.QDialog):
         ]:
             signal.connect(self._apply_selection)
         self._update_control_enabled_states(False)
+
+    def _dots_enabled_changed(self, enabled: bool) -> None:
+        if not enabled:
+            return
+
+        was_building = self._building
+        self._building = True
+        try:
+            self.marker_enable.setChecked(False)
+        finally:
+            self._building = was_building
+
+    def _markers_enabled_changed(self, enabled: bool) -> None:
+        if not enabled:
+            return
+
+        was_building = self._building
+        self._building = True
+        try:
+            self.dots_enable.setChecked(False)
+        finally:
+            self._building = was_building
 
     def _add_display_row(
             self,
@@ -1526,6 +1585,14 @@ class _TraceAppearanceDialog(qtw.QDialog):
             widget.setEnabled(has_selection and self.dots_enable.isChecked())
         for widget in self._marker_controls:
             widget.setEnabled(has_selection and self.marker_enable.isChecked())
+        selected_lines = [
+            self.owner.lines.get(label)
+            for label in self._selected_labels()
+            ] if has_selection else []
+        self.y_axis.setEnabled(
+            has_selection
+            and all(line is not self.owner.__dict__.get("line") for line in selected_lines)
+            )
         self._update_move_button_states()
 
     def _update_move_button_states(self) -> None:
@@ -1550,7 +1617,10 @@ class _TraceAppearanceDialog(qtw.QDialog):
             style.line_enabled = self.line_enable.isChecked(); style.line_color = self._combo_value(self.line_color); style.line_width = self.line_width.value(); style.line_style = self._combo_value(self.line_style)
             style.dots_enabled = self.dots_enable.isChecked(); style.dots_color = self._combo_value(self.dots_color); style.dots_size = self.dots_size.value()
             style.markers_enabled = self.marker_enable.isChecked(); style.markers_color = self._combo_value(self.marker_color); style.markers_symbol = self._combo_value(self.marker_symbol); style.markers_size = self.marker_size.value()
-            style.x_axis = self.x_axis.currentText(); style.y_axis = self.y_axis.currentText(); style.visible = self.visible.isChecked()
+            style.x_axis = self.x_axis.currentText()
+            if self.y_axis.isEnabled():
+                style.y_axis = self.y_axis.currentText()
+            style.visible = self.visible.isChecked()
             line = self.owner.lines.get(label)
             if line is not None:
                 self.owner._apply_trace_style(label, line)

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -112,6 +112,16 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
 
         return getattr(window, "_trace_key", getattr(window, "label", None))
 
+    @staticmethod
+    def _picker_matches_trace(box: Any, trace_key: Any, label: str) -> bool:
+        """Return whether a picker row represents the newly added trace."""
+
+        box_key = box.option_box.currentData()
+        return box_key == trace_key or (
+            box_key in (None, label)
+            and label == box.option_box.currentText()
+            )
+
     def _stored_trace_key(self, key: Any, line: Any) -> Any:
         """Return the source identity represented by one stored plot line."""
 
@@ -128,6 +138,16 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             self._stored_trace_key(stored_key, line) == trace_key
             for stored_key, line in self.__dict__.get("lines", {}).items()
             )
+
+    def _secondary_lines(self) -> list[Any]:
+        """Return secondary traces without relying on their display order."""
+
+        main_line = self.__dict__.get("line")
+        return [
+            line
+            for line in self.__dict__.get("lines", {}).values()
+            if line is not None and line is not main_line
+            ]
 
     def _trace_display_label(self, key: Any, line: Any) -> str:
         """Return the unchanged user-facing label for an internally keyed trace."""
@@ -375,7 +395,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         Refreshes added trace lines and restarts hidden live-trace monitors.
 
         """
-        for line in list(self.lines.values())[1:]:
+        for line in self._secondary_lines():
             line.refresh()
             from_win = line.from_win
             if (
@@ -466,10 +486,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         # Connect box options to line
         selected_box = None
         for box in self.option_boxes:
-            box_key = box.option_box.currentData()
-            if box_key == trace_key or (
-                    box_key is None and label == box.option_box.currentText()
-                    ):
+            if self._picker_matches_trace(box, trace_key, label):
                 
                 box.color_box.selectedColor.connect(
                     lambda color, selected_key=trace_key: self._set_trace_line_color(
@@ -502,7 +519,14 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
     @QtCore.pyqtSlot(bool)
     def closeEvent(self, event: object) -> None:
         # Stopped lines as needed
-        for line in list(self.lines.values())[1:]:
+        for line in self._secondary_lines():
+            disconnect_source_updates = getattr(
+                line,
+                "disconnect_source_updates",
+                None,
+                )
+            if callable(disconnect_source_updates):
+                disconnect_source_updates()
             self.remove_dataset.emit(line.from_win._dataset_key)
             if not line.from_win.visible:
                 line.from_win.monitor.stop()
@@ -545,6 +569,13 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         self.lines.pop(selected_key)
         self._trace_styles.pop(selected_key, None)
         self._ensure_trace_controls().pop(selected_key, None)
+        disconnect_source_updates = getattr(
+            line,
+            "disconnect_source_updates",
+            None,
+            )
+        if callable(disconnect_source_updates):
+            disconnect_source_updates()
         # Fetch correct viewbox to remove from
         vb = self.plot if side.lower() == "left" else self.right_vb
         vb.removeItem(line)
@@ -565,6 +596,9 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         self.get_mergables.emit()
         # Resize dock widget
         self._resize_scrollArea()
+        dialog = self.__dict__.get("_trace_appearance_dialog")
+        if dialog is not None:
+            dialog.refresh_rows()
     
     
     @QtCore.pyqtSlot(object)
@@ -700,7 +734,6 @@ class _TraceTableWidget(qtw.QTableWidget):
         trace_key = self.dialog._trace_key_for_row(index.row())
         mime_data = self.dialog._trace_mime_data(trace_key)
         if mime_data is None:
-            super().startDrag(supported_actions)
             return
 
         style = self.dialog.owner._trace_styles.get(trace_key)
@@ -1307,6 +1340,7 @@ class _TraceAppearanceDialog(qtw.QDialog):
                 label = self.owner._trace_display_label(trace_key, line)
                 trace_id = label.split()[0].replace("ID:", "") if label.startswith("ID:") else str(row + 1)
                 measurement = self.owner._trace_measurement_name(trace_key, line)
+                trace_is_draggable = self._trace_mime_data(trace_key) is not None
                 style = self.owner._trace_styles.setdefault(
                     trace_key,
                     self.owner._initial_trace_style(order=row),
@@ -1318,7 +1352,10 @@ class _TraceAppearanceDialog(qtw.QDialog):
                     }
                 for col, value in values.items():
                     item = qtw.QTableWidgetItem(value)
-                    item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+                    flags = item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable
+                    if not trace_is_draggable:
+                        flags &= ~QtCore.Qt.ItemFlag.ItemIsDragEnabled
+                    item.setFlags(flags)
                     if col == self._COL_ID:
                         item.setTextAlignment(
                             QtCore.Qt.AlignmentFlag.AlignRight
@@ -1332,11 +1369,17 @@ class _TraceAppearanceDialog(qtw.QDialog):
                 preview_item = qtw.QTableWidgetItem()
                 preview_item.setIcon(self._trace_icon(style))
                 preview_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-                preview_item.setFlags(
-                    (preview_item.flags() | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
+                preview_flags = (
+                    preview_item.flags()
                     & ~QtCore.Qt.ItemFlag.ItemIsEditable
                     )
-                preview_item.setToolTip("Drag trace preview")
+                if trace_is_draggable:
+                    preview_flags |= QtCore.Qt.ItemFlag.ItemIsDragEnabled
+                    preview_item.setToolTip("Drag trace preview")
+                else:
+                    preview_flags &= ~QtCore.Qt.ItemFlag.ItemIsDragEnabled
+                    preview_item.setToolTip("This trace cannot be dragged between plots")
+                preview_item.setFlags(preview_flags)
                 self.table.setItem(row, self._COL_PREVIEW, preview_item)
 
                 label_item = self.table.item(row, self._COL_ID)
@@ -1412,7 +1455,9 @@ class _TraceAppearanceDialog(qtw.QDialog):
         for idx in selection_model.selectedRows():
             item = self.table.item(idx.row(), self._COL_ID)
             if item is not None:
-                labels.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
+                label = item.data(QtCore.Qt.ItemDataRole.UserRole)
+                if label in self.owner.lines:
+                    labels.append(label)
         return labels
 
     def _trace_key_for_row(self, row: int) -> Any:
@@ -1434,7 +1479,11 @@ class _TraceAppearanceDialog(qtw.QDialog):
         guid = getattr(source, "_guid", "")
         param = getattr(source, "param", None)
         parameter = getattr(param, "name", "")
-        if not guid or not parameter:
+        if (
+                not guid
+                or not parameter
+                or len(getattr(param, "depends_on_", ())) != 1
+                ):
             return None
         return make_run_preview_mime(
             guid,

--- a/src/qplot/windows/_plot2d_colorbar.py
+++ b/src/qplot/windows/_plot2d_colorbar.py
@@ -119,8 +119,14 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
         if levels is None:
             return 1e-5
 
-        vmin, vmax = levels
-        span = vmax - vmin
+        return self._colorbar_rounding_for_levels(*levels)
+
+    @staticmethod
+    def _colorbar_rounding_for_levels(vmin, vmax):
+        """Return an interaction step appropriate for specific levels."""
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            span = float(vmax) - float(vmin)
         if not np.isfinite(span) or span <= 0:
             span = max(abs(vmin), abs(vmax))
         if not np.isfinite(span) or span <= 0:
@@ -139,6 +145,17 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
         """
         bar = self.__dict__.get("bar")
         if bar is not None:
+            bar.rounding = self._colorbar_rounding_for_levels(vmin, vmax)
+            finite_limit = np.finfo(float).max
+            bar.lo_lim = -finite_limit
+            bar.hi_lim = finite_limit
+            with np.errstate(over="ignore", invalid="ignore"):
+                span = float(vmax) - float(vmin)
+            interaction_enabled = bool(np.isfinite(span) and span > 0)
+            region = getattr(bar, "region", None)
+            if region is not None:
+                region.setEnabled(interaction_enabled)
+                bar.region_changed_enable = interaction_enabled
             bar.setLevels((vmin, vmax))
             self._sync_colorbar_axis_scaling()
 

--- a/src/qplot/windows/_plot2d_colorbar.py
+++ b/src/qplot/windows/_plot2d_colorbar.py
@@ -62,10 +62,41 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
             return None
 
         vmin, vmax = data_range
-        if vmin >= vmax:
+        if vmin == vmax:
+            return self._constant_colorbar_levels(vmin)
+        if vmin > vmax:
             return None
 
         return vmin, vmax
+
+    @staticmethod
+    def _constant_colorbar_levels(value):
+        """Return a small finite range containing one constant data value."""
+
+        value = float(value)
+        if not np.isfinite(value):
+            return None
+
+        if value == 0.0:
+            padding = 1e-6
+        else:
+            padding = abs(value) * 1e-6
+
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            low = value - padding
+            high = value + padding
+            if np.isfinite(low) and np.isfinite(high) and low < high:
+                return float(low), float(high)
+
+            low = float(np.nextafter(value, -np.inf))
+            high = float(np.nextafter(value, np.inf))
+        if not np.isfinite(low):
+            low = value
+        if not np.isfinite(high):
+            high = value
+        if low < high:
+            return low, high
+        return None
 
     def _finite_data_colorbar_range(self):
         """Return the finite data range without reducing an empty array."""
@@ -84,11 +115,11 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
     def _data_colorbar_rounding(self):
         """Return a finite, positive colorbar interaction step."""
 
-        data_range = self._finite_data_colorbar_range()
-        if data_range is None:
+        levels = self._data_colorbar_levels()
+        if levels is None:
             return 1e-5
 
-        vmin, vmax = data_range
+        vmin, vmax = levels
         span = vmax - vmin
         if not np.isfinite(span) or span <= 0:
             span = max(abs(vmin), abs(vmax))
@@ -96,7 +127,7 @@ class Plot2DColorbarMixin(ColorbarScaleDialogMixin):
             span = 1.0
 
         rounding = span / 1e5
-        minimum_rounding = np.finfo(float).tiny
+        minimum_rounding = np.nextafter(0.0, 1.0)
         if not np.isfinite(rounding) or rounding < minimum_rounding:
             return float(minimum_rounding)
         return float(rounding)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -208,6 +208,7 @@ class plotWidget(
         self.last_ds_len = self.ds.number_of_results
         self.config = config
         self.visible = show
+        self._closed = False
         self.operations = {}
         self._last_error_text = None
         self.show_status("Working, please wait", 0)
@@ -1195,8 +1196,8 @@ class plotWidget(
         """
         self.monitor.stop()
         self.visible = False
-        self.closed.emit(self) 
-        del self # Pretty much pointless but its here anyway.
+        self._closed = True
+        self.closed.emit(self)
 
 
     @QtCore.pyqtSlot(object)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -156,6 +156,7 @@ class plotWidget(
     end_wait = QtCore.pyqtSignal()
     make_ds = QtCore.pyqtSignal([object])
     previewTraceDropRequested = QtCore.pyqtSignal(object, object, str)
+    trace_updated = QtCore.pyqtSignal()
     
     _label_width = 95 #About the size of 3 s.f. scientific
     def __init__(self, 
@@ -209,6 +210,7 @@ class plotWidget(
         self.config = config
         self.visible = show
         self._closed = False
+        self._merged_trace_users = 0
         self.operations = {}
         self._last_error_text = None
         self.show_status("Working, please wait", 0)
@@ -1194,10 +1196,18 @@ class plotWidget(
         Unused but required by slot.
 
         """
-        self.monitor.stop()
+        if self.__dict__.get("_merged_trace_users", 0) <= 0:
+            self.monitor.stop()
         self.visible = False
         self._closed = True
         self.closed.emit(self)
+
+        if (
+                self.__dict__.get("_merged_trace_users", 0) > 0
+                and self.ds.running
+                and not self.monitor.isActive()
+                ):
+            self.monitorIntervalChanged(self.spinBox.value())
 
 
     @QtCore.pyqtSlot(object)

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -142,12 +142,14 @@ class PlotActionsMixin:
             win.close_sweeps_requested.connect(self.close_sweeps_from_plot)
 
         elif window_type == "sweeper":
+            win.merge_compatibility_changed.connect(self.post_admin)
             for item in self.windows:
                 if item.ds == win.ds and item.param == win.param and isinstance(item, plot2d):
                     win.sweep_moved.connect(item.update_sweep_line)
                     win.remove_sweep.connect(item.remove_sweep)
                     item.sweep_moved.connect(win.update_sweep_line)
                     break
+            self.post_admin()
 
         if show:
             win.update_theme(self.config)
@@ -726,8 +728,7 @@ class PlotActionsMixin:
                 continue
             try:
                 if win._dataset_key == source_key and win.param.name == param.name:
-                    if win.ds.running and not target_win.monitor.isActive():
-                        target_win.monitorIntervalChanged(target_win.spinBox.value())
+                    if win.ds.running:
                         target_win.toolbarRef.show()
                     return win
             except AttributeError:

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -22,6 +22,20 @@ def _plot_has_trace_window(target, candidate):
     return candidate.label in target.lines
 
 
+def _combo_index_for_data(combo, value):
+    """Return the first combo row whose Python user data equals ``value``."""
+
+    count = getattr(combo, "count", None)
+    item_data = getattr(combo, "itemData", None)
+    if not callable(count) or not callable(item_data):
+        return -1
+
+    for index in range(count()):
+        if item_data(index) == value:
+            return index
+    return -1
+
+
 class PlotActionsMixin:
     """
     Plot launching, preview plotting, CSV export, and plot dataset tracking.
@@ -47,7 +61,15 @@ class PlotActionsMixin:
 
 
     @QtCore.pyqtSlot(object, object, tuple)
-    def openWin(self, widget, key_or_ds, *args, show=True, **kargs):
+    def openWin(
+            self,
+            widget,
+            key_or_ds,
+            *args,
+            show=True,
+            dataset_key: DatasetKey | None = None,
+            **kargs,
+            ):
         """
         Handles opening Plot window, widget.
 
@@ -57,11 +79,15 @@ class PlotActionsMixin:
 
         if isinstance(key_or_ds, DatasetKey):
             ds = None
+            if dataset_key is not None and dataset_key != key_or_ds:
+                raise ValueError("Conflicting dataset keys supplied while opening a plot.")
             dataset_key = key_or_ds
         else:
             ds = key_or_ds
-            dataset_key = self._current_dataset_key(ds.guid)
+            if dataset_key is None:
+                dataset_key = self._current_dataset_key(ds.guid)
 
+        assert dataset_key is not None
         shared_handle = self.dataset_holder.get(dataset_key)
         loaded_for_construction = shared_handle is None and ds is None
         if shared_handle is not None:
@@ -455,6 +481,7 @@ class PlotActionsMixin:
                         param,
                         refrate=self.spinBox.value(),
                         show=show,
+                        dataset_key=dataset_key,
                     )
                     opened += 1
 
@@ -477,6 +504,7 @@ class PlotActionsMixin:
                         param,
                         refrate=self.spinBox.value(),
                         show=show,
+                        dataset_key=dataset_key,
                     )
                     opened += 1
 
@@ -634,8 +662,7 @@ class PlotActionsMixin:
             box = target_win.option_boxes[-1]
 
         source_trace_key = getattr(from_win, "_trace_key", from_win.label)
-        find_data = getattr(box.option_box, "findData", None)
-        index = find_data(source_trace_key) if callable(find_data) else -1
+        index = _combo_index_for_data(box.option_box, source_trace_key)
         if index < 0:
             index = box.option_box.findText(from_win.label)
         if index < 0:
@@ -648,7 +675,8 @@ class PlotActionsMixin:
             return False
 
         box.option_box.setCurrentIndex(index)
-        from_win.close()
+        if not getattr(from_win, "visible", False):
+            from_win.close()
         return True
 
 

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -72,6 +72,9 @@ class PlotRefreshMixin(_PlotRefreshBase):
         if not self.__dict__.get("_closed", False):
             return True
 
+        if self.__dict__.get("_merged_trace_users", 0) <= 0:
+            return False
+
         dataset_holder = self.__dict__.get("_dataset_holder")
         dataset_key = self.__dict__.get("_dataset_key")
         if not isinstance(dataset_holder, dict) or dataset_key is None:
@@ -208,10 +211,12 @@ class PlotRefreshMixin(_PlotRefreshBase):
             return
 
         retry = False
-        dataset = self.ds
-        current_ds_len = dataset.number_of_results
+        dataset = None
 
         try:
+            dataset = self.ds
+            current_ds_len = dataset.number_of_results
+
             # Plot has started, worker first defined in initFrame
             if not hasattr(self, "worker"):
                 self.initFrame()  # defined in children classes
@@ -233,21 +238,33 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 # when there is no plot data to reload.
                 self._sync_dataset_completion(dataset)
 
+        except Exception:
+            retry = True
+            raise
+
         finally:  # Ran after return or otherwise
 
             # restart monitor
-            if dataset.running or retry:
+            if retry or (dataset is not None and dataset.running):
                 self.monitorIntervalChanged(self.spinBox.value())
 
             # restard monitor if any subplots are live
-            else:
+            elif dataset is not None:
                 lines = self.__dict__.get("lines")
                 if isinstance(lines, dict) and lines:
                     main_line = self.__dict__.get("line")
                     for subplot in lines.values():
                         if subplot is main_line:
                             continue
-                        if getattr(subplot, "running", False):
+                        source = getattr(subplot, "from_win", None)
+                        source_dataset = getattr(source, "ds", None)
+                        running = getattr(
+                            source_dataset,
+                            "running",
+                            getattr(subplot, "running", False),
+                            )
+                        subplot.running = bool(running)
+                        if running:
                             self.monitorIntervalChanged(self.spinBox.value())
                             break
 
@@ -272,17 +289,18 @@ class PlotRefreshMixin(_PlotRefreshBase):
         if worker is None:
             worker = self.__dict__.get("worker")
 
-        if not self._can_process_refresh():
-            if worker is not None:
-                worker.running = False
-            self.end_wait.emit()
-            return False
-
         if worker is None:
             return False
 
-        if worker is not self.worker:
+        current_worker = self.__dict__.get("worker")
+        if worker is not current_worker:
             worker.running = False
+            return False
+        worker = current_worker
+
+        if not self._can_process_refresh():
+            worker.running = False
+            self.end_wait.emit()
             return False
 
         try:

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -66,6 +66,26 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
     """
 
+    def _can_process_refresh(self) -> bool:
+        """Return whether this window still has an active dataset owner."""
+
+        if not self.__dict__.get("_closed", False):
+            return True
+
+        dataset_holder = self.__dict__.get("_dataset_holder")
+        dataset_key = self.__dict__.get("_dataset_key")
+        if not isinstance(dataset_holder, dict) or dataset_key is None:
+            return False
+
+        handle = dataset_holder.get(dataset_key)
+        return handle is not None and getattr(handle, "users", 0) > 0
+
+    def _sync_dataset_completion(self, dataset: Any) -> None:
+        """Refresh cached QCoDeS completion state without loading plot data."""
+
+        if getattr(dataset, "running", False):
+            load_param_data_from_db_prep(dataset.cache, self.param)
+
     def load_data(
             self,
             wait_on_thread: bool = False,
@@ -89,6 +109,9 @@ class PlotRefreshMixin(_PlotRefreshBase):
             worker has finished its task. The default is False.
 
         """
+        if not self._can_process_refresh():
+            return False
+
         try:
             operations = self.oper_widget.get_data()
         except OperationValidationError as error:
@@ -181,8 +204,12 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
         """
         self.monitor.stop()
+        if not self._can_process_refresh():
+            return
+
         retry = False
-        current_ds_len = self.ds.number_of_results
+        dataset = self.ds
+        current_ds_len = dataset.number_of_results
 
         try:
             # Plot has started, worker first defined in initFrame
@@ -200,18 +227,29 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 # The actual refresh line
                 self.load_data()
 
+            elif dataset.running:
+                # Completion is a runs-table update and need not add a final
+                # result row. Keep QCoDeS' cached ``running`` flag in sync even
+                # when there is no plot data to reload.
+                self._sync_dataset_completion(dataset)
+
         finally:  # Ran after return or otherwise
 
             # restart monitor
-            if self.ds.running or retry:
+            if dataset.running or retry:
                 self.monitorIntervalChanged(self.spinBox.value())
 
             # restard monitor if any subplots are live
-            elif hasattr(self, "lines") and self.lines:
-                for subplot in list(self.lines.values())[1:]:
-                    if subplot.running:
-                        self.monitorIntervalChanged(self.spinBox.value())
-                        break
+            else:
+                lines = self.__dict__.get("lines")
+                if isinstance(lines, dict) and lines:
+                    main_line = self.__dict__.get("line")
+                    for subplot in lines.values():
+                        if subplot is main_line:
+                            continue
+                        if getattr(subplot, "running", False):
+                            self.monitorIntervalChanged(self.spinBox.value())
+                            break
 
 
     @QtCore.pyqtSlot(bool)
@@ -232,7 +270,16 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
         """
         if worker is None:
-            worker = self.worker
+            worker = self.__dict__.get("worker")
+
+        if not self._can_process_refresh():
+            if worker is not None:
+                worker.running = False
+            self.end_wait.emit()
+            return False
+
+        if worker is None:
+            return False
 
         if worker is not self.worker:
             worker.running = False
@@ -331,6 +378,11 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
     @QtCore.pyqtSlot(Exception)
     def err_raiser(self, err: Exception, worker: Any | None = None) -> None:
+        if not self._can_process_refresh():
+            if worker is not None:
+                worker.running = False
+            return
+
         if worker is not None and worker is not self.worker:
             return
 
@@ -348,6 +400,9 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
     @QtCore.pyqtSlot(str)
     def worker_printer(self, fstr: str, worker: Any | None = None) -> None:
+        if not self._can_process_refresh():
+            return
+
         if worker is not None and worker is not self.worker:
             return
 

--- a/src/qplot/windows/_subplots/subplot1d.py
+++ b/src/qplot/windows/_subplots/subplot1d.py
@@ -3,6 +3,37 @@ from PyQt6 import QtCore
 from PyQt6.QtGui import QColor
 
 
+def _subplot_axis_order(
+        parent_options: dict[str, str],
+        source_options: dict[str, str],
+        *,
+        source_is_cut: bool = False,
+        ) -> tuple[str, str] | None:
+    """Map source data axes onto a host plot, or reject incompatible axes."""
+
+    if source_is_cut:
+        shared_axis = source_options.get("x")
+        if not shared_axis:
+            return None
+        if parent_options.get("x") == shared_axis:
+            return "x", "y"
+        if parent_options.get("y") == shared_axis:
+            return "y", "x"
+        return None
+
+    if (
+            parent_options.get("x") == source_options.get("x")
+            or parent_options.get("y") == source_options.get("y")
+            ):
+        return "x", "y"
+    if (
+            parent_options.get("x") == source_options.get("y")
+            or parent_options.get("y") == source_options.get("x")
+            ):
+        return "y", "x"
+    return None
+
+
 class subplot1d(pg.PlotDataItem):
     """
     Class for handling secondary line plots on plot1d
@@ -16,21 +47,28 @@ class subplot1d(pg.PlotDataItem):
         
         self.parent = parent
         self.from_win = from_win
-        
+
+        self.choose_from: tuple[str, str] | None = None
+        self._source_update_signal = getattr(from_win, "sweep_moved", None)
+        if self._source_update_signal is not None:
+            self._source_update_signal.connect(self._source_sweep_changed)
+
         self.refresh()
         
         self.side = "left"
         self.parent.plot.addItem(self)
             
             
-    def refresh(self):
+    def refresh(self, *, source_ready: bool = False):
         """
         Fetches data from source window and updates view on parent window
 
         """
         parent = self.parent
         from_win = self.from_win
-        
+
+        self._disconnect_pending_update()
+
         # Update live state
         self.running = from_win.ds.running
         
@@ -38,18 +76,53 @@ class subplot1d(pg.PlotDataItem):
         parent_options = parent.axis_options
         from_win_options = from_win.axis_options
 
-        # for subplot, must share 1 axis parameter name, so check if flipped
-        if parent_options["x"] == from_win_options["x"] or parent_options["y"] == from_win_options["y"]:
-            self.choose_from = ["x", "y"]
-        else:
-            self.choose_from = ["y", "x"]
-            
+        self.choose_from = _subplot_axis_order(
+            parent_options,
+            from_win_options,
+            source_is_cut=hasattr(from_win, "sweep_id"),
+            )
+        if self.choose_from is None:
+            self.setData(x=[], y=[])
+            return
+
         # Wait for data to finish
-        if from_win.worker.running:
+        if from_win.worker.running and not source_ready:
             from_win.end_wait.connect(self.call_update)
         else:
             self.call_update()
-            
+
+
+    @QtCore.pyqtSlot(int, str, str, int, object)
+    def _source_sweep_changed(
+            self,
+            _sweep_id,
+            _sweep_indep,
+            _fixed_indep,
+            _fixed_index,
+            _pen,
+            ):
+        """Refresh immediately after a cut publishes new, ready-to-use data."""
+
+        self.refresh(source_ready=True)
+
+
+    def _disconnect_pending_update(self):
+        try:
+            self.from_win.end_wait.disconnect(self.call_update)
+        except TypeError:  # Signal was not connected.
+            pass
+
+
+    def disconnect_source_updates(self):
+        """Release the persistent cut-update connection when a trace is removed."""
+
+        if self._source_update_signal is not None:
+            try:
+                self._source_update_signal.disconnect(self._source_sweep_changed)
+            except TypeError:  # Signal was already disconnected.
+                pass
+            self._source_update_signal = None
+        self._disconnect_pending_update()
     
     @QtCore.pyqtSlot()
     def call_update(self):
@@ -59,10 +132,16 @@ class subplot1d(pg.PlotDataItem):
 
         """
         data = {}
-    
+
+        choose_from = self.choose_from
+        if choose_from is None:
+            self.setData(x=[], y=[])
+            self._disconnect_pending_update()
+            return
+
         # Assign data to correct axis
         for itr, axis in enumerate(["x", "y"]):
-            data[axis] = self.from_win.axis_data[self.choose_from[itr]]
+            data[axis] = self.from_win.axis_data[choose_from[itr]]
                     
         # Updates display
         self.setData(
@@ -70,10 +149,7 @@ class subplot1d(pg.PlotDataItem):
             y=data["y"],
             )
         
-        try:
-            self.from_win.end_wait.disconnect(self.call_update)
-        except TypeError: # Type error if not connected
-            pass
+        self._disconnect_pending_update()
     
     @QtCore.pyqtSlot(QColor)
     def set_color(self, col):

--- a/src/qplot/windows/_subplots/subplot1d.py
+++ b/src/qplot/windows/_subplots/subplot1d.py
@@ -47,16 +47,29 @@ class subplot1d(pg.PlotDataItem):
         
         self.parent = parent
         self.from_win = from_win
+        self._source_consumer_registered = False
+        self._source_interval_signal = None
+        self._source_interval_slot = None
 
         self.choose_from: tuple[str, str] | None = None
-        self._source_update_signal = getattr(from_win, "sweep_moved", None)
+        self._source_update_signal = getattr(from_win, "trace_updated", None)
         if self._source_update_signal is not None:
-            self._source_update_signal.connect(self._source_sweep_changed)
+            self._source_update_signal.connect(self._source_trace_updated)
+        self._source_compatibility_signal = getattr(
+            from_win,
+            "merge_compatibility_changed",
+            None,
+            )
+        if self._source_compatibility_signal is not None:
+            self._source_compatibility_signal.connect(
+                self._source_compatibility_changed
+                )
 
         self.refresh()
         
         self.side = "left"
         self.parent.plot.addItem(self)
+        self._register_source_consumer()
             
             
     def refresh(self, *, source_ready: bool = False):
@@ -87,30 +100,92 @@ class subplot1d(pg.PlotDataItem):
 
         # Wait for data to finish
         if from_win.worker.running and not source_ready:
-            from_win.end_wait.connect(self.call_update)
-        else:
-            self.call_update()
+            if self._source_update_signal is None:
+                from_win.end_wait.connect(self.call_update)
+            return
+
+        self.call_update()
 
 
-    @QtCore.pyqtSlot(int, str, str, int, object)
-    def _source_sweep_changed(
-            self,
-            _sweep_id,
-            _sweep_indep,
-            _fixed_indep,
-            _fixed_index,
-            _pen,
-            ):
+    @QtCore.pyqtSlot()
+    def _source_trace_updated(self):
         """Refresh immediately after a cut publishes new, ready-to-use data."""
 
         self.refresh(source_ready=True)
 
 
+    @QtCore.pyqtSlot()
+    def _source_compatibility_changed(self):
+        """Clear old cut data until the changed axes publish replacement data."""
+
+        self._disconnect_pending_update()
+        self.choose_from = _subplot_axis_order(
+            self.parent.axis_options,
+            self.from_win.axis_options,
+            source_is_cut=hasattr(self.from_win, "sweep_id"),
+            )
+        self.setData(x=[], y=[])
+
+
     def _disconnect_pending_update(self):
         try:
             self.from_win.end_wait.disconnect(self.call_update)
-        except TypeError:  # Signal was not connected.
+        except (TypeError, RuntimeError):  # Signal was absent or already gone.
             pass
+
+
+    def _register_source_consumer(self):
+        if self._source_consumer_registered:
+            return
+
+        source = self.from_win
+        source._merged_trace_users = max(
+            int(getattr(source, "_merged_trace_users", 0)),
+            0,
+            ) + 1
+        self._source_consumer_registered = True
+
+        if not getattr(source, "visible", True):
+            parent_spinbox = getattr(self.parent, "spinBox", None)
+            source_spinbox = getattr(source, "spinBox", None)
+            if parent_spinbox is not None and source_spinbox is not None:
+                source_spinbox.setValue(parent_spinbox.value())
+                interval_signal = getattr(parent_spinbox, "valueChanged", None)
+                if interval_signal is not None:
+                    interval_slot = source_spinbox.setValue
+                    interval_signal.connect(interval_slot)
+                    self._source_interval_signal = interval_signal
+                    self._source_interval_slot = interval_slot
+
+        if (
+                getattr(source, "_closed", False)
+                and getattr(source.ds, "running", False)
+                and not source.monitor.isActive()
+                ):
+            source.monitorIntervalChanged(source.spinBox.value())
+
+
+    def _release_source_consumer(self):
+        if not self._source_consumer_registered:
+            return
+
+        source = self.from_win
+        remaining = max(int(getattr(source, "_merged_trace_users", 1)) - 1, 0)
+        source._merged_trace_users = remaining
+        self._source_consumer_registered = False
+
+        if self._source_interval_signal is not None:
+            try:
+                self._source_interval_signal.disconnect(self._source_interval_slot)
+            except (TypeError, RuntimeError):  # Signal was absent or already gone.
+                pass
+            self._source_interval_signal = None
+            self._source_interval_slot = None
+
+        if remaining == 0 and not getattr(source, "visible", True):
+            monitor = getattr(source, "monitor", None)
+            if monitor is not None:
+                monitor.stop()
 
 
     def disconnect_source_updates(self):
@@ -118,11 +193,20 @@ class subplot1d(pg.PlotDataItem):
 
         if self._source_update_signal is not None:
             try:
-                self._source_update_signal.disconnect(self._source_sweep_changed)
-            except TypeError:  # Signal was already disconnected.
+                self._source_update_signal.disconnect(self._source_trace_updated)
+            except (TypeError, RuntimeError):  # Signal was absent or already gone.
                 pass
             self._source_update_signal = None
+        if self._source_compatibility_signal is not None:
+            try:
+                self._source_compatibility_signal.disconnect(
+                    self._source_compatibility_changed
+                    )
+            except (TypeError, RuntimeError):  # Signal was absent or already gone.
+                pass
+            self._source_compatibility_signal = None
         self._disconnect_pending_update()
+        self._release_source_consumer()
     
     @QtCore.pyqtSlot()
     def call_update(self):

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import numpy as np
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
@@ -21,6 +22,7 @@ class sweeper(plotWidget):
     their counterpart.
     """
     sweep_moved = QtCore.pyqtSignal([int, str, str, int, object])
+    merge_compatibility_changed = QtCore.pyqtSignal()
     remove_sweep = QtCore.pyqtSignal([int])
     
     def __init__(self,
@@ -144,35 +146,68 @@ class sweeper(plotWidget):
             is not ran.
 
         """
+        plot_worker = worker if worker is not None else self.worker
         if not super().refreshPlot(finished, worker=worker):
             return
-        
-        ### NOTE. self.axis_data["y"] is set to fixed param in super().refreshPlot,
-        ###       then updated to y axis value (indep param) in self.update_sweep()
-        self.fixed_indep_data = self.axis_data["y"]
-        
-        # Get correct row and param for y data
-        self.axis_param["y"] = getattr(self, "display_param", self.param)
-        
-        # Set-up fixed axis picker and slide
-        # Match range to index of fixed param data
-        self.picker.slider.setRange(0, len(self.fixed_indep_data) - 1)
-        
-        # Refresh plot
-        # blank text_box means slider signal blocked, during axis switch
-        if not self.picker.text_box.text():
-            self.picker.slider.setValue(self.fixed_index) 
-            self.picker.text_box.setText(
-                self.formatNum(self.fixed_indep_data[self.fixed_index])
+
+        try:
+            x_data = np.asarray(self.axis_data.get("x", []))
+            fixed_data = np.asarray(self.axis_data.get("y", []))
+            data_grid = np.asarray(self.dataGrid)
+            has_cut_data = (
+                x_data.size > 0
+                and fixed_data.size > 0
+                and data_grid.ndim == 2
+                and data_grid.shape[0] > 0
+                and data_grid.shape[1] > 0
                 )
-            
-            self.update_sweep()
-            self.picker.slider.blockSignals(False)
-            
-        else:
-            self.update_sweep()
-        
-        self.worker.running = False
+            if not has_cut_data:
+                self.fixed_indep_data = np.asarray([])
+                self.axis_data = {"x": np.asarray([]), "y": np.asarray([])}
+                self.line.setData([], [])
+                self.picker.slider.setRange(0, 0)
+                self.picker.slider.setEnabled(False)
+                self.picker.slider.blockSignals(False)
+                self.show_status(
+                    f"Waiting for plottable data for {self.param.name}...",
+                    5000,
+                    )
+                self.show_plot_state(
+                    "Waiting for plottable cut data",
+                    f"{self.param.name} has no cut data yet.",
+                    kind="empty",
+                    )
+                self.trace_updated.emit()
+                return
+
+            row_count = min(fixed_data.size, data_grid.shape[0])
+            column_count = min(x_data.size, data_grid.shape[1])
+            self.fixed_indep_data = fixed_data[:row_count]
+            self.axis_data["x"] = x_data[:column_count]
+            self.dataGrid = data_grid[:row_count, :column_count]
+            self.fixed_index = min(max(self.fixed_index, 0), row_count - 1)
+
+            # Get correct row and param for y data
+            self.axis_param["y"] = getattr(self, "display_param", self.param)
+
+            # Set-up fixed axis picker and slider
+            self.picker.slider.setEnabled(True)
+            self.picker.slider.setRange(0, row_count - 1)
+
+            # blank text_box means slider signal blocked during an axis switch
+            if not self.picker.text_box.text():
+                self.picker.slider.setValue(self.fixed_index)
+                self.picker.text_box.setText(
+                    self.formatNum(self.fixed_indep_data[self.fixed_index])
+                    )
+
+                self.update_sweep()
+                self.picker.slider.blockSignals(False)
+
+            else:
+                self.update_sweep()
+        finally:
+            plot_worker.running = False
         
         
     @property
@@ -223,6 +258,7 @@ class sweeper(plotWidget):
             x=self.axis_data["x"], 
             y=self.axis_data["y"],
             )
+        self.trace_updated.emit()
         
         if emit:
             # Tell source graph to update scan line on source graph
@@ -300,12 +336,12 @@ class sweeper(plotWidget):
             self.worker.axis_param["x"] = temp_y_param
         
             self.sweep_indep, self.fixed_indep = self.axis_options.values()
-        
+            self.merge_compatibility_changed.emit()
             self.refreshPlot() # Refresh without new data
             
         else:
             self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            
+            self.merge_compatibility_changed.emit()
             # Get new data
             self.refreshWindow(force=True) 
             
@@ -355,12 +391,12 @@ class sweeper(plotWidget):
             self.worker.axis_param["x"] = temp_y_param
         
             self.sweep_indep, self.fixed_indep = self.axis_options.values()
-        
+            self.merge_compatibility_changed.emit()
             self.refreshPlot() # Refresh without new data
             
         else:
             self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            
+            self.merge_compatibility_changed.emit()
             # Get new data
             self.refreshWindow(force=True) 
             

--- a/src/qplot/windows/plot1d.py
+++ b/src/qplot/windows/plot1d.py
@@ -163,7 +163,7 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
         return y_data[mask]
 
 
-    def refreshPlot(self, finished: bool = True, worker: object | None = None) -> None:
+    def refreshPlot(self, finished: bool = True, worker: Any | None = None) -> None:
         """
         Updates plot based on data produced by the thread worker. Data is 
         assigned in plotWidget.refreshPlot, then all plot items are produced
@@ -175,35 +175,37 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
             In the event the worker had to abort, finished is False and refresh
             is not ran.
         """
+        plot_worker = worker if worker is not None else self.worker
         if not super().refreshPlot(finished, worker=worker):
             return
 
-        if not self._has_plottable_line_data():
-            self.line.setData([], [])
-            self.show_status(
-                f"Waiting for plottable data for {self.param.name}...",
-                5000,
-                )
-            self.show_plot_state(
-                "Waiting for plottable data",
-                f"{self.param.name} has no finite line data yet.",
-                kind="empty",
-                )
-            self.worker.running = False
-            return
-        
-        # Main line
-        self.line.setData(
-            x=self.axis_data["x"], 
-            y=self.axis_data["y"],
-            )
-        if self.marquee is not None:
-            self.set_marquee_rect(self.marquee)
+        try:
+            if not self._has_plottable_line_data():
+                self.line.setData([], [])
+                self.show_status(
+                    f"Waiting for plottable data for {self.param.name}...",
+                    5000,
+                    )
+                self.show_plot_state(
+                    "Waiting for plottable data",
+                    f"{self.param.name} has no finite line data yet.",
+                    kind="empty",
+                    )
+                self.trace_updated.emit()
+                return
 
-        self.refresh_secondary_lines()
-        
-        # Allow new worker to be produced
-        self.worker.running = False
+            # Main line
+            self.line.setData(
+                x=self.axis_data["x"],
+                y=self.axis_data["y"],
+                )
+            if self.marquee is not None:
+                self.set_marquee_rect(self.marquee)
+
+            self.trace_updated.emit()
+            self.refresh_secondary_lines()
+        finally:
+            plot_worker.running = False
 
 
     def _has_plottable_line_data(self) -> bool:

--- a/tests/widgets/test_preview_dragdrop.py
+++ b/tests/widgets/test_preview_dragdrop.py
@@ -1,9 +1,10 @@
 import unittest
 
 from PyQt6 import QtCore
+from PyQt6 import QtWidgets as qtw
 
 from qplot.windows import main as main_window
-from qplot.windows._dataset_handle import DatasetKey
+from qplot.windows._dataset_handle import DatasetKey, TraceKey
 from qplot.windows._dragdrop import (
     make_run_preview_mime,
     preview_drop_is_compatible,
@@ -64,6 +65,7 @@ class RunPreviewDragDropTestCase(unittest.TestCase):
             def __init__(self, guid, param, label):
                 self.ds = Dataset(guid)
                 self._dataset_key = DatasetKey("database.db", guid)
+                self._trace_key = (self._dataset_key, param.name)
                 self.param = param
                 self.label = label
                 self.visible = True
@@ -107,6 +109,157 @@ class RunPreviewDragDropTestCase(unittest.TestCase):
 
         self.assertTrue(added)
         self.assertEqual(target.option_boxes[0].option_box.index, 0)
-        self.assertTrue(source.closed)
+        self.assertFalse(source.closed)
         self.assertEqual(harness.status_messages, [])
 
+    def test_add_trace_selects_exact_same_label_source_and_keeps_it_open(self):
+        class Param:
+            name = "signal"
+            depends_on = "x"
+            depends_on_ = ("x",)
+
+        class Box:
+            def __init__(self, items):
+                self.option_box = qtw.QComboBox()
+                for label, trace_key in items:
+                    self.option_box.addItem(label, trace_key)
+
+            def isEnabled(self):
+                return True
+
+        class Window:
+            def __init__(self, database_path):
+                self._dataset_key = DatasetKey(database_path, "shared-guid")
+                self._trace_key = TraceKey(self._dataset_key, Param.name)
+                self.param = Param()
+                self.label = "ID:1 signal"
+                self.visible = True
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class Harness:
+            _plot_window_for_param = main_window.MainWindow._plot_window_for_param
+            add_trace_to_plot = main_window.MainWindow.add_trace_to_plot
+
+            def show_status(self, *_args):
+                pass
+
+            def show_error(self, *_args):
+                self.errors.append(_args)
+
+            def get_1d_wins(self, _win):
+                pass
+
+        first = Window("database-a.db")
+        second = Window("database-b.db")
+        target = type(
+            "Target",
+            (),
+            {
+                "param": Param(),
+                "label": "ID:2 target",
+                "option_boxes": [
+                    Box([
+                        (first.label, first._trace_key),
+                        (second.label, second._trace_key),
+                    ])
+                ],
+            },
+        )()
+        harness = Harness()
+        harness.errors = []
+        harness.windows = [target, first, second]
+
+        added = harness.add_trace_to_plot(
+            target,
+            second._dataset_key,
+            Param.name,
+            param=second.param,
+        )
+
+        self.assertTrue(added)
+        self.assertEqual(target.option_boxes[0].option_box.currentIndex(), 1)
+        self.assertEqual(
+            target.option_boxes[0].option_box.currentData(),
+            second._trace_key,
+        )
+        self.assertFalse(second.closed)
+        self.assertEqual(harness.errors, [])
+
+    def test_add_trace_closes_temporary_hidden_source(self):
+        class Param:
+            name = "signal"
+            depends_on = "x"
+            depends_on_ = ("x",)
+
+        class Combo:
+            def __init__(self, trace_key):
+                self.trace_key = trace_key
+                self.index = None
+
+            def count(self):
+                return 1
+
+            def itemData(self, _index):
+                return self.trace_key
+
+            def findText(self, _text):
+                return -1
+
+            def setCurrentIndex(self, index):
+                self.index = index
+
+        class Box:
+            def __init__(self, trace_key):
+                self.option_box = Combo(trace_key)
+
+            def isEnabled(self):
+                return True
+
+        source_key = DatasetKey("database.db", "source-guid")
+        source = type(
+            "Source",
+            (),
+            {
+                "_dataset_key": source_key,
+                "_trace_key": (source_key, Param.name),
+                "param": Param(),
+                "label": "ID:1 signal",
+                "visible": False,
+                "closed": False,
+                "close": lambda self: setattr(self, "closed", True),
+            },
+        )()
+        target = type(
+            "Target",
+            (),
+            {
+                "param": Param(),
+                "label": "ID:2 target",
+                "option_boxes": [Box(source._trace_key)],
+            },
+        )()
+        harness = type(
+            "Harness",
+            (),
+            {
+                "add_trace_to_plot": main_window.MainWindow.add_trace_to_plot,
+                "_plot_window_for_param": lambda *_args: source,
+                "get_1d_wins": lambda *_args: None,
+                "show_status": lambda *_args: None,
+                "show_error": lambda *_args: None,
+                "windows": [target, source],
+            },
+        )()
+
+        added = harness.add_trace_to_plot(
+            target,
+            source_key,
+            Param.name,
+            param=source.param,
+        )
+
+        self.assertTrue(added)
+        self.assertTrue(source.closed)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -377,6 +377,54 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
     class Param:
         name = "signal"
 
+    def test_cut_compatibility_changes_refresh_add_to_plot_candidates(self):
+        class Signal:
+            def __init__(self):
+                self.slots = []
+
+            def connect(self, slot):
+                self.slots.append(slot)
+
+            def emit(self, *args):
+                for slot in list(self.slots):
+                    slot(*args)
+
+        class sweeper:
+            def __init__(self, dataset_key, *_args, **_kwargs):
+                holder = _args[-1]
+                self._dataset_key = dataset_key
+                self.ds = holder[dataset_key].dataset
+                self.param = object()
+                self.closed = Signal()
+                self.make_ds = Signal()
+                self.previewTraceDropRequested = Signal()
+                self.merge_compatibility_changed = Signal()
+                self.sweep_moved = Signal()
+                self.remove_sweep = Signal()
+
+        class Harness(PlotActionsMixin):
+            def __init__(self):
+                self.config = DatabaseAwareDatasetCacheTestCase.Config()
+                self.threadPool = object()
+                self.dataset_holder = {}
+                self.windows = []
+                self.fileTextbox = DatabaseAwareDatasetCacheTestCase.Field("database.db")
+                self.admin_calls = 0
+
+            def post_admin(self):
+                self.admin_calls += 1
+
+        harness = Harness()
+        dataset = self.Dataset("database.db")
+        dataset_key = DatasetKey("database.db", dataset.guid)
+
+        harness.openWin(sweeper, dataset, show=False, dataset_key=dataset_key)
+        cut = harness.windows[0]
+
+        self.assertEqual(harness.admin_calls, 1)
+        cut.merge_compatibility_changed.emit()
+        self.assertEqual(harness.admin_calls, 2)
+
     def test_database_path_aliases_produce_the_same_key(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "database.db"

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -470,6 +470,72 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         self.assertEqual(len(opened), 1)
         self.assertIs(opened[0][0][1], dataset_b)
 
+    def test_open_plot_preserves_explicit_noncurrent_database_key(self):
+        class Signal:
+            def __init__(self):
+                self.slots = []
+
+            def connect(self, slot):
+                self.slots.append(slot)
+
+        class SpinBox:
+            def value(self):
+                return 1.0
+
+        class plot1d:
+            def __init__(
+                    self,
+                    dataset_key,
+                    param,
+                    _config,
+                    _thread_pool,
+                    dataset_holder,
+                    **_kwargs,
+                    ):
+                self._dataset_key = dataset_key
+                self.param = param
+                self.dataset = dataset_holder[dataset_key].dataset
+                self.closed = Signal()
+                self.make_ds = Signal()
+                self.previewTraceDropRequested = Signal()
+                self.get_mergables = Signal()
+                self.remove_dataset = Signal()
+
+        key_a = DatasetKey("database-a.db", "shared-guid")
+        key_b = DatasetKey("database-b.db", "shared-guid")
+        dataset_a = self.Dataset("A")
+        dataset_b = self.Dataset("B")
+        param = self.Param()
+        param.depends_on = "x"
+        param.depends_on_ = ("x",)
+
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.fileTextbox = self.Field(key_b.database_path)
+        harness.spinBox = SpinBox()
+        harness.config = object()
+        harness.threadPool = object()
+        harness.dataset_holder = {key_b: DatasetHandle(dataset_b)}
+        harness.windows = []
+        harness.ds = None
+        harness._selected_dataset_key = None
+        harness._load_dataset = lambda key: (
+            dataset_a
+            if key == key_a
+            else self.fail(f"unexpected dataset load: {key}")
+        )
+        harness.post_admin = lambda: None
+        harness.show_status = lambda *_args: None
+        harness.show_error = lambda *_args: self.fail("plot load failed")
+
+        with patch("qplot.windows._plot_actions.plot1d", plot1d):
+            harness.openPlot(key_a, params=[param], show=False)
+
+        self.assertEqual(len(harness.windows), 1)
+        self.assertEqual(harness.windows[0]._dataset_key, key_a)
+        self.assertIs(harness.windows[0].dataset, dataset_a)
+        self.assertIs(harness.dataset_holder[key_a].dataset, dataset_a)
+        self.assertIs(harness.dataset_holder[key_b].dataset, dataset_b)
+
     def test_same_label_plot_from_another_database_is_a_merge_candidate(self):
         key_a = DatasetKey("database-a.db", "shared-guid")
         key_b = DatasetKey("database-b.db", "shared-guid")

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -379,6 +379,155 @@ class SnapToTraceTestCase(unittest.TestCase):
 
         self.assertEqual(window._trace_styles["main"].line_color, "#ff0000")
 
+    def test_right_axis_visibility_tracks_secondary_trace_sides(self):
+        class Axis:
+            def __init__(self):
+                self.show_values = None
+
+            def setStyle(self, *, showValues):
+                self.show_values = showValues
+
+        class Plot:
+            def __init__(self):
+                self.axis = Axis()
+
+            def getAxis(self, _name):
+                return self.axis
+
+        class Line:
+            def __init__(self):
+                self.side = "left"
+
+            def setPen(self, _pen):
+                pass
+
+            def setSymbolPen(self, _pen):
+                pass
+
+            def setSymbolBrush(self, _brush):
+                pass
+
+            def setSymbolSize(self, _size):
+                pass
+
+            def setSymbol(self, _symbol):
+                pass
+
+            def setVisible(self, _visible):
+                pass
+
+            def set_side(self, side):
+                self.side = side
+
+            def setZValue(self, _value):
+                pass
+
+        window = plot1d.__new__(plot1d)
+        window.plot = Plot()
+        window.label = "main"
+        window.line = Line()
+        secondary = Line()
+        window.lines = {"main": window.line, "secondary": secondary}
+        window._trace_styles = {
+            "main": window._initial_trace_style(),
+            "secondary": window._initial_trace_style(),
+            }
+
+        window._apply_trace_style("secondary", secondary)
+        self.assertFalse(window.plot.axis.show_values)
+
+        window._set_trace_y_axis("secondary", "Right")
+        self.assertEqual(secondary.side, "right")
+        self.assertTrue(window.plot.axis.show_values)
+
+        window._set_trace_y_axis("secondary", "Left")
+        self.assertEqual(secondary.side, "left")
+        self.assertFalse(window.plot.axis.show_values)
+
+        window._set_trace_y_axis("main", "Right")
+        self.assertEqual(window._trace_styles["main"].y_axis, "Left")
+        self.assertFalse(window.plot.axis.show_values)
+
+    def test_failed_secondary_construction_rolls_back_dataset_and_picker(self):
+        class Host(Plot1DTraceMixin, qtw.QMainWindow):
+            make_ds = QtCore.pyqtSignal(object)
+            remove_dataset = QtCore.pyqtSignal(object)
+
+        class Combo:
+            def __init__(self, data, text):
+                self.data = data
+                self.text = text
+                self.enabled = False
+
+            def currentData(self):
+                return self.data
+
+            def currentText(self):
+                return self.text
+
+            def setEnabled(self, enabled):
+                self.enabled = enabled
+
+        class Button:
+            def __init__(self):
+                self.enabled = True
+
+            def setEnabled(self, enabled):
+                self.enabled = enabled
+
+        class Box:
+            def __init__(self, trace_key, label):
+                self.option_box = Combo(trace_key, label)
+                self.del_box = Button()
+                self.reset_calls = []
+
+            def reset_box(self, labels, item_data=None):
+                self.reset_calls.append((labels, item_data))
+                self.option_box.data = None
+                self.option_box.text = ""
+
+        dataset_key = DatasetKey("database.db", "guid")
+        trace_key = TraceKey(dataset_key, "signal")
+        source = type(
+            "Source",
+            (),
+            {
+                "_dataset_key": dataset_key,
+                "_trace_key": trace_key,
+                "label": "ID:2 signal",
+            },
+        )()
+        box = Box(trace_key, source.label)
+        host = Host()
+        retained = []
+        released = []
+        try:
+            host.right_vb = object()
+            host.mergable = [source]
+            host.option_boxes = [box]
+            host.lines = {}
+            host.make_ds.connect(retained.append)
+            host.remove_dataset.connect(released.append)
+
+            with (
+                    patch(
+                        "qplot.windows._plot1d_traces.subplot1d",
+                        side_effect=RuntimeError("subplot construction failed"),
+                        ),
+                    self.assertRaisesRegex(RuntimeError, "construction failed"),
+                    ):
+                host.add_line(source.label, trace_key)
+
+            self.assertEqual(retained, [dataset_key])
+            self.assertEqual(released, [dataset_key])
+            self.assertEqual(host.mergable, [source])
+            self.assertTrue(box.option_box.enabled)
+            self.assertFalse(box.del_box.enabled)
+            self.assertEqual(box.reset_calls, [([source.label], [trace_key])])
+            self.assertEqual(host.lines, {})
+        finally:
+            host.deleteLater()
+
     def test_main_trace_control_uses_authoritative_initial_style(self):
         class Theme:
             colors = [QtGui.QColor("#008000")]
@@ -524,7 +673,7 @@ class SnapToTraceTestCase(unittest.TestCase):
             host.param = Param()
             host._guid = "guid"
             host._dataset_key = DatasetKey("database.db", host._guid)
-            host.line = object()
+            host.line = pg.PlotDataItem()
             host.lines = {host.label: host.line}
             host._trace_styles = {
                 host.label: host._TraceStyle(line_color="#d62728", dots_enabled=True)
@@ -556,6 +705,19 @@ class SnapToTraceTestCase(unittest.TestCase):
             self.assertTrue(preview_item.flags() & QtCore.Qt.ItemFlag.ItemIsDragEnabled)
             self.assertFalse(measurement_item.flags() & QtCore.Qt.ItemFlag.ItemIsEditable)
             self.assertFalse(dialog.line_color.itemIcon(0).isNull())
+
+            dialog.table.selectRow(0)
+            dialog._sync_controls_from_selection()
+            self.assertFalse(dialog.y_axis.isEnabled())
+
+            dialog.dots_enable.setChecked(True)
+            dialog.marker_enable.setChecked(True)
+            self.assertFalse(dialog.dots_enable.isChecked())
+            self.assertTrue(dialog.marker_enable.isChecked())
+
+            dialog.dots_enable.setChecked(True)
+            self.assertTrue(dialog.dots_enable.isChecked())
+            self.assertFalse(dialog.marker_enable.isChecked())
         finally:
             if dialog is not None:
                 dialog.deleteLater()
@@ -865,8 +1027,9 @@ class SnapToTraceTestCase(unittest.TestCase):
             host.closeEvent(QtGui.QCloseEvent())
 
             self.assertEqual(released, [dataset_key])
-            self.assertEqual(source.monitor.stop_count, 1)
+            self.assertEqual(source.monitor.stop_count, 0)
             self.assertEqual(secondary.disconnect_count, 1)
+            self.assertEqual(host.lines, {"main": host.line})
         finally:
             host.deleteLater()
 
@@ -951,7 +1114,8 @@ class SnapToTraceTestCase(unittest.TestCase):
                 "ds": type("Dataset", (), {"running": False})(),
                 "worker": type("Worker", (), {"running": False})(),
                 "end_wait": Signal(),
-                "sweep_moved": Signal(),
+                "trace_updated": Signal(),
+                "merge_compatibility_changed": Signal(),
                 "axis_options": {"x": "gate", "y": "field"},
                 "axis_data": {
                     "x": np.array([0.0, 1.0]),
@@ -973,12 +1137,12 @@ class SnapToTraceTestCase(unittest.TestCase):
         np.testing.assert_array_equal(initial_y, [10.0, 11.0])
 
         source.axis_data["y"] = np.array([20.0, 21.0])
-        source.sweep_moved.emit(0, "gate", "field", 1, object())
+        source.trace_updated.emit()
         _, updated_y = line.getData()
         np.testing.assert_array_equal(updated_y, [20.0, 21.0])
 
         source.axis_options = {"x": "field", "y": "gate"}
-        source.sweep_moved.emit(0, "field", "gate", 1, object())
+        source.merge_compatibility_changed.emit()
         empty_x, empty_y = line.getData()
         self.assertTrue(empty_x is None or len(empty_x) == 0)
         self.assertTrue(empty_y is None or len(empty_y) == 0)
@@ -986,10 +1150,169 @@ class SnapToTraceTestCase(unittest.TestCase):
         line.disconnect_source_updates()
         source.axis_options = {"x": "gate", "y": "field"}
         source.axis_data["y"] = np.array([30.0, 31.0])
-        source.sweep_moved.emit(0, "gate", "field", 1, object())
+        source.trace_updated.emit()
         disconnected_x, disconnected_y = line.getData()
         self.assertTrue(disconnected_x is None or len(disconnected_x) == 0)
         self.assertTrue(disconnected_y is None or len(disconnected_y) == 0)
+
+    def test_live_regular_source_waits_for_final_trace_update_signal(self):
+        class Signal:
+            def __init__(self):
+                self.slots = []
+
+            def connect(self, slot):
+                self.slots.append(slot)
+
+            def disconnect(self, slot):
+                if slot not in self.slots:
+                    raise TypeError("slot is not connected")
+                self.slots.remove(slot)
+
+            def emit(self, *args):
+                for slot in list(self.slots):
+                    slot(*args)
+
+        class Plot:
+            def addItem(self, _item):
+                pass
+
+        source = type(
+            "LineSource",
+            (),
+            {
+                "label": "ID:2 signal",
+                "param_dict": {},
+                "visible": True,
+                "ds": type("Dataset", (), {"running": True})(),
+                "worker": type("Worker", (), {"running": True})(),
+                "end_wait": Signal(),
+                "trace_updated": Signal(),
+                "axis_options": {"x": "gate", "y": "signal"},
+                "axis_data": {
+                    "x": np.array([0.0, 1.0]),
+                    "y": np.array([10.0, 11.0]),
+                },
+            },
+        )()
+        parent = type(
+            "Parent",
+            (),
+            {
+                "axis_options": {"x": "gate", "y": "current"},
+                "plot": Plot(),
+            },
+        )()
+
+        line = subplot1d(parent, source)
+
+        initial_x, initial_y = line.getData()
+        self.assertTrue(initial_x is None or len(initial_x) == 0)
+        self.assertTrue(initial_y is None or len(initial_y) == 0)
+        self.assertEqual(source.end_wait.slots, [])
+
+        source.worker.running = False
+        source.axis_data["y"] = np.array([20.0, 21.0])
+        source.trace_updated.emit()
+
+        _, updated_y = line.getData()
+        np.testing.assert_array_equal(updated_y, [20.0, 21.0])
+
+    def test_hidden_source_monitor_is_owned_until_last_subplot_disconnects(self):
+        class Signal:
+            def __init__(self):
+                self.slots = []
+
+            def connect(self, slot):
+                self.slots.append(slot)
+
+            def disconnect(self, slot):
+                if slot not in self.slots:
+                    raise TypeError("slot is not connected")
+                self.slots.remove(slot)
+
+            def emit(self, *args):
+                for slot in list(self.slots):
+                    slot(*args)
+
+        class SpinBox:
+            def __init__(self, value):
+                self._value = value
+                self.valueChanged = Signal()
+
+            def value(self):
+                return self._value
+
+            def setValue(self, value):
+                self._value = value
+
+        class Monitor:
+            def __init__(self):
+                self.stop_count = 0
+
+            def stop(self):
+                self.stop_count += 1
+
+        class Plot:
+            def addItem(self, _item):
+                pass
+
+        source = type(
+            "HiddenSource",
+            (),
+            {
+                "label": "ID:2 signal",
+                "param_dict": {},
+                "visible": False,
+                "ds": type("Dataset", (), {"running": True})(),
+                "worker": type("Worker", (), {"running": False})(),
+                "end_wait": Signal(),
+                "trace_updated": Signal(),
+                "axis_options": {"x": "gate", "y": "signal"},
+                "axis_data": {
+                    "x": np.array([0.0, 1.0]),
+                    "y": np.array([10.0, 11.0]),
+                },
+                "spinBox": SpinBox(1.0),
+                "monitor": Monitor(),
+            },
+        )()
+        first_parent = type(
+            "Parent",
+            (),
+            {
+                "axis_options": {"x": "gate", "y": "current"},
+                "plot": Plot(),
+                "spinBox": SpinBox(0.2),
+            },
+        )()
+        second_parent = type(
+            "Parent",
+            (),
+            {
+                "axis_options": {"x": "gate", "y": "current"},
+                "plot": Plot(),
+                "spinBox": SpinBox(0.4),
+            },
+        )()
+
+        first = subplot1d(first_parent, source)
+        second = subplot1d(second_parent, source)
+
+        self.assertEqual(source._merged_trace_users, 2)
+        self.assertEqual(source.spinBox.value(), 0.4)
+        first_parent.spinBox.valueChanged.emit(0.3)
+        self.assertEqual(source.spinBox.value(), 0.3)
+
+        first.disconnect_source_updates()
+        first.disconnect_source_updates()
+        self.assertEqual(source._merged_trace_users, 1)
+        self.assertEqual(source.monitor.stop_count, 0)
+        first_parent.spinBox.valueChanged.emit(0.1)
+        self.assertEqual(source.spinBox.value(), 0.3)
+
+        second.disconnect_source_updates()
+        self.assertEqual(source._merged_trace_users, 0)
+        self.assertEqual(source.monitor.stop_count, 1)
 
     def test_register_main_line_replaces_initial_empty_trace(self):
         line = object()

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -16,6 +16,7 @@ from qplot.windows._plot1d_traces import (
 )
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._subplots import custom_viewbox
+from qplot.windows._subplots.subplot1d import _subplot_axis_order, subplot1d
 from qplot.windows._widgets import QDock_context, picker_1d
 from qplot.windows.plot1d import plot1d
 
@@ -511,6 +512,7 @@ class SnapToTraceTestCase(unittest.TestCase):
     def test_trace_appearance_table_uses_readonly_preview_rows(self):
         class Param:
             name = "current"
+            depends_on_ = ("gate",)
 
         class Host(Plot1DTraceMixin, qtw.QMainWindow):
             pass
@@ -520,7 +522,10 @@ class SnapToTraceTestCase(unittest.TestCase):
         try:
             host.label = "ID:1 current"
             host.param = Param()
-            host.lines = {host.label: object()}
+            host._guid = "guid"
+            host._dataset_key = DatasetKey("database.db", host._guid)
+            host.line = object()
+            host.lines = {host.label: host.line}
             host._trace_styles = {
                 host.label: host._TraceStyle(line_color="#d62728", dots_enabled=True)
                 }
@@ -551,6 +556,64 @@ class SnapToTraceTestCase(unittest.TestCase):
             self.assertTrue(preview_item.flags() & QtCore.Qt.ItemFlag.ItemIsDragEnabled)
             self.assertFalse(measurement_item.flags() & QtCore.Qt.ItemFlag.ItemIsEditable)
             self.assertFalse(dialog.line_color.itemIcon(0).isNull())
+        finally:
+            if dialog is not None:
+                dialog.deleteLater()
+            host.deleteLater()
+
+    def test_trace_appearance_cut_row_is_not_draggable(self):
+        class Host(Plot1DTraceMixin, qtw.QMainWindow):
+            pass
+
+        cut_key = TraceKey(
+            DatasetKey("database.db", "guid"),
+            "heatmap_signal",
+            sweep_id=1,
+        )
+        cut_source = type(
+            "CutSource",
+            (),
+            {
+                "_guid": "guid",
+                "_dataset_key": cut_key.dataset_key,
+                "label": "ID:1 heatmap_signal [cut 2]",
+                "param": type(
+                    "Param",
+                    (),
+                    {
+                        "name": "heatmap_signal",
+                        "depends_on_": ("gate", "field"),
+                    },
+                )(),
+            },
+        )()
+        cut_line = type("CutLine", (), {"from_win": cut_source})()
+        host = Host()
+        dialog = None
+        try:
+            host.label = "ID:2 current"
+            host.param = type(
+                "Param",
+                (),
+                {"name": "current", "depends_on_": ("gate",)},
+            )()
+            host._guid = "target-guid"
+            host._dataset_key = DatasetKey("database.db", host._guid)
+            host.line = object()
+            host.lines = {host.label: host.line, cut_key: cut_line}
+            host._trace_styles = {
+                label: host._initial_trace_style()
+                for label in host.lines
+            }
+
+            dialog = _TraceAppearanceDialog(host)
+            dialog.refresh_rows()
+
+            preview_item = dialog.table.item(1, dialog._COL_PREVIEW)
+            self.assertFalse(
+                preview_item.flags() & QtCore.Qt.ItemFlag.ItemIsDragEnabled
+            )
+            self.assertIsNone(dialog._trace_mime_data(cut_key))
         finally:
             if dialog is not None:
                 dialog.deleteLater()
@@ -686,22 +749,39 @@ class SnapToTraceTestCase(unittest.TestCase):
             pass
 
         class Line:
-            def __init__(self):
+            def __init__(self, source=None):
                 self.z_value = None
+                self.refresh_count = 0
+                if source is not None:
+                    self.from_win = source
 
             def setZValue(self, value):
                 self.z_value = value
+
+            def refresh(self):
+                self.refresh_count += 1
+
+        source = type(
+            "Source",
+            (),
+            {
+                "visible": True,
+                "ds": type("Dataset", (), {"running": False})(),
+            },
+        )()
 
         host = Host()
         dialog = None
         try:
             host.label = "ID:1 current"
             host.param = type("Param", (), {"name": "current"})()
+            main_line = Line()
+            host.line = main_line
             host.lines = {
-                "trace a": Line(),
-                "trace b": Line(),
-                "trace c": Line(),
-                }
+                "trace a": main_line,
+                "trace b": Line(source),
+                "trace c": Line(source),
+            }
             host._trace_styles = {
                 label: host._TraceStyle(order=-1)
                 for label in host.lines
@@ -730,10 +810,186 @@ class SnapToTraceTestCase(unittest.TestCase):
                 [2, 1, 0],
                 )
             self.assertEqual(dialog._selected_labels(), ["trace b"])
+
+            host.refresh_secondary_lines()
+
+            self.assertEqual(main_line.refresh_count, 0)
+            self.assertEqual(host.lines["trace b"].refresh_count, 1)
+            self.assertEqual(host.lines["trace c"].refresh_count, 1)
+            self.assertEqual(
+                host._secondary_lines(),
+                [host.lines["trace b"], host.lines["trace c"]],
+            )
         finally:
             if dialog is not None:
                 dialog.deleteLater()
             host.deleteLater()
+
+    def test_close_releases_reordered_secondary_traces_only(self):
+        class Host(Plot1DTraceMixin, qtw.QMainWindow):
+            remove_dataset = QtCore.pyqtSignal([object])
+
+        class Monitor:
+            def __init__(self):
+                self.stop_count = 0
+
+            def stop(self):
+                self.stop_count += 1
+
+        class Secondary:
+            def __init__(self, source):
+                self.from_win = source
+                self.disconnect_count = 0
+
+            def disconnect_source_updates(self):
+                self.disconnect_count += 1
+
+        dataset_key = DatasetKey("database.db", "guid")
+        source = type(
+            "Source",
+            (),
+            {
+                "_dataset_key": dataset_key,
+                "visible": False,
+                "monitor": Monitor(),
+            },
+        )()
+        host = Host()
+        released = []
+        try:
+            host.line = object()
+            secondary = Secondary(source)
+            host.lines = {"secondary": secondary, "main": host.line}
+            host.remove_dataset.connect(released.append)
+
+            host.closeEvent(QtGui.QCloseEvent())
+
+            self.assertEqual(released, [dataset_key])
+            self.assertEqual(source.monitor.stop_count, 1)
+            self.assertEqual(secondary.disconnect_count, 1)
+        finally:
+            host.deleteLater()
+
+    def test_legacy_label_picker_matches_resolved_trace_key(self):
+        class Combo:
+            def currentData(self):
+                return "ID:1 voltage"
+
+            def currentText(self):
+                return "ID:1 voltage"
+
+        box = type("Box", (), {"option_box": Combo()})()
+        trace_key = TraceKey(
+            DatasetKey("database.db", "guid"),
+            "voltage",
+        )
+
+        self.assertTrue(
+            Plot1DTraceMixin._picker_matches_trace(
+                box,
+                trace_key,
+                "ID:1 voltage",
+            )
+        )
+
+    def test_subplot_axis_mapping_rejects_incompatible_cut_axis(self):
+        self.assertEqual(
+            _subplot_axis_order(
+                {"x": "gate", "y": "current"},
+                {"x": "gate", "y": "field"},
+                source_is_cut=True,
+            ),
+            ("x", "y"),
+        )
+        self.assertEqual(
+            _subplot_axis_order(
+                {"x": "current", "y": "gate"},
+                {"x": "gate", "y": "field"},
+                source_is_cut=True,
+            ),
+            ("y", "x"),
+        )
+        self.assertIsNone(
+            _subplot_axis_order(
+                {"x": "gate", "y": "current"},
+                {"x": "field", "y": "gate"},
+                source_is_cut=True,
+            )
+        )
+
+    def test_completed_cut_updates_and_clears_merged_subplot_immediately(self):
+        class Signal:
+            def __init__(self):
+                self.slots = []
+
+            def connect(self, slot):
+                self.slots.append(slot)
+
+            def disconnect(self, slot):
+                if slot not in self.slots:
+                    raise TypeError("slot is not connected")
+                self.slots.remove(slot)
+
+            def emit(self, *args):
+                for slot in list(self.slots):
+                    slot(*args)
+
+        class Plot:
+            def __init__(self):
+                self.items = []
+
+            def addItem(self, item):
+                self.items.append(item)
+
+        source = type(
+            "CutSource",
+            (),
+            {
+                "label": "ID:1 signal [cut 1]",
+                "param_dict": {},
+                "sweep_id": 0,
+                "ds": type("Dataset", (), {"running": False})(),
+                "worker": type("Worker", (), {"running": False})(),
+                "end_wait": Signal(),
+                "sweep_moved": Signal(),
+                "axis_options": {"x": "gate", "y": "field"},
+                "axis_data": {
+                    "x": np.array([0.0, 1.0]),
+                    "y": np.array([10.0, 11.0]),
+                },
+            },
+        )()
+        parent = type(
+            "Parent",
+            (),
+            {
+                "axis_options": {"x": "gate", "y": "current"},
+                "plot": Plot(),
+            },
+        )()
+        line = subplot1d(parent, source)
+
+        _, initial_y = line.getData()
+        np.testing.assert_array_equal(initial_y, [10.0, 11.0])
+
+        source.axis_data["y"] = np.array([20.0, 21.0])
+        source.sweep_moved.emit(0, "gate", "field", 1, object())
+        _, updated_y = line.getData()
+        np.testing.assert_array_equal(updated_y, [20.0, 21.0])
+
+        source.axis_options = {"x": "field", "y": "gate"}
+        source.sweep_moved.emit(0, "field", "gate", 1, object())
+        empty_x, empty_y = line.getData()
+        self.assertTrue(empty_x is None or len(empty_x) == 0)
+        self.assertTrue(empty_y is None or len(empty_y) == 0)
+
+        line.disconnect_source_updates()
+        source.axis_options = {"x": "gate", "y": "field"}
+        source.axis_data["y"] = np.array([30.0, 31.0])
+        source.sweep_moved.emit(0, "gate", "field", 1, object())
+        disconnected_x, disconnected_y = line.getData()
+        self.assertTrue(disconnected_x is None or len(disconnected_x) == 0)
+        self.assertTrue(disconnected_y is None or len(disconnected_y) == 0)
 
     def test_register_main_line_replaces_initial_empty_trace(self):
         line = object()
@@ -798,6 +1054,7 @@ class SnapToTraceTestCase(unittest.TestCase):
         made_datasets = []
         removed_datasets = []
         picker_updates = []
+        trace_dialog = None
 
         try:
             host.config = Config()
@@ -817,6 +1074,12 @@ class SnapToTraceTestCase(unittest.TestCase):
             host.right_vb = None
             host.line = host.plot.plot(x=[0.0, 1.0], y=[1.0, 2.0])
             host.label = source.label
+            host._guid = "shared-guid"
+            host.param = type(
+                "Param",
+                (),
+                {"name": "voltage", "depends_on_": ("gate",)},
+            )()
             host._dataset_key = DatasetKey("database-a.db", "shared-guid")
             host._trace_key = TraceKey(host._dataset_key, "voltage")
             host.lines = {host.label: host.line}
@@ -859,6 +1122,11 @@ class SnapToTraceTestCase(unittest.TestCase):
             self.assertEqual(secondary.opts["pen"].color().name(), style.line_color)
             self.assertEqual(secondary.side, "left")
 
+            trace_dialog = _TraceAppearanceDialog(host)
+            host._trace_appearance_dialog = trace_dialog
+            trace_dialog.refresh_rows()
+            self.assertEqual(trace_dialog.table.rowCount(), 2)
+
             host.remove_line(source.label, source._trace_key)
 
             self.assertNotIn(source._trace_key, host.lines)
@@ -867,7 +1135,12 @@ class SnapToTraceTestCase(unittest.TestCase):
             self.assertFalse(host.plot.getAxis("right").style["showValues"])
             self.assertEqual(removed_datasets, [source._dataset_key])
             self.assertEqual(picker_updates, [True])
+            self.assertEqual(trace_dialog.table.rowCount(), 1)
+            trace_dialog.table.selectRow(0)
+            self.assertEqual(trace_dialog._selected_labels(), [host.label])
         finally:
+            if trace_dialog is not None:
+                trace_dialog.deleteLater()
             host.deleteLater()
 
     def test_alt_drag_edge_handle_resizes_marquee_symmetrically(self):

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import pyqtgraph as pg
@@ -14,6 +15,149 @@ from qplot.windows.plot2d import _COLORBAR_COLORMAPS, plot2d
 
 
 class Plot2dLiveRefreshTestCase(unittest.TestCase):
+    def test_empty_cut_refresh_clears_trace_and_releases_worker(self):
+        class Slider:
+            def __init__(self):
+                self.range = None
+                self.enabled = True
+                self.blocked = True
+
+            def setRange(self, low, high):
+                self.range = (low, high)
+
+            def setEnabled(self, enabled):
+                self.enabled = enabled
+
+            def blockSignals(self, blocked):
+                self.blocked = blocked
+
+        class TextBox:
+            def text(self):
+                return ""
+
+        class Line:
+            def __init__(self):
+                self.calls = []
+
+            def setData(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+
+        class Worker:
+            running = True
+
+        cut = sweeper.__new__(sweeper)
+        qtw.QMainWindow.__init__(cut)
+        worker = Worker()
+        slider = Slider()
+        cut.worker = worker
+        cut.axis_data = {"x": np.asarray([]), "y": np.asarray([])}
+        cut.axis_param = {"x": object(), "y": object()}
+        cut.dataGrid = np.empty((0, 0))
+        cut.line = Line()
+        cut.picker = type(
+            "Picker",
+            (),
+            {"slider": slider, "text_box": TextBox()},
+            )()
+        cut.param = type("Param", (), {"name": "signal"})()
+        statuses = []
+        states = []
+        cut.show_status = lambda *args: statuses.append(args)
+        cut.show_plot_state = lambda *args, **kwargs: states.append((args, kwargs))
+        trace_updates = []
+        cut.trace_updated.connect(lambda: trace_updates.append(True))
+
+        with patch.object(plotWidget, "refreshPlot", return_value=True):
+            sweeper.refreshPlot(cut, True, worker=worker)
+
+        self.assertFalse(worker.running)
+        self.assertEqual(cut.line.calls[-1], (([], []), {}))
+        self.assertEqual(slider.range, (0, 0))
+        self.assertFalse(slider.enabled)
+        self.assertFalse(slider.blocked)
+        self.assertEqual(trace_updates, [True])
+        self.assertIn("Waiting for plottable data", statuses[-1][0])
+        self.assertEqual(states[-1][0][0], "Waiting for plottable cut data")
+
+    def test_cursor_driven_cut_update_notifies_merged_traces(self):
+        class Signal:
+            def __init__(self):
+                self.emissions = []
+
+            def emit(self, *args):
+                self.emissions.append(args)
+
+        class Line:
+            def __init__(self):
+                self.data = None
+
+            def setData(self, *, x, y):
+                self.data = (x, y)
+
+        cut = type("Cut", (), {})()
+        cut.fixed_index = 1
+        cut.dataGrid = np.array([[10.0, 11.0], [20.0, 21.0]])
+        cut.axis_data = {"x": np.array([0.0, 1.0]), "y": np.array([])}
+        cut.line = Line()
+        cut.trace_updated = Signal()
+        cut.sweep_moved = Signal()
+
+        sweeper.update_sweep(cut, emit=False)
+
+        np.testing.assert_array_equal(cut.axis_data["y"], [20.0, 21.0])
+        np.testing.assert_array_equal(cut.line.data[0], [0.0, 1.0])
+        np.testing.assert_array_equal(cut.line.data[1], [20.0, 21.0])
+        self.assertEqual(cut.trace_updated.emissions, [()])
+        self.assertEqual(cut.sweep_moved.emissions, [])
+
+    def test_cut_axis_changes_publish_merge_compatibility_updates(self):
+        class Signal:
+            def __init__(self):
+                self.emissions = []
+
+            def emit(self, *args):
+                self.emissions.append(args)
+
+        class Control:
+            def __init__(self, text=""):
+                self.text = text
+
+            def blockSignals(self, _blocked):
+                pass
+
+            def currentText(self):
+                return self.text
+
+            def setText(self, text):
+                self.text = text
+
+            def setValue(self, _value):
+                pass
+
+        cut = type("Cut", (), {})()
+        cut.picker = type(
+            "Picker",
+            (),
+            {
+                "slider": Control(),
+                "text_box": Control(),
+                "option_box": Control("field"),
+            },
+        )()
+        cut.axis_dropdown = {"x": Control("gate")}
+        cut.axis_options = {"x": "gate", "y": "field"}
+        cut.sweep_indep = "gate"
+        cut.fixed_indep = "field"
+        cut.merge_compatibility_changed = Signal()
+        refreshes = []
+        cut.refreshWindow = lambda *, force: refreshes.append(force)
+
+        sweeper.change_axis(cut, "x")
+        sweeper.change_fixed_param(cut, 0)
+
+        self.assertEqual(refreshes, [True, True])
+        self.assertEqual(cut.merge_compatibility_changed.emissions, [(), ()])
+
     def test_heatmap_cut_identity_includes_unique_id_and_visible_number(self):
         cut = sweeper.__new__(sweeper)
         cut.label = "ID:1 heatmap_signal"
@@ -1506,6 +1650,45 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         self.assertEqual(levels, (0.0, smallest))
         self.assertEqual(rounding, smallest)
         self.assertEqual(tuple(bar.levels()), levels)
+
+    def test_programmatic_colorbar_levels_recompute_interaction_rounding(self):
+        window = plot2d.__new__(plot2d)
+        window.bar = pg.ColorBarItem(values=(0.0, 1e9), rounding=1e4)
+
+        window._set_colorbar_levels(-1e-6, 1e-6)
+        window.bar._regionChanging()
+
+        self.assertEqual(window.bar.rounding, 2e-11)
+        self.assertEqual(tuple(window.bar.levels()), (-1e-6, 1e-6))
+
+        smallest = np.nextafter(0.0, 1.0)
+        window._set_colorbar_levels(0.0, smallest)
+        window.bar._regionChanging()
+
+        self.assertEqual(window.bar.rounding, smallest)
+        self.assertEqual(tuple(window.bar.levels()), (0.0, smallest))
+
+    def test_extreme_colorbar_levels_keep_native_interaction_finite(self):
+        window = plot2d.__new__(plot2d)
+        maximum = np.finfo(float).max
+        levels = window._constant_colorbar_levels(maximum)
+        window.bar = pg.ColorBarItem(values=(0.0, 1.0), rounding=1e-5)
+
+        window._set_colorbar_levels(*levels)
+        window.bar.region.blockSignals(True)
+        window.bar.region.setRegion((63, 255))
+        window.bar.region.blockSignals(False)
+        window.bar._regionChanging()
+
+        self.assertTrue(np.isfinite(window.bar.levels()).all())
+        self.assertLessEqual(window.bar.levels()[1], maximum)
+
+        window._set_colorbar_levels(-maximum, maximum)
+        before = tuple(window.bar.levels())
+        window.bar._regionChanging()
+
+        self.assertFalse(window.bar.region.isEnabled())
+        self.assertEqual(tuple(window.bar.levels()), before)
 
     def test_outside_colorbar_drag_widens_levels_about_midpoint(self):
         for start_y, drag_y in ((40.0, 24.0), (210.0, 226.0)):

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -1462,21 +1462,50 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
                 self.assertEqual(window.bar.values, (10.0, 20.0))
                 self.assertEqual(window._colorbar_manual_levels, (10.0, 20.0))
 
-    def test_constant_heatmap_uses_positive_finite_colorbar_rounding(self):
+    def test_constant_heatmap_uses_padded_levels_and_finite_rounding(self):
         window = plot2d.__new__(plot2d)
 
-        for value in (0.0, 7.5, -7.5, np.nextafter(0.0, 1.0)):
+        for value in (
+                0.0,
+                7.5,
+                -7.5,
+                np.nextafter(0.0, 1.0),
+                np.finfo(float).max,
+                -np.finfo(float).max,
+                ):
             with self.subTest(value=value):
                 window.dataGrid = np.full((2, 2), value)
 
+                levels = window._data_colorbar_levels()
                 rounding = window._data_colorbar_rounding()
 
+                self.assertIsNotNone(levels)
+                low, high = levels
+                self.assertTrue(np.isfinite((low, high)).all())
+                self.assertLess(low, high)
+                self.assertLessEqual(low, value)
+                self.assertGreaterEqual(high, value)
                 self.assertTrue(np.isfinite(rounding))
-                self.assertGreaterEqual(rounding, np.finfo(float).tiny)
+                self.assertGreater(rounding, 0.0)
+                self.assertLessEqual(rounding, high - low)
 
-                bar = pg.ColorBarItem(values=(0.0, 1.0), rounding=rounding)
+                bar = pg.ColorBarItem(values=levels, rounding=rounding)
                 bar._regionChanging()
                 self.assertTrue(np.isfinite(bar.values).all())
+
+    def test_subnormal_colorbar_interaction_preserves_data_scale(self):
+        window = plot2d.__new__(plot2d)
+        smallest = np.nextafter(0.0, 1.0)
+        window.dataGrid = np.array([[0.0, smallest]])
+
+        levels = window._data_colorbar_levels()
+        rounding = window._data_colorbar_rounding()
+        bar = pg.ColorBarItem(values=levels, rounding=rounding)
+        bar._regionChanging()
+
+        self.assertEqual(levels, (0.0, smallest))
+        self.assertEqual(rounding, smallest)
+        self.assertEqual(tuple(bar.levels()), levels)
 
     def test_outside_colorbar_drag_widens_levels_about_midpoint(self):
         for start_y, drag_y in ((40.0, 24.0), (210.0, 226.0)):

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -37,6 +37,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         def __init__(self, number_of_results=10, running=True):
             self.number_of_results = number_of_results
             self.running = running
+            self.cache = object()
 
     class Worker:
         def __init__(self, running):
@@ -75,6 +76,44 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
 
         self.assertEqual(window.load_calls, ["load"])
         self.assertEqual(window.last_ds_len, 0)
+        self.assertEqual(window.restart_intervals, [0.2])
+
+    def test_refresh_detects_completion_without_a_new_result_row(self):
+        window = self._window(worker_running=False)
+        window.last_ds_len = window.ds.number_of_results
+        window.param = object()
+        completion_checks = []
+
+        old_prep = plot_refresh_module.load_param_data_from_db_prep
+        try:
+            def complete(cache, param):
+                completion_checks.append((cache, param))
+                window.ds.running = False
+                return True
+
+            plot_refresh_module.load_param_data_from_db_prep = complete
+            plotWidget.refreshWindow(window)
+        finally:
+            plot_refresh_module.load_param_data_from_db_prep = old_prep
+
+        self.assertEqual(completion_checks, [(window.ds.cache, window.param)])
+        self.assertEqual(window.load_calls, [])
+        self.assertEqual(window.restart_intervals, [])
+
+    def test_secondary_trace_restart_does_not_depend_on_dictionary_order(self):
+        window = self._window(worker_running=False)
+        window.ds.running = False
+        window.last_ds_len = window.ds.number_of_results
+        main_line = self.Worker(running=True)
+        secondary_line = self.Worker(running=True)
+        window.line = main_line
+        window.lines = {
+            "secondary": secondary_line,
+            "main": main_line,
+            }
+
+        plotWidget.refreshWindow(window)
+
         self.assertEqual(window.restart_intervals, [0.2])
 
     def test_invalid_operation_input_stops_load_with_visible_feedback(self):
@@ -348,6 +387,46 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         plotWidget.refreshPlot(window, True, worker=self.Worker())
 
         self.assertEqual(window.end_wait.emitted, 0)
+
+    def test_closed_worker_callback_does_not_revive_unowned_dataset(self):
+        class DeleteTimer:
+            def __init__(self):
+                self.stopped = 0
+
+            def stop(self):
+                self.stopped += 1
+
+        window = self._window()
+        dataset_key = DatasetKey("database.db", "guid")
+        delete_timer = DeleteTimer()
+        handle = DatasetHandle(
+            object(),
+            users=0,
+            delete_timer=delete_timer,
+            )
+        window._closed = True
+        window._dataset_key = dataset_key
+        window._dataset_holder = {dataset_key: handle}
+
+        result = plotWidget.refreshPlot(window, True, worker=window.worker)
+
+        self.assertFalse(result)
+        self.assertFalse(window.worker.running)
+        self.assertEqual(window.end_wait.emitted, 1)
+        self.assertIs(window._dataset_holder[dataset_key], handle)
+        self.assertIs(handle.delete_timer, delete_timer)
+        self.assertEqual(delete_timer.stopped, 0)
+
+    def test_closed_hidden_source_can_refresh_while_a_trace_retains_it(self):
+        window = self._window()
+        dataset_key = DatasetKey("database.db", "guid")
+        window._closed = True
+        window._dataset_key = dataset_key
+        window._dataset_holder = {
+            dataset_key: DatasetHandle(object(), users=1),
+            }
+
+        self.assertTrue(plotWidget._can_process_refresh(window))
 
     def test_current_worker_failure_reports_error_and_releases_wait(self):
         window = self._window()

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
@@ -78,6 +79,23 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.last_ds_len, 0)
         self.assertEqual(window.restart_intervals, [0.2])
 
+    def test_refresh_restarts_monitor_after_transient_row_count_error(self):
+        class Dataset:
+            running = True
+
+            @property
+            def number_of_results(self):
+                raise RuntimeError("database temporarily unavailable")
+
+        window = self._window(worker_running=False)
+        window._dataset_holder[window._dataset_key].dataset = Dataset()
+
+        with self.assertRaisesRegex(RuntimeError, "temporarily unavailable"):
+            plotWidget.refreshWindow(window)
+
+        self.assertEqual(window.monitor.stopped, 1)
+        self.assertEqual(window.restart_intervals, [0.2])
+
     def test_refresh_detects_completion_without_a_new_result_row(self):
         window = self._window(worker_running=False)
         window.last_ds_len = window.ds.number_of_results
@@ -115,6 +133,28 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         plotWidget.refreshWindow(window)
 
         self.assertEqual(window.restart_intervals, [0.2])
+
+    def test_completed_secondary_source_does_not_keep_target_monitor_running(self):
+        window = self._window(worker_running=False)
+        window.ds.running = False
+        window.last_ds_len = window.ds.number_of_results
+        main_line = self.Worker(running=False)
+        secondary_line = self.Worker(running=True)
+        secondary_line.from_win = type(
+            "Source",
+            (),
+            {"ds": self.Dataset(running=False)},
+            )()
+        window.line = main_line
+        window.lines = {
+            "secondary": secondary_line,
+            "main": main_line,
+            }
+
+        plotWidget.refreshWindow(window)
+
+        self.assertFalse(secondary_line.running)
+        self.assertEqual(window.restart_intervals, [])
 
     def test_invalid_operation_input_stops_load_with_visible_feedback(self):
         class Operations:
@@ -388,6 +428,19 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
 
         self.assertEqual(window.end_wait.emitted, 0)
 
+    def test_closed_stale_completion_cannot_release_current_worker_wait(self):
+        window = self._window()
+        stale_worker = self.Worker()
+        window._closed = True
+        window._merged_trace_users = 0
+
+        result = plotWidget.refreshPlot(window, True, worker=stale_worker)
+
+        self.assertFalse(result)
+        self.assertFalse(stale_worker.running)
+        self.assertTrue(window.worker.running)
+        self.assertEqual(window.end_wait.emitted, 0)
+
     def test_closed_worker_callback_does_not_revive_unowned_dataset(self):
         class DeleteTimer:
             def __init__(self):
@@ -421,11 +474,98 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         window = self._window()
         dataset_key = DatasetKey("database.db", "guid")
         window._closed = True
+        window._merged_trace_users = 1
         window._dataset_key = dataset_key
         window._dataset_holder = {
             dataset_key: DatasetHandle(object(), users=1),
             }
 
+        self.assertTrue(plotWidget._can_process_refresh(window))
+
+    def test_closed_source_rejects_callbacks_from_unrelated_dataset_user(self):
+        window = self._window()
+        dataset_key = DatasetKey("database.db", "guid")
+        window._closed = True
+        window._merged_trace_users = 0
+        window._dataset_key = dataset_key
+        window._dataset_holder = {
+            dataset_key: DatasetHandle(object(), users=2),
+            }
+
+        self.assertFalse(plotWidget._can_process_refresh(window))
+
+    def test_line_refresh_releases_worker_when_secondary_refresh_raises(self):
+        class Line:
+            def setData(self, *args, **kwargs):
+                pass
+
+        class Worker:
+            running = True
+
+        window = plot1d.__new__(plot1d)
+        qtw.QMainWindow.__init__(window)
+        worker = Worker()
+        window.worker = worker
+        window.axis_data = {"x": [0.0, 1.0], "y": [10.0, 20.0]}
+        window.line = Line()
+        window.marquee = None
+        window.refresh_secondary_lines = lambda: (_ for _ in ()).throw(
+            RuntimeError("secondary refresh failed")
+            )
+        trace_updates = []
+        window.trace_updated.connect(lambda: trace_updates.append(True))
+
+        with (
+                patch.object(plotWidget, "refreshPlot", return_value=True),
+                self.assertRaisesRegex(RuntimeError, "secondary refresh failed"),
+                ):
+            plot1d.refreshPlot(window, True, worker=worker)
+
+        self.assertFalse(worker.running)
+        self.assertEqual(trace_updates, [True])
+
+    def test_closing_retained_live_source_keeps_its_monitor_running(self):
+        class Dataset:
+            running = True
+
+        class Monitor:
+            def __init__(self):
+                self.active = False
+                self.stop_count = 0
+
+            def isActive(self):
+                return self.active
+
+            def stop(self):
+                self.active = False
+                self.stop_count += 1
+
+        class SpinBox:
+            def value(self):
+                return 0.2
+
+        dataset_key = DatasetKey("database.db", "guid")
+        dataset = Dataset()
+        window = plotWidget.__new__(plotWidget)
+        qtw.QMainWindow.__init__(window)
+        window.monitor = Monitor()
+        window.spinBox = SpinBox()
+        window._dataset_key = dataset_key
+        window._dataset_holder = {
+            dataset_key: DatasetHandle(dataset, users=1),
+            }
+        window._merged_trace_users = 1
+        window._closed = False
+        window.visible = True
+        restart_intervals = []
+        window.monitorIntervalChanged = restart_intervals.append
+
+        plotWidget.closeEvent(window, QtGui.QCloseEvent())
+
+        self.assertTrue(window._closed)
+        self.assertFalse(window.visible)
+        self.assertEqual(window.monitor.stop_count, 0)
+        self.assertEqual(restart_intervals, [0.2])
         self.assertTrue(plotWidget._can_process_refresh(window))
 
     def test_current_worker_failure_reports_error_and_releases_wait(self):
@@ -536,6 +676,7 @@ class PlotStateOverlayTestCase(unittest.TestCase):
             name = "signal"
 
         window = plot1d.__new__(plot1d)
+        qtw.QMainWindow.__init__(window)
         worker = Worker()
         line = Line()
         states = []
@@ -552,6 +693,8 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         window.show_status = lambda *args: statuses.append(args)
         window.show_plot_state = lambda *args, **kwargs: states.append((args, kwargs))
         window.hide_plot_state = lambda: None
+        trace_updates = []
+        window.trace_updated.connect(lambda: trace_updates.append(True))
 
         plot1d.refreshPlot(window, True, worker=worker)
 
@@ -562,6 +705,63 @@ class PlotStateOverlayTestCase(unittest.TestCase):
         self.assertIn("Waiting for plottable data", statuses[-1][0])
         self.assertEqual(states[-1][0][0], "Waiting for plottable data")
         self.assertEqual(states[-1][1]["kind"], "empty")
+        self.assertEqual(trace_updates, [True])
+
+    def test_successful_line_refresh_notifies_merged_traces_once(self):
+        class Signal:
+            def __init__(self):
+                self.emitted = 0
+
+            def emit(self):
+                self.emitted += 1
+
+        class Line:
+            def __init__(self):
+                self.calls = []
+
+            def setData(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+
+        class Worker:
+            read_data = False
+            running = True
+            dataset_length_at_start = 5
+            axis_data = {"x": [0.0, 1.0], "y": [10.0, 20.0]}
+            axis_param = {"x": object(), "y": object()}
+            started_at = 0
+
+        class Dataset:
+            number_of_results = 2
+
+        class Param:
+            name = "signal"
+
+        window = plot1d.__new__(plot1d)
+        qtw.QMainWindow.__init__(window)
+        worker = Worker()
+        window.worker = worker
+        window.line = Line()
+        window.marquee = None
+        window._guid = "guid"
+        window._dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
+        window.param = Param()
+        window.end_wait = Signal()
+        window._set_param_axis_labels = lambda: None
+        window.show_status = lambda *_args: None
+        window.show_plot_state = lambda *_args, **_kwargs: None
+        window.hide_plot_state = lambda: None
+        window.refresh_secondary_lines = lambda: None
+        trace_updates = []
+        window.trace_updated.connect(lambda: trace_updates.append(True))
+
+        plot1d.refreshPlot(window, True, worker=worker)
+
+        self.assertEqual(
+            window.line.calls,
+            [((), {"x": [0.0, 1.0], "y": [10.0, 20.0]})],
+            )
+        self.assertEqual(trace_updates, [True])
 
 
 class RunListParentLookupTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

- preserve explicit database identity when opening plots and select the exact same-label trace during cross-database drops
- keep visible source plots open after copy/drop while still cleaning up hidden helper windows
- make reordered, removed, and failed-to-construct secondary traces safe across refresh, close, picker, and Trace Appearance paths
- keep ordinary merged live traces updating after their source closes, with source-specific polling ownership shared safely across targets
- refresh merged heatmap cuts for both slider and heatmap-cursor movement, clear stale data on axis changes, refresh Add to Plot candidates, and handle empty cut data safely
- reject stale and unowned worker callbacks without releasing the current waiter, detect completion without a final row, and restart polling after transient row-count errors
- keep right-axis visibility and mutually exclusive dot/marker controls consistent with the rendered traces
- give constant, subnormal, and extreme-valued heatmaps accurate levels plus dynamically synchronized interaction rounding

## Why

This is the bugfix-only follow-up to #45. PR #45 was merged while the second audit and validation pass was still running, so the independently reproduced residual fixes are isolated here.

The final audit found additional live-source ownership, cut-notification, callback-ordering, empty-data, colorbar-interaction, and trace-control defects. Each reproduced defect now has regression coverage.

## Validation

- `.venv-mac/bin/python -m pytest`: 459 passed, 13 subtests passed, 74% branch coverage
- `.venv-mac/bin/python -m ruff check .`: passed
- `.venv-mac/bin/python -m mypy`: passed across 60 configured source files
- isolated sdist and wheel build: passed
- Twine checks for both artifacts: passed
- isolated wheel install, import, version, and packaged-schema smoke test: passed
- isolated offscreen qPlot startup: reached the GUI event loop without an application error
- three independent final code-path audits: no remaining reproducible functional bugs in the reviewed scope

## Scope

Bugfix-only. The diff against current `main` contains commits `a58e559` and `4fe49f7`; no version bump, dependency change, release publication, or unrelated feature work is included.