### PR TITLE
Prepare 1.5.0 beta 3: fix correctness and lifecycle blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ### Fixed
 
+- Restore horizontal and vertical heatmap cut windows after axis-state
+  initialization prevented their fixed-axis controls from being constructed.
 - Reject measurements with more than two independent axes instead of silently
   averaging omitted dimensions, and show unsupported-dimensionality
   placeholders in run previews.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+## 1.5.0-b3 - 2026-08-01
+
 ### Fixed
 
 - Reject measurements with more than two independent axes instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ### Fixed
 
+- Reject measurements with more than two independent axes instead of silently
+  averaging omitted dimensions, and show unsupported-dimensionality
+  placeholders in run previews.
+- Invalidate previews when dependency or grid-shape metadata changes, without
+  regenerating them for storage-size-only updates.
+- Coalesce repeated plot refresh requests and run main-window database polling
+  outside the GUI thread.
+- Close selected, exported, and cached dataset connections deterministically
+  when their last owner releases them.
+- Reject non-finite or reversed manual axis limits without raising from a Qt
+  callback.
+- Save configuration updates atomically so interrupted writes preserve the
+  previous valid file.
 - Keep 1D traces from different databases distinct when their run IDs and
   parameter names match.
 - Keep multiple cuts from the same heatmap distinct and visibly numbered when

--- a/README.md
+++ b/README.md
@@ -110,11 +110,14 @@ qplot.run()
 Plot windows may appear before their data has finished loading. Check the
 status bar at the bottom of the plot window before assuming a load has failed.
 
-For detailed workflows, plot controls, live data behavior, operations, CSV
-export, and keyboard shortcuts, see [docs/user-guide.md](docs/user-guide.md).
+For the installed `1.4.0` release, see its
+[versioned user guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.4.0/docs/user-guide.md).
+For the current beta, see [docs/user-guide.md](docs/user-guide.md).
 
-For setup and runtime problems, see
-[docs/troubleshooting.md](docs/troubleshooting.md).
+Likewise, use the
+[1.4.0 troubleshooting guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.4.0/docs/troubleshooting.md)
+for the full release or [docs/troubleshooting.md](docs/troubleshooting.md) for
+the current beta.
 
 For release history, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ automatically when qPlot is installed.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b2`; it is documented below but is not used for the default install.
+is `1.5.0-b3`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -44,7 +44,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b2
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b3
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,12 +116,13 @@ Config keys use dotted paths in code and in `qplot-cfg`, for example
 | `user_preference.bar_colour_excluded_prefixes` | string array | `[]` | any strings | Hide colour maps with these prefixes. |
 | `user_preference.confirm_close` | boolean | `true` | `true` or `false` | Ask before closing the main window. |
 | `user_preference.confirm_close_all` | boolean | `true` | `true` or `false` | Ask before closing all plot windows. |
+| `user_preference.auto_plot` | boolean | `false` | `true` or `false` | Automatically open newly detected runs. |
 | `user_preference.mouse_mode` | string | `"pan"` | `pan` or `rect` | Default plot mouse interaction mode. |
 | `user_preference.copy_plot_image_resolution` | string | `"screen"` | `screen`, `dpi_300`, or `svg` | Format/resolution used by plot-window Copy Plot Image. |
 | `user_preference.default_refresh_rate` | number | `1` | `value >= 0` | Default plot refresh interval. |
 | `runtime_settings.max_threads` | integer | `4` | `value >= 1` | Maximum worker threads for background loading. |
 | `runtime_settings.max_full_heatmap_points` | integer | `2000000` | `1 <= value <= 2000000000` | Maximum estimated points loaded at full resolution before 2D plot windows use SQL spatial aggregation. |
-| `runtime_settings.del_grace_period` | number | `10` | `0 <= value <= 300` | Grace period before deleting temporary files. |
+| `runtime_settings.del_grace_period` | number | `10` | `0 <= value <= 300` | Seconds to retain an unused plot dataset connection for quick reopening. |
 | `runtime_settings.cloud_sync_timeout` | number | `120` | `1 <= value <= 3600` | Seconds to wait for cloud storage to hydrate a database before failing. |
 
 ## Adding Config Keys

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,13 +27,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.0-b2`. The package metadata uses the PEP 440 normal
-form `1.5.0b2`; the GitHub release tag should be `v1.5.0-b2`.
+The current beta is `1.5.0-b3`. The package metadata uses the PEP 440 normal
+form `1.5.0b3`; the GitHub release tag should be `v1.5.0-b3`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b2
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b3
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b2`, even if the Git tag includes a separator,
-   such as `v1.5.0-b2`.
+   package form, such as `1.5.0b3`, even if the Git tag includes a separator,
+   such as `v1.5.0-b3`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -133,8 +133,11 @@ There are several ways to open plots:
 * Enter `*` as the measurement to open all plottable measurements for the
   selected run.
 
-Parameters with one independent variable open as line plots. Parameters with
-two or more independent variables open as heatmaps.
+Parameters with one independent variable open as line plots, and parameters
+with two independent variables open as heatmaps. Measurements with three or
+more independent variables are not projected or averaged implicitly: qPlot
+shows an `nD` unsupported placeholder in the run table and leaves the data
+available for CSV export. Create an explicit 1D/2D slice before plotting it.
 
 Plot windows may appear before their data has finished loading. Check the plot
 window status bar; unless qPlot stops responding or shows an error, wait for the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -76,7 +76,7 @@ the app picker, set a per-user `.db` association from Command Prompt after
 replacing the Python path:
 
 ```batch
-reg add HKCU\Software\Classes\qplot.db\shell\open\command /ve /d "\"C:\path\to\QCoDeS-Plotter\.venv\Scripts\pythonw.exe\" -m qplot \"%%1\"" /f
+reg add HKCU\Software\Classes\qplot.db\shell\open\command /ve /d "\"C:\path\to\QCoDeS-Plotter\.venv\Scripts\pythonw.exe\" -m qplot \"%1\"" /f
 reg add HKCU\Software\Classes\.db /ve /d qplot.db /f
 ```
 
@@ -117,7 +117,8 @@ Common actions:
   or troubleshooting.
 * The refresh interval controls how often qPlot checks for new runs. Set it to
   `0.0 s` to disable automatic checks.
-* `Auto-plot` opens newly detected runs automatically.
+* `Auto-plot` opens newly detected runs automatically. When enabled while a run
+  is already in progress, it also opens the newest running run immediately.
 
 The selected-run preview tab can plot or export individual measurements through
 double-click and context-menu actions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ files = [
     "src/qplot/configuration/themes/light.py",
     "src/qplot/datahandling/__init__.py",
     "src/qplot/datahandling/LoadFromDB.py",
+    "src/qplot/datahandling/dimensions.py",
     "src/qplot/datahandling/qcodes_cache.py",
     "src/qplot/datahandling/readSQL.py",
     "src/qplot/datahandling/readonly.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b2"
+version = "1.5.0b3"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]

--- a/scripts/liveplot.py
+++ b/scripts/liveplot.py
@@ -27,7 +27,9 @@ from qcodes.instrument_drivers.mock_instruments import (
 )
 
 qc.Instrument.close_all()
-initialise_or_create_database_at(os.path.join(os.getcwd(), "tests", "data", "qplot-demo.db"))
+database_folder = os.path.join(os.getcwd(), "tests", "data")
+os.makedirs(database_folder, exist_ok=True)
+initialise_or_create_database_at(os.path.join(database_folder, "qplot-demo.db"))
 
 
 # A dummy signal generator with two parameters ch1 and ch2

--- a/scripts/time_stress.py
+++ b/scripts/time_stress.py
@@ -11,52 +11,52 @@ import sys
 from os.path import join
 from time import time
 
+import numpy as np
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
-from qcodes.dataset import load_by_guid
 
 from qplot import config
-from qplot.windows import MainWindow, plot1d, plot2d
+from qplot.windows import MainWindow, plot2d
 
 
 class test2d(plot2d):
     
     timer = QtCore.pyqtSignal([object, float, int])
     
-    def refreshWindow(self, force : bool = False):
-        
-        start_time = time()
-        
-        super().refreshWindow()
-        
-        refresh_time = time() - start_time
-        
-        current_length = len(self.depvarData)
-        
-        if current_length != self.last_df_len:
-            self.timer.emit(self, refresh_time, current_length)
+    def load_data(self, *args, **kwargs):
+        self._timing_started_at = time()
+        return super().load_data(*args, **kwargs)
+
+
+    def refreshPlot(self, finished=True, worker=None):
+        current_worker = worker if worker is not None else getattr(self, "worker", None)
+        super().refreshPlot(finished, worker=worker)
+        if not finished or current_worker is not getattr(self, "worker", None):
+            return
+        if not hasattr(self, "dataGrid"):
+            return
+
+        current_length = int(np.asarray(self.dataGrid).size)
+        previous_length = getattr(self, "_timed_data_length", None)
+        if current_length == previous_length:
+            return
+
+        self._timed_data_length = current_length
+        started_at = getattr(self, "_timing_started_at", time())
+        self.timer.emit(self, time() - started_at, current_length)
     
         
 class testMain(MainWindow):
-    
-    @QtCore.pyqtSlot(str)
-    def openPlot(self, guid : str=None):
-        if not self.ds:
-            ds = load_by_guid(guid)
-        elif guid and self.ds.guid != guid:
-            ds = load_by_guid(guid)
-        else:
-            ds = self.ds
-            
-        for param in ds.get_parameters():
-            if param.depends_on != "":
-                depends_on = param.depends_on_
-                if len(depends_on) == 1:
-                    self.openWin(plot1d, ds, param, self.config, refrate = self.spinBox.value())
-                else:
-                    self.openWin(test2d, ds, param, self.config, refrate = self.spinBox.value())
-                    
-                self.windows[-1].timer.connect(save_time_log)
+    def openWin(self, widget, *args, **kwargs):
+        timed_widget = test2d if widget is plot2d else widget
+        window_count = len(self.windows)
+        super().openWin(timed_widget, *args, **kwargs)
+        if len(self.windows) <= window_count:
+            return
+
+        window = self.windows[-1]
+        if isinstance(window, test2d):
+            window.timer.connect(save_time_log)
                 
                 
                 

--- a/src/qplot/__main__.py
+++ b/src/qplot/__main__.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 
 from PyQt6 import QtWidgets as qtw
 
@@ -12,6 +11,25 @@ from qplot.diagnostics import (
 )
 from qplot.windows import MainWindow
 
+QT_OPTIONS_WITH_VALUES = {
+    "-display",
+    "-font",
+    "-geometry",
+    "-name",
+    "-platform",
+    "-platformpluginpath",
+    "-platformtheme",
+    "-plugin",
+    "-qwindowgeometry",
+    "-qwindowicon",
+    "-qwindowtitle",
+    "-session",
+    "-style",
+    "-stylesheet",
+    "-title",
+    "-visual",
+}
+
 
 def _database_path_from_arguments(args):
     """
@@ -21,12 +39,21 @@ def _database_path_from_arguments(args):
     Qt options are ignored here so they can still be handled by QApplication.
 
     """
+    skip_next = False
+    positional_only = False
     for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--":
+            positional_only = True
+            continue
+        if not positional_only and arg in QT_OPTIONS_WITH_VALUES:
+            skip_next = True
+            continue
         if arg.startswith("-"):
             continue
-
-        if Path(arg).suffix.lower() == ".db":
-            return arg
+        return arg
 
     return None
 
@@ -53,12 +80,13 @@ def run(return_objects=False, database_path=None):
         quietly and successfully.
     database_path : str, optional
         QCoDeS database path to load after the main window opens. When omitted,
-        qPlot uses the first `.db` path passed on the command line, if any.
+        qPlot uses the first positional path passed on the command line, if any.
 
     Returns
     -------
-    tuple[PyQt6.QtWidgets.QApplication, qplot.windows.main.MainWindow] | None
-        Returned only when return_objects is true.
+    tuple[PyQt6.QtWidgets.QApplication, qplot.windows.main.MainWindow] | int
+        Application objects when return_objects is true; otherwise the Qt
+        event-loop exit status.
         
     """
     configure_logging()
@@ -81,7 +109,7 @@ def run(return_objects=False, database_path=None):
 
     if return_objects:
         return app, w
-    return None
+    return exit_code
 
 if __name__=="__main__":
-    run()
+    raise SystemExit(run())

--- a/src/qplot/configuration/config.py
+++ b/src/qplot/configuration/config.py
@@ -1,4 +1,7 @@
 import json
+import os
+import stat
+import tempfile
 from copy import deepcopy
 from importlib.resources import files
 from os import makedirs, path
@@ -40,8 +43,6 @@ class config:
         # Make config file if missing
         if not path.isfile(self.default_file):
             makedirs(path.dirname(self.default_file), exist_ok=True)
-            open(self.default_file, 'x').close()
-            
             # Create config from schema
             self.reset_to_defaults()
         else:
@@ -223,8 +224,54 @@ class config:
             path of file
 
         """
-        with open(path, "w") as fp:
-            json.dump(self.config, fp, indent=4)
+        directory = os.path.dirname(os.path.abspath(path))
+        makedirs(directory, exist_ok=True)
+        file_mode = None
+        try:
+            file_mode = stat.S_IMODE(os.stat(path).st_mode)
+        except FileNotFoundError:
+            pass
+
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{os.path.basename(path)}.",
+            suffix=".tmp",
+            dir=directory,
+            text=True,
+            )
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as fp:
+                json.dump(self.config, fp, indent=4)
+                fp.write("\n")
+                fp.flush()
+                os.fsync(fp.fileno())
+            if file_mode is not None:
+                os.chmod(temporary_path, file_mode)
+            os.replace(temporary_path, path)
+            self._sync_config_directory(directory)
+        except Exception:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+
+    @staticmethod
+    def _sync_config_directory(directory: str) -> None:
+        """Persist the rename on platforms that support directory fsync."""
+
+        if os.name == "nt":
+            return
+        try:
+            descriptor = os.open(directory, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(descriptor)
+        except OSError:
+            pass
+        finally:
+            os.close(descriptor)
             
     
     def reset_to_defaults(self):

--- a/src/qplot/datahandling/LoadFromDB.py
+++ b/src/qplot/datahandling/LoadFromDB.py
@@ -20,10 +20,10 @@ from qplot.datahandling.qcodes_cache import (
     cache_dataset_connection,
     cache_dataset_run_id,
     cache_is_live,
+    cache_lock,
     parameter_is_complete,
     prepare_cache_if_empty,
     set_cache_dataset_completed,
-    set_parameter_complete,
 )
 
 if TYPE_CHECKING:
@@ -69,6 +69,15 @@ def append_shaped_parameter_data_to_existing_arrays(
     else:
         shape = None
 
+    # QCoDeS inserts shaped refreshes into existing arrays in place. Work on
+    # private copies so a concurrent worker cannot mutate the shared cache
+    # before qPlot's monotonic commit check.
+    if shape is not None:
+        existing_data_1_tree = {
+            name: values.copy()
+            for name, values in existing_data_1_tree.items()
+            }
+
     (merged_data[meas_parameter], updated_write_status[meas_parameter]) = (
         _merge_data(
             existing_data_1_tree,
@@ -83,7 +92,8 @@ def append_shaped_parameter_data_to_existing_arrays(
 
 def load_param_data_from_db_prep(
         cache : "qcodes.dataset.data_set_cache.DataSetCacheWithDBBackend",
-        param : "qcodes.dataset.descriptions.param_spec.ParamSpec"
+        param : "qcodes.dataset.descriptions.param_spec.ParamSpec",
+        connection=None,
         ):
     if cache_is_live(cache):
         raise RuntimeError(
@@ -95,13 +105,15 @@ def load_param_data_from_db_prep(
     if parameter_is_complete(param): # Altered to be per param
         return True
 
-    is_completed = completed(cache_dataset_connection(cache), cache_dataset_run_id(cache))
-    if cache_dataset_completed(cache) != is_completed:
-        set_cache_dataset_completed(cache, is_completed)
-    if cache_dataset_completed(cache):
-        set_parameter_complete(param, True)
-    if cache_data(cache) == {}:
-        prepare_cache_if_empty(cache)
+    with cache_lock(cache):
+        is_completed = completed(
+            connection or cache_dataset_connection(cache),
+            cache_dataset_run_id(cache),
+            )
+        if cache_dataset_completed(cache) != is_completed:
+            set_cache_dataset_completed(cache, is_completed)
+        if cache_data(cache) == {}:
+            prepare_cache_if_empty(cache)
     
     return False
 

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -462,6 +462,7 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
             new_runs = find_new_runs(
                 self.last_run_id,
                 database_path=self.database_path,
+                cancelled_callback=self._cancelled.is_set,
                 ) or {}
             for guid in self.watched_runs:
                 if self._cancelled.is_set():
@@ -470,10 +471,13 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
                     guid,
                     database_path=self.database_path,
                     include_storage_bytes=False,
+                    cancelled_callback=self._cancelled.is_set,
                     )
                 if status:
                     statuses[guid] = status
         except Exception as err:
+            if self._cancelled.is_set():
+                return
             log_exception("Database refresh worker failed", err, __name__)
             self._emit_finished(new_runs, statuses, err)
             return
@@ -561,7 +565,10 @@ class DatabaseLoadWorker(QtCore.QRunnable):
 
             self._emit_status("Opening database read-only...")
             self._emit_status("Loading basic run list...")
-            runs = get_runs_basic_via_sql(self.database_path) or {}
+            runs = get_runs_basic_via_sql(
+                self.database_path,
+                cancelled_callback=self._is_cancelled,
+                ) or {}
             if self._is_cancelled():
                 return
         except InterruptedError:
@@ -754,28 +761,37 @@ class DatabaseDetailWorker(_PrioritizedRunWorker):
                 return
 
             self._emit_status(f"Loading run details... 0/{total}")
-            for details in iter_run_detail_batches_via_sql(
-                    self.database_path,
-                    self.run_ids,
-                    batch_size=self.batch_size,
-                    infer_missing_shapes=False,
-                    include_storage_bytes=False,
-                    include_storage_estimate=True,
-                    include_read_setpoint_count=False,
-                    ):
+            done = set()
+            while len(done) < total:
                 if self._is_cancelled():
                     return
 
-                completed += len(details)
-                if details:
-                    self._emit_batch_ready(details)
+                batch = self._next_priority_batch(done, self.batch_size)
+                if not batch:
+                    break
+                for details in iter_run_detail_batches_via_sql(
+                        self.database_path,
+                        batch,
+                        batch_size=self.batch_size,
+                        infer_missing_shapes=False,
+                        include_storage_bytes=False,
+                        include_storage_estimate=True,
+                        include_read_setpoint_count=False,
+                        cancelled_callback=self._is_cancelled,
+                        ):
+                    if self._is_cancelled():
+                        return
+                    if details:
+                        self._emit_batch_ready(details)
+
+                done.update(batch)
+                completed = len(done)
                 self._emit_status(
                     f"Loading run details... {min(completed, total)}/{total}"
                     )
-
-                if self._is_cancelled():
-                    return
         except Exception as err:
+            if self._is_cancelled():
+                return
             log_exception("Database detail worker failed", err, __name__)
             self._emit_finished(err)
             return
@@ -815,6 +831,7 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                         self.database_path,
                         batch,
                         batch_size=1,
+                        cancelled_callback=self._is_cancelled,
                         ):
                     if self._is_cancelled():
                         return
@@ -845,6 +862,7 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                         self.database_path,
                         batch,
                         batch_size=storage_batch_size,
+                        cancelled_callback=self._is_cancelled,
                         ):
                     if self._is_cancelled():
                         return
@@ -857,6 +875,8 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                     f"Loading exact run sizes... {len(storage_done)}/{total}"
                     )
         except Exception as err:
+            if self._is_cancelled():
+                return
             log_exception("Expensive database detail worker failed", err, __name__)
             self._emit_finished(err)
             return

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -17,6 +17,8 @@ from PyQt6 import QtCore
 
 from qplot.datahandling.readonly import sqlite_read_only_connection
 from qplot.datahandling.readSQL import (
+    find_new_runs,
+    get_run_status,
     get_runs_basic_via_sql,
     iter_run_detail_batches_via_sql,
     iter_run_shape_batches_via_sql,
@@ -425,6 +427,73 @@ class DatabaseDetailSignals(QtCore.QObject):
     status = QtCore.pyqtSignal(int, str)
     batch_ready = QtCore.pyqtSignal(int, str, object)
     finished = QtCore.pyqtSignal(int, str, object)
+
+
+class DatabaseRefreshSignals(QtCore.QObject):
+    """Signals emitted by a coalesced main-window refresh worker."""
+
+    finished = QtCore.pyqtSignal(int, str, object, object, object)
+
+
+class DatabaseRefreshWorker(QtCore.QRunnable):
+    """Fetch new runs and live-run status without blocking the GUI thread."""
+
+    def __init__(self, generation, database_path, last_run_id, watched_runs):
+        super().__init__()
+        self.signals = DatabaseRefreshSignals()
+        self.generation = generation
+        self.database_path = database_path
+        self.last_run_id = int(last_run_id or 0)
+        self.watched_runs = list(watched_runs or [])
+        self._cancelled = threading.Event()
+
+
+    def cancel(self):
+        self._cancelled.set()
+
+
+    def run(self):
+        new_runs = {}
+        statuses = {}
+        try:
+            if self._cancelled.is_set():
+                return
+
+            new_runs = find_new_runs(
+                self.last_run_id,
+                database_path=self.database_path,
+                ) or {}
+            for guid in self.watched_runs:
+                if self._cancelled.is_set():
+                    return
+                status = get_run_status(
+                    guid,
+                    database_path=self.database_path,
+                    include_storage_bytes=False,
+                    )
+                if status:
+                    statuses[guid] = status
+        except Exception as err:
+            log_exception("Database refresh worker failed", err, __name__)
+            self._emit_finished(new_runs, statuses, err)
+            return
+
+        self._emit_finished(new_runs, statuses, None)
+
+
+    def _emit_finished(self, new_runs, statuses, error):
+        try:
+            self.signals.finished.emit(
+                self.generation,
+                self.database_path,
+                new_runs,
+                statuses,
+                error,
+                )
+        except RuntimeError as err:
+            message = str(err)
+            if not ("wrapped C/C++ object" in message and "has been deleted" in message):
+                raise
 
 
 class DatabaseLoadWorker(QtCore.QRunnable):

--- a/src/qplot/datahandling/dimensions.py
+++ b/src/qplot/datahandling/dimensions.py
@@ -1,0 +1,43 @@
+"""Shared rules for the dimensionality qPlot can display safely."""
+
+from collections.abc import Iterable
+
+MAX_SUPPORTED_PLOT_DIMENSIONS = 2
+
+
+class UnsupportedPlotDimensionError(ValueError):
+    """Raised when a measurement cannot be represented without projection."""
+
+
+def normalise_axes(axes: Iterable[object] | None) -> tuple[str, ...]:
+    """Return non-empty axis names in their declared order."""
+
+    items = () if axes is None else axes
+    return tuple(str(axis) for axis in items if str(axis))
+
+
+def unsupported_plot_message(parameter: object, axes: Iterable[object] | None) -> str:
+    """Describe why a measurement is not safe to plot."""
+
+    axis_names = normalise_axes(axes)
+    name = str(parameter or "Measurement")
+    axis_text = ", ".join(axis_names)
+    return (
+        f'{name} has {len(axis_names)} independent axes ({axis_text}). '
+        "qPlot supports 1D and 2D measurements only; displaying this data "
+        "would require an explicit slice or projection."
+    )
+
+
+def ensure_supported_plot_dimensions(
+        parameter: object,
+        axes: Iterable[object] | None,
+        ) -> tuple[str, ...]:
+    """Validate that a dependent parameter can be displayed without data loss."""
+
+    axis_names = normalise_axes(axes)
+    if len(axis_names) > MAX_SUPPORTED_PLOT_DIMENSIONS:
+        raise UnsupportedPlotDimensionError(
+            unsupported_plot_message(parameter, axis_names)
+            )
+    return axis_names

--- a/src/qplot/datahandling/qcodes_cache.py
+++ b/src/qplot/datahandling/qcodes_cache.py
@@ -5,6 +5,20 @@ qPlot needs per-parameter refreshes that QCoDeS does not expose as a stable
 public API. Keep those private-attribute touches in this module so future
 QCoDeS upgrades have one place to adapt.
 """
+from threading import Lock, RLock
+
+_CACHE_LOCK_CREATION = Lock()
+
+
+def cache_lock(cache):
+    """Return qPlot's per-cache lock, creating it safely on first use."""
+
+    with _CACHE_LOCK_CREATION:
+        lock = getattr(cache, "_qplot_lock", None)
+        if lock is None:
+            lock = RLock()
+            cache._qplot_lock = lock
+        return lock
 
 
 def cache_dataset(cache):
@@ -68,8 +82,21 @@ def set_parameter_complete(param, complete=True):
 
 
 def prepare_cache_if_empty(cache):
-    if cache_data(cache) == {}:
-        cache.prepare()
+    with cache_lock(cache):
+        if cache_data(cache) == {}:
+            cache.prepare()
+
+
+def snapshot_cache_parameter_state(cache, parameter_name):
+    """Take a consistent shallow snapshot for one parameter-tree read."""
+
+    with cache_lock(cache):
+        parameter_data = dict(cache_parameter_data(cache, parameter_name))
+        return (
+            dict(cache_write_status(cache)),
+            dict(cache_read_status(cache)),
+            {parameter_name: parameter_data},
+            )
 
 
 def update_cache_parameter_data(
@@ -79,9 +106,27 @@ def update_cache_parameter_data(
         updated_write_status,
         updated_data,
         ):
-    cache_read_status(cache)[parameter_name] = updated_read_status[parameter_name]
-    cache_write_status(cache)[parameter_name] = updated_write_status[parameter_name]
-    cache_data(cache)[parameter_name] = updated_data[parameter_name]
+    """Commit a parameter refresh unless a newer worker already won the race."""
+
+    with cache_lock(cache):
+        next_read_status = updated_read_status[parameter_name]
+        next_write_status = updated_write_status[parameter_name]
+        current_read_status = cache_read_status(cache).get(parameter_name, -1)
+        current_write_status = cache_write_status(cache).get(parameter_name, -1)
+
+        # QCoDeS represents an untouched shaped parameter with ``None``. Treat
+        # it as older than any concrete row count when comparing results.
+        comparable = lambda status: -1 if status is None else status
+        if (
+                comparable(current_read_status) > comparable(next_read_status)
+                or comparable(current_write_status) > comparable(next_write_status)
+                ):
+            return False
+
+        cache_read_status(cache)[parameter_name] = next_read_status
+        cache_write_status(cache)[parameter_name] = next_write_status
+        cache_data(cache)[parameter_name] = updated_data[parameter_name]
+        return True
 
 
 def cache_has_no_written_data(cache):

--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -7,7 +7,21 @@ from qcodes.dataset.sqlite.database import get_DB_location
 from qplot.datahandling.readonly import qcodes_read_only_connection
 
 
-def get_runs_via_sql(database_path=None, include_details=True):
+def _install_cancel_progress_handler(conn, cancelled_callback):
+    if cancelled_callback is None:
+        return
+    if cancelled_callback():
+        raise InterruptedError("Database read cancelled.")
+    set_progress_handler = getattr(conn, "set_progress_handler", None)
+    if callable(set_progress_handler):
+        set_progress_handler(lambda: int(bool(cancelled_callback())), 1000)
+
+
+def get_runs_via_sql(
+        database_path=None,
+        include_details=True,
+        cancelled_callback=None,
+        ):
     """
     Read from the currently initialised QCoDeS database and fetches all data to
     be displayed in Main Window runList
@@ -22,6 +36,7 @@ def get_runs_via_sql(database_path=None, include_details=True):
     """
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         return _fetch_run_rows(
             cursor,
@@ -32,7 +47,7 @@ def get_runs_via_sql(database_path=None, include_details=True):
         conn.close()
 
 
-def get_runs_basic_via_sql(database_path=None):
+def get_runs_basic_via_sql(database_path=None, cancelled_callback=None):
     """
     Read the run list without scanning result tables.
 
@@ -42,7 +57,11 @@ def get_runs_basic_via_sql(database_path=None):
     to later targeted loads.
 
     """
-    return get_runs_via_sql(database_path=database_path, include_details=False)
+    return get_runs_via_sql(
+        database_path=database_path,
+        include_details=False,
+        cancelled_callback=cancelled_callback,
+        )
 
 
 def iter_run_detail_batches_via_sql(
@@ -53,6 +72,7 @@ def iter_run_detail_batches_via_sql(
         include_storage_bytes=True,
         include_storage_estimate=False,
         include_read_setpoint_count=True,
+        cancelled_callback=None,
         ):
     """
     Yield detailed run metadata in small batches.
@@ -68,8 +88,11 @@ def iter_run_detail_batches_via_sql(
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         for offset in range(0, len(run_ids), batch_size):
+            if cancelled_callback is not None and cancelled_callback():
+                raise InterruptedError("Database detail read cancelled.")
             batch = run_ids[offset:offset + batch_size]
             placeholders = ", ".join("?" for _ in batch)
             rows = _fetch_run_rows(
@@ -88,7 +111,12 @@ def iter_run_detail_batches_via_sql(
         conn.close()
 
 
-def iter_run_shape_batches_via_sql(database_path, run_ids, batch_size=1):
+def iter_run_shape_batches_via_sql(
+        database_path,
+        run_ids,
+        batch_size=1,
+        cancelled_callback=None,
+        ):
     """
     Yield setpoint-shape metadata for runs that need result-table inference.
 
@@ -103,8 +131,11 @@ def iter_run_shape_batches_via_sql(database_path, run_ids, batch_size=1):
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         for offset in range(0, len(run_ids), batch_size):
+            if cancelled_callback is not None and cancelled_callback():
+                raise InterruptedError("Database shape read cancelled.")
             batch = run_ids[offset:offset + batch_size]
             placeholders = ", ".join("?" for _ in batch)
             rows = _fetch_run_rows(
@@ -128,7 +159,12 @@ def iter_run_shape_batches_via_sql(database_path, run_ids, batch_size=1):
         conn.close()
 
 
-def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
+def iter_run_storage_batches_via_sql(
+        database_path,
+        run_ids,
+        batch_size=25,
+        cancelled_callback=None,
+        ):
     """
     Yield per-run storage sizes after the cheap detail pass has completed.
 
@@ -144,6 +180,7 @@ def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         run_tables = _run_storage_tables(cursor, run_ids)
         table_names = {
@@ -156,6 +193,8 @@ def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
             return
 
         for offset in range(0, len(run_ids), batch_size):
+            if cancelled_callback is not None and cancelled_callback():
+                raise InterruptedError("Database storage read cancelled.")
             rows = {}
             for run_id in run_ids[offset:offset + batch_size]:
                 metadata = run_tables.get(run_id)
@@ -177,7 +216,7 @@ def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
         conn.close()
 
 
-def find_new_runs(last_run_id, database_path=None):
+def find_new_runs(last_run_id, database_path=None, cancelled_callback=None):
     """
     Fetch all runs created after the last seen run ID.
 
@@ -199,6 +238,7 @@ def find_new_runs(last_run_id, database_path=None):
     conn = qcodes_read_only_connection(database_path or get_DB_location())
 
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         return _fetch_run_rows(cursor, "WHERE runs.run_id > ?", (last_run_id, ))
     finally:
@@ -725,13 +765,19 @@ def _estimated_table_row_bytes(columns):
     return row_bytes
 
 
-def get_run_status(guid, database_path=None, include_storage_bytes=True):
+def get_run_status(
+        guid,
+        database_path=None,
+        include_storage_bytes=True,
+        cancelled_callback=None,
+        ):
     """
     Returns completion and result count information for one run.
 
     """
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         optional_columns = _existing_run_columns(cursor, ["measurement_exception"])
         optional_select = "".join(

--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -177,7 +177,7 @@ def iter_run_storage_batches_via_sql(database_path, run_ids, batch_size=25):
         conn.close()
 
 
-def find_new_runs(last_run_id):
+def find_new_runs(last_run_id, database_path=None):
     """
     Fetch all runs created after the last seen run ID.
 
@@ -196,7 +196,7 @@ def find_new_runs(last_run_id):
         Has layout: 
             run_id : {column_name: column_data}
     """
-    conn = qcodes_read_only_connection(get_DB_location())
+    conn = qcodes_read_only_connection(database_path or get_DB_location())
 
     try:
         cursor = conn.cursor()
@@ -725,12 +725,12 @@ def _estimated_table_row_bytes(columns):
     return row_bytes
 
 
-def get_run_status(guid):
+def get_run_status(guid, database_path=None, include_storage_bytes=True):
     """
     Returns completion and result count information for one run.
 
     """
-    conn = qcodes_read_only_connection(get_DB_location())
+    conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
         cursor = conn.cursor()
         optional_columns = _existing_run_columns(cursor, ["measurement_exception"])
@@ -755,14 +755,16 @@ def get_run_status(guid):
         if value is None:
             return {}
 
+        is_completed = bool(value[1])
         status = {
             "completed_timestamp": value[0],
             "is_completed": value[1],
             "result_count": _result_count(cursor, value[2]),
-            "storage_bytes": _table_storage_bytes(cursor, value[2]),
-            "storage_bytes_estimated": False,
             "database_modified_timestamp": _database_modified_timestamp(cursor),
             }
+        if include_storage_bytes or is_completed:
+            status["storage_bytes"] = _table_storage_bytes(cursor, value[2])
+            status["storage_bytes_estimated"] = False
         for index, column in enumerate(optional_columns, start=5):
             status[column] = value[index]
 

--- a/src/qplot/tools/plot_tools.py
+++ b/src/qplot/tools/plot_tools.py
@@ -137,7 +137,15 @@ def differentiate(
         axis_num = 0
        
     data = data_dict[key]
-    new_data = np.gradient(data, data_dict[dx], axis=axis_num)
+    coordinates = np.asarray(data_dict[dx], dtype=float)
+    if coordinates.ndim != 1 or coordinates.size < 2:
+        raise ValueError("Differentiation requires at least two axis coordinates.")
+    if not np.all(np.isfinite(coordinates)):
+        raise ValueError("Differentiation axis coordinates must be finite.")
+    if np.any(np.diff(coordinates) == 0):
+        raise ValueError("Differentiation axis coordinates must not repeat.")
+
+    new_data = np.gradient(data, coordinates, axis=axis_num)
     
     return {key : new_data}
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -5,17 +5,16 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from PyQt6 import QtCore
 
-from qplot.datahandling import load_param_data_from_db
+from qplot.datahandling import load_param_data_from_db, load_param_data_from_db_prep
 from qplot.datahandling.dimensions import ensure_supported_plot_dimensions
 from qplot.datahandling.qcodes_cache import (
-    cache_data,
     cache_database_path,
+    cache_is_live,
     cache_parameter_data,
-    cache_read_status,
     cache_rundescriber,
     cache_table_name,
-    cache_write_status,
     set_parameter_complete,
+    snapshot_cache_parameter_state,
 )
 from qplot.datahandling.readonly import (
     qcodes_read_only_connection,
@@ -118,15 +117,44 @@ class loader(QtCore.QRunnable):
             ensure_supported_plot_dimensions(
                 getattr(self.param, "name", "Measurement"),
                 getattr(self.param, "depends_on_", ()),
-                )
+            )
             cache = self.cache
+            cache_live = cache_is_live(cache)
 
-            if self.read_data and self._should_use_sql_heatmap():
+            # Completion checks and cache preparation can query SQLite, so do
+            # them here rather than on the GUI thread. In-memory live caches
+            # are already authoritative and should never be read via SQLite.
+            if self.read_data:
+                if cache_live:
+                    self.read_data = False
+                else:
+                    completion_conn = qcodes_read_only_connection(
+                        cache_database_path(cache)
+                        )
+                    try:
+                        complete = load_param_data_from_db_prep(
+                            cache,
+                            self.param,
+                            connection=completion_conn,
+                            )
+                    finally:
+                        completion_conn.close()
+                    self.read_data = not complete
+
+            use_sql_heatmap = (
+                self.read_data
+                and not cache_live
+                and self._should_use_sql_heatmap()
+                )
+            if use_sql_heatmap:
                 set_parameter_complete(self.param, False)
                 self._load_large_heatmap_from_sql()
 
             else:
                 if self.read_data:
+                    write_status, read_status, existing_data = (
+                        snapshot_cache_parameter_state(cache, self.param.name)
+                        )
                     conn = qcodes_read_only_connection(cache_database_path(cache))
                     try:
                         (
@@ -138,9 +166,9 @@ class loader(QtCore.QRunnable):
                             self.table_name,
                             cache_rundescriber(cache),
                             self.param.name,
-                            cache_write_status(cache),
-                            cache_read_status(cache),
-                            cache_data(cache)
+                            write_status,
+                            read_status,
+                            existing_data,
                         )
                     finally:
                         conn.close()
@@ -250,13 +278,11 @@ class loader(QtCore.QRunnable):
         if len(getattr(self.param, "depends_on_", ())) <= 1:
             return False
 
-        # SQL heatmap loading aggregates before Python operations. When the
-        # user has selected operations, preserve their semantics by loading
-        # the raw grid and reducing it only after the pipeline succeeds.
-        if getattr(self, "operations", None):
-            return False
-
         if self.force_sql_heatmap:
+            if getattr(self, "operations", None):
+                raise OperationExecutionError(
+                    "Operations cannot be applied to a heatmap detail reload."
+                    )
             return True
 
         setpoint_count = self._large_heatmap_point_count()
@@ -268,7 +294,14 @@ class loader(QtCore.QRunnable):
             "max_full_heatmap_points",
             MAX_FULL_HEATMAP_POINTS,
             )))
-        return setpoint_count > limit
+        requires_bounded_load = setpoint_count > limit
+        if requires_bounded_load and getattr(self, "operations", None):
+            raise OperationExecutionError(
+                f"This heatmap has approximately {setpoint_count:,} points, "
+                f"which exceeds the full-resolution operation limit of {limit:,}. "
+                "Disable operations or increase max_full_heatmap_points."
+                )
+        return requires_bounded_load
 
 
     def _large_heatmap_point_count(self):
@@ -829,7 +862,7 @@ class loader(QtCore.QRunnable):
         data_grid = np.full(
             (y_axis.size, x_axis.size),
             np.nan,
-            dtype=np.float32,
+            dtype=float,
             )
         data_grid[y_indices, x_indices] = z_data
         empty_bins_filled = bool(np.any(~np.isfinite(data_grid)))
@@ -963,7 +996,7 @@ class loader(QtCore.QRunnable):
         np.add.at(grid_sum, (y_index, x_index), z_data)
         np.add.at(grid_count, (y_index, x_index), 1)
 
-        data_grid = np.full(grid_sum.shape, np.nan, dtype=np.float32)
+        data_grid = np.full(grid_sum.shape, np.nan, dtype=float)
         np.divide(
             grid_sum,
             grid_count,
@@ -1006,7 +1039,7 @@ class loader(QtCore.QRunnable):
         np.add.at(grid_sum, (y_index, x_index), z_data)
         np.add.at(grid_count, (y_index, x_index), 1)
 
-        data_grid = np.full(grid_sum.shape, np.nan, dtype=np.float32)
+        data_grid = np.full(grid_sum.shape, np.nan, dtype=float)
         np.divide(
             grid_sum,
             grid_count,
@@ -1028,7 +1061,7 @@ class loader(QtCore.QRunnable):
         if not np.any(np.isfinite(data_grid)):
             return data_grid
 
-        filled = np.array(data_grid, dtype=np.float32, copy=True)
+        filled = np.array(data_grid, dtype=float, copy=True)
         row_positions = np.arange(filled.shape[0], dtype=float)
         column_positions = np.arange(filled.shape[1], dtype=float)
 
@@ -1296,6 +1329,10 @@ class loader(QtCore.QRunnable):
     def _apply_operation_metadata(self):
         """Update the dependent-variable label and unit after derivatives."""
 
+        is_line_plot = len(getattr(self.param, "depends_on_", ())) == 1
+        if is_line_plot:
+            self.display_param = copy(self.axis_param["y"])
+
         for operation in self.operations:
             axis_name = getattr(operation, "derivative_axis", None)
             if axis_name not in ("x", "y"):
@@ -1319,7 +1356,7 @@ class loader(QtCore.QRunnable):
             elif axis_unit:
                 self.display_param.unit = f"1/{axis_unit}"
 
-        if len(getattr(self.param, "depends_on_", ())) == 1:
+        if is_line_plot:
             self.axis_param["y"] = self.display_param
 
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -6,6 +6,7 @@ import numpy as np
 from PyQt6 import QtCore
 
 from qplot.datahandling import load_param_data_from_db
+from qplot.datahandling.dimensions import ensure_supported_plot_dimensions
 from qplot.datahandling.qcodes_cache import (
     cache_data,
     cache_database_path,
@@ -114,6 +115,10 @@ class loader(QtCore.QRunnable):
     
     def run(self):
         try:
+            ensure_supported_plot_dimensions(
+                getattr(self.param, "name", "Measurement"),
+                getattr(self.param, "depends_on_", ()),
+                )
             cache = self.cache
 
             if self.read_data and self._should_use_sql_heatmap():

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -6,12 +6,12 @@ from PyQt6 import QtWidgets as qtw
 from PyQt6.QtGui import QDesktopServices
 from qcodes.dataset.sqlite.database import get_DB_location
 
-from qplot.datahandling import find_new_runs
 from qplot.datahandling.database import (
     DATABASE_CLOUD_SYNC_TIMEOUT_SECONDS,
     DatabaseDetailWorker,
     DatabaseExpensiveDetailWorker,
     DatabaseLoadWorker,
+    DatabaseRefreshWorker,
     database_info_rows,
 )
 from qplot.datahandling.readonly import set_qcodes_database_location
@@ -120,6 +120,8 @@ class DatabaseActionsMixin:
     by MainWindow, plus show_status(), show_error(), and openPlot().
     """
 
+    _database_refresh_worker: DatabaseRefreshWorker | None
+
     def load_startup_database(self):
         """
         Load the highest-priority available startup database.
@@ -207,6 +209,7 @@ class DatabaseActionsMixin:
         cancel_detail_load = getattr(self, "_cancel_database_detail_load", None)
         if callable(cancel_detail_load):
             cancel_detail_load()
+        DatabaseActionsMixin._cancel_database_refresh(self)
 
         self._database_load_generation = getattr(self, "_database_load_generation", 0) + 1
         self._database_load_active = False
@@ -222,13 +225,21 @@ class DatabaseActionsMixin:
         self.run_idBox.setText("")
         self.measurementBox.setText("*")
         self.selected_run_id = None
-        self.ds = None
-        self._selected_dataset_key = None
+        release_selected = getattr(self, "_release_selected_dataset", None)
+        if callable(release_selected):
+            release_selected()
+        else:
+            self.ds = None
+            self._selected_dataset_key = None
         self.localLastFile = None
 
-        for holder in self.dataset_holder.values():
-            holder.cancel_delete_timer()
-        self.dataset_holder.clear()
+        close_handles = getattr(self, "_close_all_dataset_handles", None)
+        if callable(close_handles):
+            close_handles()
+        else:
+            for holder in self.dataset_holder.values():
+                holder.cancel_delete_timer()
+            self.dataset_holder.clear()
 
         self.RunList.blockSignals(True)
         self.RunList.clearSelection()
@@ -286,45 +297,117 @@ class DatabaseActionsMixin:
             self.show_status("Load a database before refreshing.", 5000)
             return
 
-        self.show_status("Checking for new runs...", 0)
-
-        try:
-            newRuns = find_new_runs(self.RunList.maxRunId)
-            updatedRuns = self.RunList.checkWatching()
-            if updatedRuns:
-                self.infoBox.preview.add_runs(updatedRuns)
-                prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
-                if callable(prioritize_previews):
-                    prioritize_previews()
-        except Exception as err:
-            log_exception("Main-window refresh failed", err, __name__)
-            self.show_error("Refresh Failed", "Could not refresh the run list.", str(err))
+        if getattr(self, "_database_refresh_active", False):
+            self._database_refresh_pending = True
+            self.show_status("Database refresh queued.", 3000)
             return
 
-        if newRuns:
-            self.RunList.maxRunId = max(self.RunList.maxRunId, max(newRuns))
+        self.show_status("Checking for new runs...", 0)
+        self._database_refresh_generation = (
+            getattr(self, "_database_refresh_generation", 0) + 1
+            )
+        generation = self._database_refresh_generation
+        self._database_refresh_active = True
+        self._database_refresh_pending = False
+        database_path = self.fileTextbox.text()
+        watched_guids = [
+            run.guid
+            for run in list(self.RunList.watching)
+            if getattr(run, "guid", None)
+            ]
+        worker = DatabaseRefreshWorker(
+            generation,
+            database_path,
+            self.RunList.maxRunId,
+            watched_guids,
+        )
+        self._database_refresh_worker = worker
+        worker.signals.finished.connect(
+            lambda *args: self.database_refresh_finished(*args)
+            )
+        self.databaseRefreshThreadPool.start(worker)
 
-        if not newRuns:
-            self._sync_empty_state()
+
+    @QtCore.pyqtSlot(int, str, object, object, object)
+    def database_refresh_finished(
+            self,
+            generation,
+            database_path,
+            new_runs,
+            statuses,
+            error,
+            ):
+        if generation != getattr(self, "_database_refresh_generation", 0):
+            return
+        if not getattr(self, "_database_refresh_active", False):
+            return
+
+        self._database_refresh_active = False
+        self._database_refresh_worker = None
+        pending = bool(getattr(self, "_database_refresh_pending", False))
+        self._database_refresh_pending = False
+
+        try:
+            if database_path != self.fileTextbox.text():
+                return
+            if error is not None:
+                log_exception("Main-window refresh failed", error, __name__)
+                self.show_error(
+                    "Refresh Failed",
+                    "Could not refresh the run list.",
+                    str(error),
+                    )
+                return
+
+            self._apply_database_refresh_result(new_runs or {}, statuses or {})
+        finally:
+            if pending and database_path == self.fileTextbox.text():
+                QtCore.QTimer.singleShot(0, self.refreshMain)
+
+
+    def _apply_database_refresh_result(self, new_runs, statuses):
+        updated_runs = self.RunList.checkWatching(statuses)
+        if updated_runs:
+            self.infoBox.preview.add_runs(updated_runs)
+            prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
+            if callable(prioritize_previews):
+                prioritize_previews()
+
+        if new_runs:
+            self.RunList.maxRunId = max(self.RunList.maxRunId, max(new_runs))
+            self.RunList.addRuns(new_runs)
+            self.infoBox.preview.add_runs(new_runs)
+            prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
+            if callable(prioritize_previews):
+                prioritize_previews()
+
+        self._sync_empty_state()
+        if not new_runs:
             if self.RunList.topLevelItemCount() == 0:
                 self.show_status(self._empty_database_refresh_status(), 3000)
             else:
                 self.show_status("No new runs found.", 3000)
             return
 
-        self.RunList.addRuns(newRuns)
-        self.infoBox.preview.add_runs(newRuns)
-        prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
-        if callable(prioritize_previews):
-            prioritize_previews()
-        self._sync_empty_state()
-        count = len(newRuns)
+        count = len(new_runs)
         noun = "run" if count == 1 else "runs"
         self.show_status(f"Found {count} new {noun}.", 5000)
 
         if self.autoPlotBox.isChecked():
-            for run in newRuns.values():
+            for run in new_runs.values():
                 self.openPlot(run["guid"])
+
+
+    def _cancel_database_refresh(self):
+        worker = getattr(self, "_database_refresh_worker", None)
+        if worker is not None:
+            worker.cancel()
+        self._database_refresh_generation = (
+            getattr(self, "_database_refresh_generation", 0) + 1
+            )
+        self._database_refresh_active = False
+        self._database_refresh_pending = False
+        self._database_refresh_worker = None
 
 
     @QtCore.pyqtSlot()
@@ -536,6 +619,8 @@ class DatabaseActionsMixin:
             self.show_status("Wait for the current database load to finish.", 5000)
             return False
 
+        DatabaseActionsMixin._cancel_database_refresh(self)
+
         if abspath == get_DB_location() and self.fileTextbox.text() == abspath:
             if not self.infoBox.preview.has_database(abspath):
                 self.infoBox.preview.set_database_runs(
@@ -580,8 +665,12 @@ class DatabaseActionsMixin:
         self.run_idBox.setText("")
         self.measurementBox.setText("*")
         self.selected_run_id = None
-        self.ds = None
-        self._selected_dataset_key = None
+        release_selected = getattr(self, "_release_selected_dataset", None)
+        if callable(release_selected):
+            release_selected()
+        else:
+            self.ds = None
+            self._selected_dataset_key = None
 
         self.RunList.clearSelection()
         self.RunList.clear()

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -342,11 +342,6 @@ class DatabaseActionsMixin:
         if not getattr(self, "_database_refresh_active", False):
             return
 
-        self._database_refresh_active = False
-        self._database_refresh_worker = None
-        pending = bool(getattr(self, "_database_refresh_pending", False))
-        self._database_refresh_pending = False
-
         try:
             if database_path != self.fileTextbox.text():
                 return
@@ -361,6 +356,10 @@ class DatabaseActionsMixin:
 
             self._apply_database_refresh_result(new_runs or {}, statuses or {})
         finally:
+            self._database_refresh_active = False
+            self._database_refresh_worker = None
+            pending = bool(getattr(self, "_database_refresh_pending", False))
+            self._database_refresh_pending = False
             if pending and database_path == self.fileTextbox.text():
                 QtCore.QTimer.singleShot(0, self.refreshMain)
 
@@ -642,6 +641,7 @@ class DatabaseActionsMixin:
             "load_started_at": load_started_at,
         }
 
+        self._set_database_load_controls_enabled(False)
         self._show_database_load_panel(load_message)
 
         try:

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -4,6 +4,17 @@ from dataclasses import dataclass
 from PyQt6 import QtCore
 
 
+def close_dataset_connection(dataset: object) -> bool:
+    """Close a dataset's backing connection when it exposes one."""
+
+    connection = getattr(dataset, "conn", None)
+    close = getattr(connection, "close", None)
+    if not callable(close):
+        return False
+    close()
+    return True
+
+
 def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
     """Return a stable, platform-normalised identity for a database file."""
     return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
@@ -45,6 +56,7 @@ class DatasetHandle:
     dataset: object
     users: int = 1
     delete_timer: QtCore.QTimer | None = None
+    closed: bool = False
 
     def retain(self):
         """
@@ -72,3 +84,14 @@ class DatasetHandle:
         if self.delete_timer is not None:
             self.delete_timer.stop()
             self.delete_timer = None
+
+
+    def close(self):
+        """Cancel pending eviction and deterministically close the dataset."""
+
+        self.cancel_delete_timer()
+        if self.closed:
+            return False
+        closed_connection = close_dataset_connection(self.dataset)
+        self.closed = True
+        return closed_connection

--- a/src/qplot/windows/_plot1d_snap.py
+++ b/src/qplot/windows/_plot1d_snap.py
@@ -63,6 +63,7 @@ def _nearest_trace_sample(
         x_data: npt.ArrayLike,
         y_data: npt.ArrayLike,
         cursor_x: float,
+        cursor_y: float | None = None,
         ) -> _SnapTraceSample | None:
     """
     Return the finite plotted sample nearest to a cursor X coordinate.
@@ -83,7 +84,11 @@ def _nearest_trace_sample(
     finite_indices = np.flatnonzero(finite)
     x_values = x_data[finite]
     y_values = y_data[finite]
-    index = int(np.argmin(np.abs(x_values - cursor_x)))
+    if cursor_y is None:
+        distances = np.abs(x_values - cursor_x)
+    else:
+        distances = np.square(x_values - cursor_x) + np.square(y_values - cursor_y)
+    index = int(np.argmin(distances))
 
     return _SnapTraceSample(
         x_value=float(x_values[index]),
@@ -309,15 +314,14 @@ class Plot1DSnapMixin(_Plot1DSnapBase):
                 continue
 
             viewbox = self._viewbox_for_line(line)
-            mouse_point = viewbox.mapSceneToView(scene_pos)
-            sample = _nearest_trace_sample(data[0], data[1], mouse_point.x())
+            sample, distance = self._nearest_scene_trace_sample(
+                data[0],
+                data[1],
+                scene_pos,
+                viewbox,
+                )
             if sample is None:
                 continue
-
-            point_scene = viewbox.mapViewToScene(
-                QtCore.QPointF(sample.x_value, sample.y_value)
-                )
-            distance = _scene_distance_squared(point_scene, scene_pos)
 
             if nearest_distance is None or distance < nearest_distance:
                 nearest = (
@@ -330,6 +334,50 @@ class Plot1DSnapMixin(_Plot1DSnapBase):
                 nearest_distance = distance
 
         return nearest
+
+
+    @staticmethod
+    def _nearest_scene_trace_sample(x_data, y_data, scene_pos, viewbox):
+        """Return the trace sample nearest to a scene position in screen space."""
+
+        x_data = np.asarray(x_data, dtype=float)
+        y_data = np.asarray(y_data, dtype=float)
+        count = min(x_data.size, y_data.size)
+        if count == 0:
+            return None, None
+
+        x_data = x_data[:count]
+        y_data = y_data[:count]
+        finite = np.isfinite(x_data) & np.isfinite(y_data)
+        if not np.any(finite):
+            return None, None
+
+        finite_indices = np.flatnonzero(finite)
+        x_values = x_data[finite]
+        y_values = y_data[finite]
+        origin = viewbox.mapViewToScene(QtCore.QPointF(0.0, 0.0))
+        x_basis = viewbox.mapViewToScene(QtCore.QPointF(1.0, 0.0))
+        y_basis = viewbox.mapViewToScene(QtCore.QPointF(0.0, 1.0))
+        scene_x = (
+            origin.x()
+            + x_values * (x_basis.x() - origin.x())
+            + y_values * (y_basis.x() - origin.x())
+            )
+        scene_y = (
+            origin.y()
+            + x_values * (x_basis.y() - origin.y())
+            + y_values * (y_basis.y() - origin.y())
+            )
+        distances = np.square(scene_x - scene_pos.x()) + np.square(
+            scene_y - scene_pos.y()
+            )
+        index = int(np.argmin(distances))
+        sample = _SnapTraceSample(
+            x_value=float(x_values[index]),
+            y_value=float(y_values[index]),
+            point_number=int(finite_indices[index]) + 1,
+            )
+        return sample, float(distances[index])
 
 
     def _viewbox_for_line(self, line):

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -415,8 +415,9 @@ class plotWidget(
             self.toolbarRef.hide()
         
         self.spinBox = qtw.QDoubleSpinBox()
+        self.spinBox.setRange(0.0, 86_400.0)
         self.spinBox.setSingleStep(0.1)
-        self.spinBox.setDecimals(1)
+        self.spinBox.setDecimals(3)
 
         self.toolbarRef.addWidget(qtw.QLabel("Refresh interval (s): "))
         self.toolbarRef.addWidget(self.spinBox)
@@ -790,6 +791,7 @@ class plotWidget(
             self.axis_dropdown[axis].currentIndexChanged.connect(
                                         lambda index, axis=axis: self.change_axis(axis)
                                         )
+        self._axis_selection = self.axis_options
             
         # Produce seperations line as QDockWidget as none inbuilt
         sep = qtw.QFrame()
@@ -916,6 +918,11 @@ class plotWidget(
             Formated string for display.
 
         """
+        if not isfinite(num):
+            if num != num:
+                return "nan"
+            return "-inf" if num < 0 else "inf"
+
         try: # Get number of leading/following zeros
             log = int(log10(abs(num)))
         except ValueError:
@@ -1334,7 +1341,8 @@ class plotWidget(
             update.
 
         """
-        duplicates = [k for k, v in self.axis_dropdown.items() 
+        previous = getattr(self, "_axis_selection", self.axis_options)
+        duplicates = [k for k, v in self.axis_dropdown.items()
                           if self.axis_dropdown[key].currentText() == v.currentText()
                           and k != key
                      ]
@@ -1343,29 +1351,11 @@ class plotWidget(
         if len(duplicates) == 1:
             self.axis_dropdown[duplicates[0]].blockSignals(True)
             
-            # Fetch axis parameter from self.axis_param["<x/y>"]
             self.axis_dropdown[duplicates[0]].setCurrentIndex(
-                self.axis_dropdown[duplicates[0]].findText(self.axis_param[key].name)
+                self.axis_dropdown[duplicates[0]].findText(previous[key])
                 )
             
             self.axis_dropdown[duplicates[0]].blockSignals(False)
             
-            # Flip worker data to match change
-            temp_y_data = self.worker.axis_data["y"]
-            temp_y_param = self.worker.axis_param["y"]
-            
-            self.worker.axis_data["y"] = self.worker.axis_data["x"]
-            self.worker.axis_data["x"] = temp_y_data
-            
-            self.worker.axis_param["y"] = self.worker.axis_param["x"]
-            self.worker.axis_param["x"] = temp_y_param
-            
-            if hasattr(self.worker, "dataGrid"):
-                self.worker.dataGrid = self.worker.dataGrid.transpose()
-                
-            # Refresh without loading new dataset data
-            self.refreshPlot()
-            
-        else:
-            # get new data
-            self.refreshWindow(force=True)
+        self._axis_selection = self.axis_options
+        self.refreshWindow(force=True)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -791,7 +791,13 @@ class plotWidget(
             self.axis_dropdown[axis].currentIndexChanged.connect(
                                         lambda index, axis=axis: self.change_axis(axis)
                                         )
-        self._axis_selection = self.axis_options
+        # Do not call the overridable ``axis_options`` property while the base
+        # controls are still being constructed. Cut windows add their fixed-
+        # axis picker only after this method returns.
+        self._axis_selection = {
+            axis: dropdown.currentText()
+            for axis, dropdown in self.axis_dropdown.items()
+            }
             
         # Produce seperations line as QDockWidget as none inbuilt
         sep = qtw.QFrame()

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -5,10 +5,14 @@ import pandas as pd
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
+from qplot.datahandling.dimensions import (
+    MAX_SUPPORTED_PLOT_DIMENSIONS,
+    unsupported_plot_message,
+)
 from qplot.datahandling.readonly import load_by_guid_read_only, load_by_id_read_only
 from qplot.diagnostics import log_exception
 
-from ._dataset_handle import DatasetHandle, DatasetKey
+from ._dataset_handle import DatasetHandle, DatasetKey, close_dataset_connection
 from .plot1d import plot1d
 from .plot2d import plot2d
 
@@ -46,6 +50,70 @@ class PlotActionsMixin:
     """
 
     _selected_dataset_key: DatasetKey | None
+
+    def _dataset_is_held(self, dataset):
+        return dataset is not None and any(
+            handle.dataset is dataset
+            for handle in self.dataset_holder.values()
+            )
+
+
+    def _close_dataset_if_unowned(self, dataset, context="Dataset cleanup failed"):
+        if dataset is None or dataset is getattr(self, "ds", None):
+            return False
+        if self._dataset_is_held(dataset):
+            return False
+        try:
+            return close_dataset_connection(dataset)
+        except Exception as err:
+            log_exception(context, err, __name__)
+            return False
+
+
+    def _replace_selected_dataset(self, dataset, dataset_key):
+        previous = getattr(self, "ds", None)
+        self.ds = dataset
+        self._selected_dataset_key = dataset_key
+        if previous is not dataset:
+            self._close_dataset_if_unowned(
+                previous,
+                context="Previous selected dataset cleanup failed",
+                )
+
+
+    def _release_selected_dataset(self):
+        previous = getattr(self, "ds", None)
+        self.ds = None
+        self._selected_dataset_key = None
+        return self._close_dataset_if_unowned(
+            previous,
+            context="Selected dataset cleanup failed",
+            )
+
+
+    def _evict_dataset_handle(self, dataset_key):
+        handle = self.dataset_holder.pop(dataset_key, None)
+        if handle is None:
+            return False
+
+        handle.cancel_delete_timer()
+        if handle.dataset is getattr(self, "ds", None):
+            return True
+        try:
+            handle.close()
+        except Exception as err:
+            log_exception("Plot dataset cleanup failed", err, __name__)
+        return True
+
+
+    def _close_all_dataset_handles(self):
+        handles = list(self.dataset_holder.values())
+        self.dataset_holder.clear()
+        for handle in handles:
+            try:
+                handle.close()
+            except Exception as err:
+                log_exception("Plot dataset cleanup failed", err, __name__)
 
     @QtCore.pyqtSlot(object)
     def onClose(self, win):
@@ -207,10 +275,10 @@ class PlotActionsMixin:
             else:
                 handle = self.dataset_holder.get(dataset_key)
                 if handle is None:
-                    self.ds = self._load_dataset(dataset_key)
+                    dataset = self._load_dataset(dataset_key)
                 else:
-                    self.ds = handle.dataset
-                self._selected_dataset_key = dataset_key
+                    dataset = handle.dataset
+                self._replace_selected_dataset(dataset, dataset_key)
         except Exception as err:
             log_exception("Selected run load failed", err, __name__)
             self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
@@ -304,10 +372,10 @@ class PlotActionsMixin:
 
         params = self._selected_measurement_params(ds)
         if params is None:
+            self._close_dataset_if_unowned(ds)
             return
 
-        self.ds = ds
-        self._selected_dataset_key = self._current_dataset_key(ds.guid)
+        self._replace_selected_dataset(ds, self._current_dataset_key(ds.guid))
         self.openPlot(params=params)
 
 
@@ -333,12 +401,14 @@ class PlotActionsMixin:
         ds = self._dataset_for_plot_target()
         if ds is None:
             return
+        try:
+            params = self._selected_measurement_params(ds)
+            if params is None:
+                return
 
-        params = self._selected_measurement_params(ds)
-        if params is None:
-            return
-
-        self._export_measurement_csv(ds, params)
+            self._export_measurement_csv(ds, params)
+        finally:
+            self._close_dataset_if_unowned(ds, context="CSV dataset cleanup failed")
 
 
     @QtCore.pyqtSlot(str)
@@ -371,7 +441,13 @@ class PlotActionsMixin:
             self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
             return
 
-        self._export_preview_csv(ds, parameter_name)
+        try:
+            self._export_preview_csv(ds, parameter_name)
+        finally:
+            self._close_dataset_if_unowned(
+                ds,
+                context="Preview CSV dataset cleanup failed",
+                )
 
 
     def _export_preview_csv(self, dataset, parameter_name):
@@ -453,6 +529,7 @@ class PlotActionsMixin:
 
         opened = 0
         skipped = 0
+        unsupported = []
         try:
             if not params:
                 params = ds.get_parameters()
@@ -462,6 +539,11 @@ class PlotActionsMixin:
                     continue
 
                 depends_on = param.depends_on_
+                if len(depends_on) > MAX_SUPPORTED_PLOT_DIMENSIONS:
+                    unsupported.append(
+                        unsupported_plot_message(param.name, depends_on)
+                        )
+                    continue
                 skip = False
 
                 if len(depends_on) == 1:
@@ -514,9 +596,14 @@ class PlotActionsMixin:
 
             if opened:
                 noun = "plot" if opened == 1 else "plots"
-                self.show_status(f"Opened {opened} {noun}.", 5000)
+                message = f"Opened {opened} {noun}."
+                if unsupported:
+                    message += f" Skipped {len(unsupported)} unsupported measurement(s)."
+                self.show_status(message, 8000 if unsupported else 5000)
             elif skipped:
                 self.show_status("Selected plot windows are already open.", 5000)
+            elif unsupported:
+                self.show_status(unsupported[0], 10_000)
             else:
                 self.show_status("No plottable parameters found for this run.", 5000)
 
@@ -528,10 +615,10 @@ class PlotActionsMixin:
                 handle.dataset is ds for handle in self.dataset_holder.values()
             )
             if loaded_by_open_plot and self.ds is not ds and not dataset_is_held:
-                try:
-                    ds.conn.close()
-                except Exception as err:
-                    log_exception("Unused plot dataset cleanup failed", err, __name__)
+                self._close_dataset_if_unowned(
+                    ds,
+                    context="Unused plot dataset cleanup failed",
+                    )
 
 
     def open_param_by_index(self, index: int):
@@ -584,10 +671,10 @@ class PlotActionsMixin:
             try:
                 handle = self.dataset_holder.get(dataset_key)
                 if handle is None:
-                    self.ds = self._load_dataset(dataset_key)
+                    dataset = self._load_dataset(dataset_key)
                 else:
-                    self.ds = handle.dataset
-                self._selected_dataset_key = dataset_key
+                    dataset = handle.dataset
+                self._replace_selected_dataset(dataset, dataset_key)
             except Exception as err:
                 log_exception("Preview plot run load failed", err, __name__)
                 self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
@@ -688,7 +775,13 @@ class PlotActionsMixin:
 
     def _parameter_from_key(self, dataset_key, parameter_name):
         ds = self._dataset_for_key(dataset_key)
-        return self._measurement_param_by_name(ds, parameter_name)
+        try:
+            return self._measurement_param_by_name(ds, parameter_name)
+        finally:
+            self._close_dataset_if_unowned(
+                ds,
+                context="Parameter lookup dataset cleanup failed",
+                )
 
 
     def _measurement_param_by_name(self, dataset, parameter_name):
@@ -860,14 +953,14 @@ class PlotActionsMixin:
             del_time = self.config.get("runtime_settings.del_grace_period")
 
             if del_time == 0:
-                self.dataset_holder.pop(dataset_key)
+                self._evict_dataset_handle(dataset_key)
 
             elif handle.delete_timer is None:
                 del_timer = QtCore.QTimer()
                 del_timer.setSingleShot(True)
                 handle.delete_timer = del_timer
                 del_timer.timeout.connect(
-                    lambda key=dataset_key: self.dataset_holder.pop(key, None)
+                    lambda key=dataset_key: self._evict_dataset_handle(key)
                 )
                 del_timer.start(int(del_time * 1000))
 

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -13,6 +13,7 @@ from qplot.datahandling.readonly import load_by_guid_read_only, load_by_id_read_
 from qplot.diagnostics import log_exception
 
 from ._dataset_handle import DatasetHandle, DatasetKey, close_dataset_connection
+from ._subplots.subplot1d import _subplot_axis_order
 from .plot1d import plot1d
 from .plot2d import plot2d
 
@@ -182,9 +183,14 @@ class PlotActionsMixin:
                 show=show,
                 **kargs,
             )
-            window_type = win.__class__.__name__
-            if window_type not in {"plot1d", "plot2d", "sweeper"}:
-                raise TypeError(f"Unknown window of type: {window_type}")
+            if win.__class__.__name__ == "sweeper":
+                window_type = "sweeper"
+            elif isinstance(win, plot1d):
+                window_type = "plot1d"
+            elif isinstance(win, plot2d):
+                window_type = "plot2d"
+            else:
+                raise TypeError(f"Unknown window of type: {win.__class__.__name__}")
         except Exception:
             if loaded_for_construction:
                 try:
@@ -254,7 +260,7 @@ class PlotActionsMixin:
             try:
                 same_source = item.ds == source_win.ds and item.param == source_win.param
                 should_close = same_source and item.sweep_id in target_ids
-            except AttributeError:
+            except (AttributeError, RuntimeError):
                 continue
 
             if should_close:
@@ -370,7 +376,17 @@ class PlotActionsMixin:
         if ds is None:
             return
 
-        params = self._selected_measurement_params(ds)
+        try:
+            params = self._selected_measurement_params(ds)
+        except Exception as error:
+            log_exception("Run parameter enumeration failed", error, __name__)
+            self._close_dataset_if_unowned(ds)
+            self.show_error(
+                "Run Load Failed",
+                "Could not read the selected run's measurements.",
+                str(error),
+                )
+            return
         if params is None:
             self._close_dataset_if_unowned(ds)
             return
@@ -993,17 +1009,14 @@ class PlotActionsMixin:
 
         for item in self.windows:
             try:
-                if item.param.depends_on == win.param.depends_on:
-                    if not _plot_has_trace_window(win, item):
-                        wins.append(item)
-
-                elif (
-                    item.__class__.__name__ == "sweeper"
-                    and item.axis_options["x"] == win.param.depends_on
-                ):
-                    if not _plot_has_trace_window(win, item):
-                        wins.append(item)
-            except AttributeError:
+                compatible = _subplot_axis_order(
+                    win.axis_options,
+                    item.axis_options,
+                    source_is_cut=item.__class__.__name__ == "sweeper",
+                    )
+                if compatible is not None and not _plot_has_trace_window(win, item):
+                    wins.append(item)
+            except (AttributeError, RuntimeError):
                 continue
 
         win.update_line_picker(wins)

--- a/src/qplot/windows/_plot_axis_scaling.py
+++ b/src/qplot/windows/_plot_axis_scaling.py
@@ -270,12 +270,26 @@ class PlotAxisScalingMixin(_PlotAxisScalingBase):
     def _axis_scale_range_text_changed(self, axis: _AxisName) -> None:
         ui = self._axis_scale_controls[axis]
         axis_number = self._axis_scale_axis_number(axis)
-        values = list(self.vb.viewRange()[axis_number])
-        for index, text in enumerate((ui.minText.text(), ui.maxText.text())):
-            try:
-                values[index] = float(text)
-            except ValueError:
-                pass
+        previous_values = list(self.vb.viewRange()[axis_number])
+        try:
+            values = [float(ui.minText.text()), float(ui.maxText.text())]
+        except ValueError:
+            values = []
+
+        if (
+                len(values) != 2
+                or not all(isfinite(value) for value in values)
+                or values[0] >= values[1]
+                ):
+            ui.minText.setText(f"{previous_values[0]:.5g}")
+            ui.maxText.setText(f"{previous_values[1]:.5g}")
+            show_status = getattr(self, "show_status", None)
+            if callable(show_status):
+                show_status(
+                    "Axis limits must be finite numbers with minimum below maximum.",
+                    5000,
+                    )
+            return
 
         ui.manualRadio.setChecked(True)
         if axis == "x":

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Any
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
-from qplot.datahandling import load_param_data_from_db_prep
 from qplot.datahandling.qcodes_cache import (
+    cache_dataset_completed,
     cache_has_no_written_data,
-    cache_is_live,
+    set_parameter_complete,
     update_cache_parameter_data,
 )
 from qplot.diagnostics import log_exception
@@ -84,10 +84,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
         return handle is not None and getattr(handle, "users", 0) > 0
 
     def _sync_dataset_completion(self, dataset: Any) -> None:
-        """Refresh cached QCoDeS completion state without loading plot data."""
+        """Schedule a final worker read so completion and data commit together."""
 
         if getattr(dataset, "running", False):
-            load_param_data_from_db_prep(dataset.cache, self.param)
+            self.load_data()
 
     def load_data(
             self,
@@ -143,20 +143,8 @@ class PlotRefreshMixin(_PlotRefreshBase):
             )
         worker.dataset_length_at_start = self.ds.number_of_results
 
-        use_sql_heatmap = force_sql_heatmap
-        if not use_sql_heatmap and not cache_is_live(self.ds.cache):
-            use_sql_heatmap = worker._should_use_sql_heatmap()
-
-        if use_sql_heatmap:
-            complete = False
-        else:
-            complete = load_param_data_from_db_prep(self.ds.cache, self.param)
-            worker.read_data = not complete
-
         if status_message is not None:
             message = status_message
-        elif complete:
-            message = f"Processing cached data for {self.param.name}..."
         else:
             message = f"Loading data for {self.param.name}..."
         self.show_status(message, 0)
@@ -346,13 +334,23 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 cache = self.ds.cache
                 name = self.param.name
 
-                update_cache_parameter_data(
+                cache_updated = update_cache_parameter_data(
                     cache,
                     name,
                     worker.updated_read_status,
                     worker.updated_write_status,
                     worker.cache_data,
                     )
+                if not cache_updated:
+                    self._refresh_pending = True
+                    self.show_status(
+                        "A newer refresh finished first; synchronising this plot...",
+                        5000,
+                        )
+                    return False
+
+                if cache_dataset_completed(cache):
+                    set_parameter_complete(self.param, True)
 
                 if not cache_has_no_written_data(cache):
                     self._live = False

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -226,8 +226,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
             # Check if new data has been added to the dataset
             if current_ds_len != self.last_ds_len or force:
                 if self.worker.running:  # No need to run if already updating
-                    if not force:
-                        return
+                    self._refresh_pending = True
+                    if force:
+                        self.show_status("Refresh queued after the current load.", 3000)
+                    return
 
                 # The actual refresh line
                 self.load_data()
@@ -267,6 +269,32 @@ class PlotRefreshMixin(_PlotRefreshBase):
                         if running:
                             self.monitorIntervalChanged(self.spinBox.value())
                             break
+
+
+    def _schedule_pending_refresh(self) -> None:
+        state = self.__dict__
+        if not state.get("_refresh_pending", False):
+            return
+        if state.get("_refresh_pending_scheduled", False):
+            return
+
+        self._refresh_pending_scheduled = True
+        QtCore.QTimer.singleShot(0, self._run_pending_refresh)
+
+
+    def _run_pending_refresh(self) -> None:
+        self._refresh_pending_scheduled = False
+        if not self.__dict__.get("_refresh_pending", False):
+            return
+        if not self._can_process_refresh():
+            self._refresh_pending = False
+            return
+        if getattr(getattr(self, "worker", None), "running", False):
+            self._schedule_pending_refresh()
+            return
+
+        self._refresh_pending = False
+        self.refreshWindow(force=True)
 
 
     @QtCore.pyqtSlot(bool)
@@ -391,7 +419,9 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
         finally:  # Allow code to move on from wait_on_thread
             if worker is self.worker:
+                worker.running = False
                 self.end_wait.emit()
+                self._schedule_pending_refresh()
 
 
     @QtCore.pyqtSlot(Exception)

--- a/src/qplot/windows/_preferences.py
+++ b/src/qplot/windows/_preferences.py
@@ -139,7 +139,7 @@ class PreferencesDialog(qtw.QDialog):
         self.refreshRateSpin.setAccessibleName("Default refresh interval")
         self.refreshRateSpin.setRange(0.0, 86_400.0)
         self.refreshRateSpin.setSingleStep(0.1)
-        self.refreshRateSpin.setDecimals(1)
+        self.refreshRateSpin.setDecimals(3)
         self.refreshRateSpin.setSuffix(" s")
         self._add_row(form, "&Default refresh interval:", self.refreshRateSpin)
 

--- a/src/qplot/windows/_run_controls.py
+++ b/src/qplot/windows/_run_controls.py
@@ -44,8 +44,9 @@ class RunControlsMixin:
 
         """
         self.spinBox = qtw.QDoubleSpinBox()
+        self.spinBox.setRange(0.0, 86_400.0)
         self.spinBox.setSingleStep(0.1)
-        self.spinBox.setDecimals(1)
+        self.spinBox.setDecimals(3)
         self.spinBox.setSuffix(" s")
         self.spinBox.setFixedWidth(84)
         self.spinBox.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
@@ -57,7 +58,9 @@ class RunControlsMixin:
 
         self.autoPlotBox = qtw.QCheckBox()
         self.autoPlotBox.setChecked(self.config.get(AUTO_PLOT_KEY))
-        self.autoPlotBox.setToolTip("Automatically open plots for newly detected runs")
+        self.autoPlotBox.setToolTip(
+            "Open newly detected runs and the newest running run when enabled"
+            )
         self.autoPlotBox.toggled.connect(self._auto_plot_changed)
 
         self.refreshDatabaseButton = qtw.QToolButton()

--- a/src/qplot/windows/_run_controls.py
+++ b/src/qplot/windows/_run_controls.py
@@ -449,7 +449,11 @@ class RunControlsMixin:
         self.RunList.blockSignals(True)
         self.RunList.clearSelection()
         self.RunList.blockSignals(False)
-        self.ds = None
+        release_selected = getattr(self, "_release_selected_dataset", None)
+        if callable(release_selected):
+            release_selected()
+        else:
+            self.ds = None
         self.infoBox.clear()
 
         try:

--- a/src/qplot/windows/_subplots/subplot1d.py
+++ b/src/qplot/windows/_subplots/subplot1d.py
@@ -11,25 +11,13 @@ def _subplot_axis_order(
         ) -> tuple[str, str] | None:
     """Map source data axes onto a host plot, or reject incompatible axes."""
 
-    if source_is_cut:
-        shared_axis = source_options.get("x")
-        if not shared_axis:
-            return None
-        if parent_options.get("x") == shared_axis:
-            return "x", "y"
-        if parent_options.get("y") == shared_axis:
-            return "y", "x"
+    del source_is_cut
+    shared_x = parent_options.get("x")
+    if not shared_x:
         return None
-
-    if (
-            parent_options.get("x") == source_options.get("x")
-            or parent_options.get("y") == source_options.get("y")
-            ):
+    if shared_x == source_options.get("x"):
         return "x", "y"
-    if (
-            parent_options.get("x") == source_options.get("y")
-            or parent_options.get("y") == source_options.get("x")
-            ):
+    if shared_x == source_options.get("y"):
         return "y", "x"
     return None
 

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -321,29 +321,9 @@ class sweeper(plotWidget):
                 )
             self.axis_dropdown["x"].blockSignals(False)
             
-        # NOTE, same as self.change_axis() from here
-            
-            # Switch data
-            temp_y_data = self.worker.axis_data["y"]
-            temp_y_param = self.worker.axis_param["y"]
-            self.worker.dataGrid = self.worker.dataGrid.transpose()
-            
-            # Switch worker data to track changes
-            self.worker.axis_data["y"] = self.worker.axis_data["x"]
-            self.worker.axis_data["x"] = temp_y_data
-            
-            self.worker.axis_param["y"] = self.worker.axis_param["x"]
-            self.worker.axis_param["x"] = temp_y_param
-        
-            self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            self.merge_compatibility_changed.emit()
-            self.refreshPlot() # Refresh without new data
-            
-        else:
-            self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            self.merge_compatibility_changed.emit()
-            # Get new data
-            self.refreshWindow(force=True) 
+        self.sweep_indep, self.fixed_indep = self.axis_options.values()
+        self.merge_compatibility_changed.emit()
+        self.refreshWindow(force=True)
             
     
     @QtCore.pyqtSlot()
@@ -376,29 +356,9 @@ class sweeper(plotWidget):
                 )
             self.picker.option_box.blockSignals(False)
             
-        # NOTE, same as self.change_fixed_param() from here
-            
-            # Switch data
-            temp_y_data = self.worker.axis_data["y"]
-            temp_y_param = self.worker.axis_param["y"]
-            self.worker.dataGrid = self.worker.dataGrid.transpose()
-            
-            # Switch worker data to track changes
-            self.worker.axis_data["y"] = self.worker.axis_data["x"]
-            self.worker.axis_data["x"] = temp_y_data
-            
-            self.worker.axis_param["y"] = self.worker.axis_param["x"]
-            self.worker.axis_param["x"] = temp_y_param
-        
-            self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            self.merge_compatibility_changed.emit()
-            self.refreshPlot() # Refresh without new data
-            
-        else:
-            self.sweep_indep, self.fixed_indep = self.axis_options.values()
-            self.merge_compatibility_changed.emit()
-            # Get new data
-            self.refreshWindow(force=True) 
+        self.sweep_indep, self.fixed_indep = self.axis_options.values()
+        self.merge_compatibility_changed.emit()
+        self.refreshWindow(force=True)
             
             
     @QtCore.pyqtSlot(int, int)

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -4,6 +4,10 @@ import numpy as np
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
+from qplot.datahandling.dimensions import (
+    MAX_SUPPORTED_PLOT_DIMENSIONS,
+    unsupported_plot_message,
+)
 from qplot.datahandling.readonly import sqlite_read_only_connection
 from qplot.diagnostics import log_exception
 
@@ -216,14 +220,15 @@ class PreviewTab(qtw.QWidget):
 
     def _metadata_signature(self, metadata):
         return tuple(
-            metadata.get(key)
+            _signature_value(metadata.get(key))
             for key in (
                 "result_table_name",
                 "result_count",
-                "completed_timestamp",
-                "is_completed",
-                "database_modified_timestamp",
-                "storage_bytes",
+                "run_description",
+                "measure_parameters",
+                "sweep_parameters",
+                "setpoint_shape",
+                "point_shape",
                 )
             )
 
@@ -432,6 +437,18 @@ class PreviewCard(qtw.QWidget):
         super().__init__(*args)
         self.parameter = preview.get("parameter", "")
 
+        if preview.get("unsupported"):
+            label = unsupported_preview_label(
+                preview,
+                preview_size,
+                "previewUnsupported",
+                )
+            layout = qtw.QHBoxLayout()
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.addWidget(label)
+            self.setLayout(layout)
+            return
+
         image = DraggablePreviewImageLabel(
             guid,
             self.parameter,
@@ -629,7 +646,12 @@ def generate_run_previews(database_path, metadata, size=PREVIEW_SIZE):
             if parameter not in available_columns:
                 continue
 
-            axes = [axis for axis in axes if axis in available_columns]
+            declared_axes = [str(axis) for axis in axes]
+            if len(declared_axes) > MAX_SUPPORTED_PLOT_DIMENSIONS:
+                previews.append(_unsupported_preview(parameter, declared_axes))
+                continue
+
+            axes = [axis for axis in declared_axes if axis in available_columns]
             if len(axes) == 1:
                 preview = _preview_1d(cursor, table_name, metadata, parameter, axes[0], size)
             elif len(axes) >= 2:
@@ -645,6 +667,32 @@ def generate_run_previews(database_path, metadata, size=PREVIEW_SIZE):
         conn.close()
 
     return previews
+
+
+def _unsupported_preview(parameter, axes):
+    axes = [str(axis) for axis in axes]
+    return {
+        "parameter": str(parameter),
+        "axes": axes,
+        "dimension_count": len(axes),
+        "title": unsupported_plot_message(parameter, axes),
+        "unsupported": True,
+        }
+
+
+def unsupported_preview_label(preview, size, object_name):
+    dimensions = int(preview.get("dimension_count") or len(preview.get("axes") or []))
+    text = f"{dimensions}D" if int(size) <= 32 else f"{dimensions}D\nunsupported"
+    label = qtw.QLabel(text)
+    label.setObjectName(object_name)
+    label.setAccessibleName(f"{dimensions}D measurement unsupported")
+    label.setFixedSize(int(size), int(size))
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+    label.setWordWrap(True)
+    label.setToolTip(preview.get("title", "Unsupported measurement dimensionality"))
+    label.setFrameShape(qtw.QFrame.Shape.Box)
+    label.setFrameShadow(qtw.QFrame.Shadow.Plain)
+    return label
 
 
 def _preview_1d(cursor, table_name, metadata, parameter, axis, size):
@@ -1688,6 +1736,19 @@ def _json_dict(value):
         return {}
 
     return decoded if isinstance(decoded, dict) else {}
+
+
+def _signature_value(value):
+    """Freeze nested metadata so in-place mutations cannot hide changes."""
+
+    if isinstance(value, dict):
+        return tuple(
+            (str(key), _signature_value(item))
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            )
+    if isinstance(value, (list, tuple)):
+        return tuple(_signature_value(item) for item in value)
+    return value
 
 
 def _table_columns(cursor, table_name):

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 import numpy as np
 from PyQt6 import QtCore, QtGui
@@ -26,6 +27,8 @@ PREVIEW_REMAINING_PRIORITY = 0
 PREVIEW_VISIBLE_PRIORITY = 50
 PREVIEW_SELECTED_PRIORITY = 100
 PREVIEW_SELECTED_PROPERTY = "previewSelected"
+PREVIEW_CACHE_MAX_BYTES = 128 * 1024 * 1024
+PREVIEW_CACHE_MAX_ENTRIES = 512
 VIRIDIS_STOPS = np.asarray([
     (68, 1, 84),
     (72, 35, 116),
@@ -60,7 +63,8 @@ class PreviewTab(qtw.QWidget):
         self.generation = 0
         self.current_guid = None
         self.run_metadata = {}
-        self.cache = {}
+        self.cache = OrderedDict()
+        self.cache_bytes = 0
         self.errors = {}
         self.queue = {}
         self.active: set[tuple[int, str]] = set()
@@ -111,7 +115,8 @@ class PreviewTab(qtw.QWidget):
         self.preview_size = preview_size
         self._update_minimum_height()
         self.generation += 1
-        self.cache = {}
+        self.cache = OrderedDict()
+        self.cache_bytes = 0
         self.errors = {}
         self.queue = {}
         self.metadata_signatures = {
@@ -119,7 +124,6 @@ class PreviewTab(qtw.QWidget):
             for guid, metadata in self.run_metadata.items()
             }
 
-        self._enqueue_all(priority=PREVIEW_REMAINING_PRIORITY)
         if self.current_guid:
             self._show_message("Generating preview...")
             self._enqueue(
@@ -135,7 +139,8 @@ class PreviewTab(qtw.QWidget):
         self.database_path = database_path
         self.current_guid = None
         self.run_metadata = self._normalise_runs(runs)
-        self.cache = {}
+        self.cache = OrderedDict()
+        self.cache_bytes = 0
         self.errors = {}
         self.queue = {}
         self.active = set()
@@ -145,8 +150,6 @@ class PreviewTab(qtw.QWidget):
             }
 
         self._show_message("Select a run")
-        self._enqueue_all(priority=PREVIEW_REMAINING_PRIORITY)
-        self._schedule_start_next()
 
 
     def add_runs(self, runs, queue_previews=True):
@@ -161,10 +164,10 @@ class PreviewTab(qtw.QWidget):
             self.metadata_signatures[guid] = signature
 
             if changed:
-                self.cache.pop(guid, None)
+                self._drop_cached(guid)
                 self.errors.pop(guid, None)
 
-            if queue_previews:
+            if queue_previews and guid == self.current_guid:
                 self._enqueue(
                     guid,
                     priority=PREVIEW_REMAINING_PRIORITY,
@@ -185,14 +188,15 @@ class PreviewTab(qtw.QWidget):
             return
 
         if guid in self.cache:
-            self._show_previews(self.cache[guid])
+            self._show_previews(self._cached_previews(guid))
             return
 
         if guid in self.errors:
-            self._show_message("Preview failed", self.errors[guid])
-            return
+            self.errors.pop(guid, None)
+            self._show_message("Retrying preview...")
+        else:
+            self._show_message("Generating preview...")
 
-        self._show_message("Generating preview...")
         self._enqueue(guid, priority=PREVIEW_SELECTED_PRIORITY)
         self._start_next()
 
@@ -243,9 +247,10 @@ class PreviewTab(qtw.QWidget):
             selected_guids.add(self.current_guid)
             visible_guids.discard(self.current_guid)
 
-        self._enqueue_all(priority=PREVIEW_REMAINING_PRIORITY)
+        requested_guids = selected_guids | visible_guids
         for guid in list(self.queue):
-            self.queue[guid] = PREVIEW_REMAINING_PRIORITY
+            if guid not in requested_guids:
+                self.queue.pop(guid, None)
 
         for guid in visible_guids:
             self._enqueue(guid, priority=PREVIEW_VISIBLE_PRIORITY)
@@ -324,6 +329,49 @@ class PreviewTab(qtw.QWidget):
         self.queue[guid] = max(priority, self.queue.get(guid, priority))
 
 
+    def _cached_previews(self, guid):
+        previews = self.cache.pop(guid)
+        self.cache[guid] = previews
+        return previews
+
+
+    def _drop_cached(self, guid):
+        previews = self.cache.pop(guid, None)
+        if previews is not None:
+            self.cache_bytes = max(
+                0,
+                self.cache_bytes - self._preview_bytes(previews),
+                )
+
+
+    def _store_cached(self, guid, previews):
+        self._drop_cached(guid)
+        self.cache[guid] = previews
+        self.cache_bytes += self._preview_bytes(previews)
+        while (
+                len(self.cache) > PREVIEW_CACHE_MAX_ENTRIES
+                or self.cache_bytes > PREVIEW_CACHE_MAX_BYTES
+                ):
+            evict_guid = next(
+                (cached_guid for cached_guid in self.cache if cached_guid != self.current_guid),
+                None,
+                )
+            if evict_guid is None:
+                break
+            self._drop_cached(evict_guid)
+
+
+    @staticmethod
+    def _preview_bytes(previews):
+        total = 0
+        for preview in previews or []:
+            image = preview.get("image") if isinstance(preview, dict) else None
+            size_in_bytes = getattr(image, "sizeInBytes", None)
+            if callable(size_in_bytes):
+                total += max(0, int(size_in_bytes()))
+        return total
+
+
     def _schedule_start_next(self):
         if self._start_scheduled:
             return
@@ -381,7 +429,7 @@ class PreviewTab(qtw.QWidget):
         if error:
             self.errors[guid] = str(error)
         else:
-            self.cache[guid] = previews
+            self._store_cached(guid, previews)
             self.previewsReady.emit(guid, previews)
 
         if guid == self.current_guid:

--- a/src/qplot/windows/_widgets/run_list_items.py
+++ b/src/qplot/windows/_widgets/run_list_items.py
@@ -2,7 +2,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from ._run_formatting import one_dimensional_duplicate_point_count, run_tooltip_text
-from .preview import DraggablePreviewImageLabel
+from .preview import DraggablePreviewImageLabel, unsupported_preview_label
 
 MEASUREMENT_PREVIEW_SIZE = 22
 MEASUREMENT_PREVIEW_SPACING = 3
@@ -65,6 +65,16 @@ class RunPreviewCell(qtw.QWidget):
 
         preview_count = 0
         for preview in previews or []:
+            if preview.get("unsupported"):
+                label = unsupported_preview_label(
+                    preview,
+                    self.icon_size,
+                    "measurementPreviewUnsupported",
+                    )
+                self.content_layout.addWidget(label)
+                preview_count += 1
+                continue
+
             image = preview.get("image")
             if image is None:
                 continue

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from os.path import isfile
+from typing import cast
 
 import numpy as np
 from PyQt6 import (
@@ -713,9 +714,8 @@ class RunList(qtw.QTreeWidget):
         Produces the context menu at mouse position on right click.
         Allows user to open specific plots from the selected run.
         
-        Relies on the fact the the right click is consered the same as a left 
-        click for slots. So right click also runs the selection code of left
-        click before the context menu, auto loading data needed in Main Window.
+        Selects the row under the pointer before building actions so every menu
+        command targets the row that was actually clicked.
 
         Parameters
         ----------
@@ -726,6 +726,24 @@ class RunList(qtw.QTreeWidget):
         main = self.main_window()
         if main is None:
             return
+
+        item = self.itemAt(pos)
+        if item is None:
+            main.show_status("Right-click a run to open its plot menu.", 3000)
+            return
+        item = cast(qtw.QTreeWidgetItem, item)
+        while True:
+            parent = item.parent()
+            if parent is None:
+                break
+            item = parent
+        if not isinstance(item, SortableTreeWidgetItem):
+            return
+
+        if self.currentItem() is not item or item not in self.selectedItems():
+            self.clearSelection()
+            self.setCurrentItem(item)
+            item.setSelected(True)
 
         if main.ds is None:
             main.show_status("Select a run before opening the context menu.", 5000)

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -601,7 +601,7 @@ class RunList(qtw.QTreeWidget):
             return text if text else None
 
 
-    def checkWatching(self):
+    def checkWatching(self, statuses=None):
         """
         Check unfinished runs within table and sets finish time if completed.
 
@@ -610,7 +610,11 @@ class RunList(qtw.QTreeWidget):
         updated_runs = {}
         for run in self.watching:
 
-            status = get_run_status(run.guid)
+            status = (
+                get_run_status(run.guid)
+                if statuses is None
+                else statuses.get(run.guid, {})
+                )
             if not status:
                 continue
 

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -21,6 +21,9 @@ from qplot.datahandling.database import (
     DatabaseLoadWorker as DatabaseLoadWorker,
 )
 from qplot.datahandling.database import (
+    DatabaseRefreshWorker as DatabaseRefreshWorker,
+)
+from qplot.datahandling.database import (
     database_info_report as database_info_report,
 )
 from qplot.datahandling.database import (
@@ -101,7 +104,7 @@ class DatabasePathLineEdit(qtw.QLineEdit):
         self.databaseDropped.emit(os.path.abspath(path))
 
 
-class MainWindow(  # type: ignore[misc]
+class MainWindow(
     DatabaseActionsMixin,
     PlotActionsMixin,
     RunControlsMixin,
@@ -137,6 +140,8 @@ class MainWindow(  # type: ignore[misc]
         self.databaseDetailThreadPool.setMaxThreadCount(1)
         self.databaseExpensiveDetailThreadPool = QtCore.QThreadPool(self)
         self.databaseExpensiveDetailThreadPool.setMaxThreadCount(1)
+        self.databaseRefreshThreadPool = QtCore.QThreadPool(self)
+        self.databaseRefreshThreadPool.setMaxThreadCount(1)
         self._database_load_generation = 0
         self._database_load_active = False
         self._database_load_state = None
@@ -147,6 +152,10 @@ class MainWindow(  # type: ignore[misc]
         self._database_expensive_detail_generation = 0
         self._database_expensive_detail_active = False
         self._database_expensive_detail_worker = None
+        self._database_refresh_generation = 0
+        self._database_refresh_active = False
+        self._database_refresh_pending = False
+        self._database_refresh_worker: DatabaseRefreshWorker | None = None
         self._next_plot_x = 0
         self._next_plot_y = 0
         self.localLastFile = None
@@ -414,6 +423,9 @@ class MainWindow(  # type: ignore[misc]
             )
         if expensive_detail_worker is not None:
             expensive_detail_worker.cancel()
+        refresh_worker = getattr(self, "_database_refresh_worker", None)
+        if refresh_worker is not None:
+            refresh_worker.cancel()
         self._database_load_generation += 1
         self._database_load_active = False
         self._database_load_state = None
@@ -428,8 +440,20 @@ class MainWindow(  # type: ignore[misc]
             )
         self._database_expensive_detail_active = False
         self._database_expensive_detail_worker = None
+        self._database_refresh_generation = (
+            getattr(self, "_database_refresh_generation", 0) + 1
+            )
+        self._database_refresh_active = False
+        self._database_refresh_pending = False
+        self._database_refresh_worker = None
         self.monitor.stop()
         qtw.QApplication.closeAllWindows()
+        release_selected = getattr(self, "_release_selected_dataset", None)
+        if callable(release_selected):
+            release_selected()
+        close_handles = getattr(self, "_close_all_dataset_handles", None)
+        if callable(close_handles):
+            close_handles()
     
    
     @QtCore.pyqtSlot()

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -1047,8 +1047,18 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         for axis in ("x", "y"):
             left_low, left_high = left[axis]
             right_low, right_high = right[axis]
-            width = max(abs(left_high - left_low), abs(right_high - right_low), 1.0)
-            tolerance = width * 0.01
+            width = max(abs(left_high - left_low), abs(right_high - right_low))
+            coordinate_scale = max(
+                abs(left_low),
+                abs(left_high),
+                abs(right_low),
+                abs(right_high),
+                1.0,
+                )
+            tolerance = max(
+                width * 0.01,
+                np.finfo(float).eps * coordinate_scale * 16,
+                )
             if (
                     abs(left_low - right_low) > tolerance
                     or abs(left_high - right_high) > tolerance

--- a/tests/datahandling/test_dimensions.py
+++ b/tests/datahandling/test_dimensions.py
@@ -1,0 +1,32 @@
+import unittest
+
+from qplot.datahandling.dimensions import (
+    UnsupportedPlotDimensionError,
+    ensure_supported_plot_dimensions,
+    unsupported_plot_message,
+)
+
+
+class PlotDimensionTestCase(unittest.TestCase):
+    def test_one_and_two_dimensional_measurements_are_supported(self):
+        self.assertEqual(ensure_supported_plot_dimensions("line", ["x"]), ("x",))
+        self.assertEqual(
+            ensure_supported_plot_dimensions("map", ["x", "y"]),
+            ("x", "y"),
+            )
+
+    def test_higher_dimensional_measurement_is_rejected_with_axes(self):
+        with self.assertRaisesRegex(
+                UnsupportedPlotDimensionError,
+                r"signal has 3 independent axes \(x, y, z\)",
+                ):
+            ensure_supported_plot_dimensions("signal", ["x", "y", "z"])
+
+        self.assertIn(
+            "explicit slice or projection",
+            unsupported_plot_message("signal", ["x", "y", "z"]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/datahandling/test_qcodes_cache.py
+++ b/tests/datahandling/test_qcodes_cache.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from qplot.datahandling import LoadFromDB as load_from_db
 from qplot.datahandling.qcodes_cache import (
     cache_database_path,
@@ -12,6 +14,7 @@ from qplot.datahandling.qcodes_cache import (
     prepare_cache_if_empty,
     set_cache_dataset_completed,
     set_parameter_complete,
+    snapshot_cache_parameter_state,
     update_cache_parameter_data,
 )
 
@@ -66,6 +69,19 @@ def test_cache_prepare_helper_prepares_empty_cache():
     assert cache._data == {"signal": {"signal": [5, 6]}}
 
 
+def test_cache_parameter_snapshot_copies_state_mappings():
+    cache = Cache()
+
+    write_status, read_status, data = snapshot_cache_parameter_state(cache, "signal")
+    cache._write_status["signal"] = 9
+    cache._read_status["signal"] = 9
+    cache._data["signal"]["extra"] = [3]
+
+    assert write_status == {"signal": 0}
+    assert read_status == {"signal": 0}
+    assert data == {"signal": {"signal": [1, 2]}}
+
+
 def test_dataset_completion_helper_sets_private_flag():
     cache = Cache()
 
@@ -77,7 +93,7 @@ def test_dataset_completion_helper_sets_private_flag():
 def test_cache_update_writes_single_parameter_state():
     cache = Cache()
 
-    update_cache_parameter_data(
+    committed = update_cache_parameter_data(
         cache,
         "signal",
         {"signal": 4},
@@ -89,6 +105,44 @@ def test_cache_update_writes_single_parameter_state():
     assert cache._write_status["signal"] == 4
     assert cache._data["signal"] == {"signal": [3, 4]}
     assert not cache_has_no_written_data(cache)
+    assert committed
+
+
+def test_cache_update_rejects_result_older_than_current_parameter_state():
+    cache = Cache()
+    cache._read_status["signal"] = 8
+    cache._write_status["signal"] = 8
+
+    committed = update_cache_parameter_data(
+        cache,
+        "signal",
+        {"signal": 4},
+        {"signal": 4},
+        {"signal": {"signal": [3, 4]}},
+    )
+
+    assert not committed
+    assert cache._read_status["signal"] == 8
+    assert cache._write_status["signal"] == 8
+    assert cache._data["signal"] == {"signal": [1, 2]}
+
+
+def test_cache_update_accepts_first_result_after_none_shaped_status():
+    cache = Cache()
+    cache._read_status["signal"] = None
+    cache._write_status["signal"] = None
+
+    committed = update_cache_parameter_data(
+        cache,
+        "signal",
+        {"signal": 0},
+        {"signal": 0},
+        {"signal": {"signal": []}},
+    )
+
+    assert committed
+    assert cache._read_status["signal"] == 0
+    assert cache._write_status["signal"] == 0
 
 
 def test_parameter_completion_helpers_set_private_flag():
@@ -101,7 +155,26 @@ def test_parameter_completion_helpers_set_private_flag():
     assert parameter_is_complete(param)
 
 
-def test_load_param_data_from_db_prep_marks_completed_param(monkeypatch):
+def test_shaped_merge_does_not_mutate_shared_existing_array():
+    class RunDescriber:
+        shapes = {"signal": (2,)}
+
+    existing = {"signal": {"signal": np.array([1.0, np.nan])}}
+
+    write_status, merged = load_from_db.append_shaped_parameter_data_to_existing_arrays(
+        RunDescriber(),
+        "signal",
+        {"signal": 1},
+        existing,
+        {"signal": {"signal": np.array([2.0])}},
+        )
+
+    np.testing.assert_array_equal(existing["signal"]["signal"], [1.0, np.nan])
+    np.testing.assert_array_equal(merged["signal"]["signal"], [1.0, 2.0])
+    assert write_status["signal"] == 2
+
+
+def test_load_param_data_from_db_prep_defers_parameter_completion_until_commit(monkeypatch):
     cache = Cache()
     cache._data = {}
     param = Param()
@@ -112,7 +185,7 @@ def test_load_param_data_from_db_prep_marks_completed_param(monkeypatch):
 
     assert result is False
     assert cache._dataset.completed
-    assert param._complete
+    assert not param._complete
     assert cache.prepare_called
 
 

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -8,6 +8,36 @@ from qplot.datahandling import readSQL
 
 
 class RunSizeTestCase(unittest.TestCase):
+    def test_cancel_progress_handler_interrupts_a_running_sql_statement(self):
+        conn = sqlite3.connect(":memory:")
+        callback_count = 0
+
+        def cancelled():
+            nonlocal callback_count
+            callback_count += 1
+            return callback_count > 5
+
+        try:
+            readSQL._install_cancel_progress_handler(conn, cancelled)
+            with self.assertRaisesRegex(sqlite3.OperationalError, "interrupted"):
+                conn.execute(
+                    "WITH RECURSIVE values_(n) AS ("
+                    "SELECT 1 UNION ALL SELECT n + 1 FROM values_ WHERE n < 10000000"
+                    ") SELECT SUM(n) FROM values_"
+                    ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertGreater(callback_count, 5)
+
+    def test_cancel_progress_handler_rejects_already_cancelled_read(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            with self.assertRaisesRegex(InterruptedError, "cancelled"):
+                readSQL._install_cancel_progress_handler(conn, lambda: True)
+        finally:
+            conn.close()
+
     def test_has_finished_returns_optional_timestamp_scalar(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = os.path.join(temp_dir, "runs.db")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from jsonschema import ValidationError
 from PyQt6 import QtWidgets as qtw
@@ -70,6 +71,26 @@ class TemporaryConfigTestCase(unittest.TestCase):
 
         self.assertEqual(cfg.get("user_preference.theme"), "light")
         self.assertEqual(config().get("user_preference.theme"), "light")
+
+    def test_config_write_failure_preserves_previous_file(self):
+        cfg = config()
+        previous_contents = Path(config.default_file).read_text(encoding="utf-8")
+
+        with (
+            patch(
+                "qplot.configuration.config.json.dump",
+                side_effect=OSError("simulated write failure"),
+                ),
+            self.assertRaisesRegex(OSError, "simulated write failure"),
+            ):
+            cfg.update("user_preference.theme", "dark")
+
+        self.assertEqual(
+            Path(config.default_file).read_text(encoding="utf-8"),
+            previous_contents,
+            )
+        self.assertEqual(cfg.get("user_preference.theme"), "light")
+        self.assertEqual(list(Path(config.default_path).glob("*.tmp")), [])
 
     def test_config_cli_set_value_converts_values(self):
         with redirect_stdout(io.StringIO()):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,8 +190,9 @@ class TemporaryConfigTestCase(unittest.TestCase):
                 ]),
             "/tmp/example.db",
             )
-        self.assertIsNone(
-            qplot_main._database_path_from_arguments(["-style", "Fusion", "notes.txt"])
+        self.assertEqual(
+            qplot_main._database_path_from_arguments(["-style", "Fusion", "notes.txt"]),
+            "notes.txt",
             )
 
     def test_application_identity_uses_qplot_name(self):
@@ -213,6 +214,30 @@ class TemporaryConfigTestCase(unittest.TestCase):
             app.setApplicationName(old_name)
             if old_display_name is not None and hasattr(app, "setApplicationDisplayName"):
                 app.setApplicationDisplayName(old_display_name)
+
+    def test_run_returns_qt_event_loop_exit_status(self):
+        class Application:
+            def setApplicationName(self, _name):
+                pass
+
+            def setApplicationDisplayName(self, _name):
+                pass
+
+            def exec(self):
+                return 7
+
+        application = Application()
+        with (
+            patch.object(qplot_main.qtw, "QApplication", return_value=application),
+            patch.object(qplot_main, "MainWindow", return_value=object()),
+            patch.object(qplot_main, "configure_logging"),
+            patch.object(qplot_main, "install_excepthook"),
+            patch.object(qplot_main, "log_event"),
+            redirect_stdout(io.StringIO()),
+            ):
+            exit_status = qplot_main.run(database_path="example.db")
+
+        self.assertEqual(exit_status, 7)
 
     def test_main_window_uses_configured_default_refresh_rate(self):
         cfg = config()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,7 +15,7 @@ from qplot.tools.plot_tools import (
     pass_filter,
     subtract_mean,
 )
-from qplot.tools.worker import loader
+from qplot.tools.worker import OperationExecutionError, loader
 from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plotWin import plotWidget
 
@@ -509,6 +509,16 @@ class ToolFunctionTestCase(unittest.TestCase):
         np.testing.assert_array_equal(filtered["y"], np.array([2.0, 4.0, 5.0]))
         np.testing.assert_allclose(differentiated["y"], np.array([2.0, 2.0, 2.0]))
 
+    def test_derivative_rejects_duplicate_coordinates(self):
+        data = {
+            "x": np.array([0.0, 1.0, 1.0]),
+            "y": np.array([0.0, 1.0, 2.0]),
+            "z": None,
+        }
+
+        with self.assertRaisesRegex(ValueError, "must not repeat"):
+            differentiate("x", data)
+
     def test_fill_below_handles_bounded_leading_trailing_and_over_limit_gaps(self):
         data_grid = np.array([
             [1.0, np.nan, 1.0, 1.0],
@@ -575,12 +585,35 @@ class ToolFunctionTestCase(unittest.TestCase):
         np.testing.assert_array_equal(worker.axis_data["x"], [1.0, 2.0])
         np.testing.assert_array_equal(worker.axis_data["y"], [3.0, 4.0])
 
-    def test_large_heatmap_with_operations_does_not_aggregate_in_sql(self):
+    def test_large_heatmap_with_operations_is_rejected_before_full_load(self):
         worker = self._sql_heatmap_worker(None)
         worker.max_full_heatmap_points = 10
         worker.operations = [lambda data: data]
 
-        self.assertFalse(loader._should_use_sql_heatmap(worker))
+        with self.assertRaisesRegex(
+                OperationExecutionError,
+                "exceeds the full-resolution operation limit",
+                ):
+            loader._should_use_sql_heatmap(worker)
+
+    def test_heatmap_gridding_preserves_float64_coordinate_and_value_precision(self):
+        worker = loader.__new__(loader)
+        worker.sampled_heatmap_source = False
+        worker.aggregated_heatmap_source = False
+        baseline = 1_000_000_000_000.0
+
+        x_axis, _y_axis, data_grid = loader._heatmap_grid_from_arrays(
+            worker,
+            np.array([baseline, baseline + 1.0]),
+            np.array([0.0, 0.0]),
+            np.array([baseline + 2.0, baseline + 3.0]),
+            max_cells=4,
+            )
+
+        self.assertEqual(x_axis.dtype, np.dtype(float))
+        self.assertEqual(data_grid.dtype, np.dtype(float))
+        self.assertEqual(x_axis[1] - x_axis[0], 1.0)
+        self.assertEqual(data_grid[0, 1] - data_grid[0, 0], 1.0)
 
     def test_derivative_operation_updates_dependent_label_and_unit(self):
         class Param:

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -580,6 +580,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             "is_completed": False,
             }
         preview.run_metadata = {"run-guid": old_metadata}
+        preview.current_guid = "run-guid"
         preview.metadata_signatures = {
             "run-guid": preview._metadata_signature(old_metadata)
             }
@@ -656,7 +657,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         self.assertEqual(preview.queue, {})
         self.assertEqual(preview.run_metadata["run-guid"]["result_count"], 100)
 
-    def test_preview_tab_queues_every_run_on_database_load(self):
+    def test_preview_tab_does_not_eagerly_queue_every_run_on_database_load(self):
         preview = PreviewTab(preview_size=100)
         preview._start_next = lambda: None
         generation_changes = []
@@ -669,10 +670,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             2: {"guid": "guid-2", "run_timestamp": 101.0},
             })
 
-        self.assertEqual(preview.queue, {
-            "guid-1": preview_module.PREVIEW_REMAINING_PRIORITY,
-            "guid-2": preview_module.PREVIEW_REMAINING_PRIORITY,
-            })
+        self.assertEqual(preview.queue, {})
         self.assertEqual(generation_changes, [])
 
     def test_preview_tab_marks_only_active_worker_as_generating(self):
@@ -693,8 +691,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             1: {"guid": "guid-1", "run_timestamp": 100.0},
             2: {"guid": "guid-2", "run_timestamp": 101.0},
             })
-
-        preview._start_next()
+        preview.set_current_run(type("Dataset", (), {"guid": "guid-2"})())
 
         self.assertEqual(generation_changes, [("guid-2", True)])
         self.assertEqual(started_workers[0].guid, "guid-2")
@@ -721,11 +718,11 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         runs = {1: {"guid": "shared-guid", "run_timestamp": 100.0}}
 
         preview.set_database_runs("old.db", runs)
-        preview._start_next()
+        preview.set_current_run(type("Dataset", (), {"guid": "shared-guid"})())
         stale_generation = preview.generation
 
         preview.set_database_runs("current.db", runs)
-        preview._start_next()
+        preview.set_current_run(type("Dataset", (), {"guid": "shared-guid"})())
         current_generation = preview.generation
 
         preview._worker_finished(stale_generation, "shared-guid", [], None)
@@ -746,7 +743,7 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         self.assertEqual(preview.active, set())
         self.assertEqual(generation_changes[-1], ("shared-guid", False))
 
-    def test_preview_tab_prioritizes_selected_then_visible_then_remaining_runs(self):
+    def test_preview_tab_queues_only_selected_and_visible_runs_by_priority(self):
         preview = PreviewTab(preview_size=100)
         preview._start_next = lambda: None
         preview.set_database_runs("previews.db", {
@@ -768,21 +765,48 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             preview.queue["guid-1"],
             preview_module.PREVIEW_VISIBLE_PRIORITY,
             )
-        self.assertEqual(
-            preview.queue["guid-3"],
-            preview_module.PREVIEW_REMAINING_PRIORITY,
-            )
+        self.assertNotIn("guid-3", preview.queue)
 
         preview.prioritize_runs(visible_run_ids=[3])
 
-        self.assertEqual(
-            preview.queue["guid-1"],
-            preview_module.PREVIEW_REMAINING_PRIORITY,
-            )
+        self.assertNotIn("guid-1", preview.queue)
+        self.assertNotIn("guid-2", preview.queue)
         self.assertEqual(
             preview.queue["guid-3"],
             preview_module.PREVIEW_VISIBLE_PRIORITY,
             )
+
+    def test_preview_tab_retries_a_transient_error_when_run_is_reselected(self):
+        preview = PreviewTab(preview_size=100)
+        preview.database_path = "previews.db"
+        preview.run_metadata = {"run-guid": {"guid": "run-guid"}}
+        preview.errors = {"run-guid": "database was temporarily locked"}
+        preview._start_next = lambda: None
+
+        preview.set_current_run(type("Dataset", (), {"guid": "run-guid"})())
+
+        self.assertNotIn("run-guid", preview.errors)
+        self.assertEqual(
+            preview.queue["run-guid"],
+            preview_module.PREVIEW_SELECTED_PRIORITY,
+            )
+
+    def test_preview_cache_evicts_least_recently_used_noncurrent_entry(self):
+        preview = PreviewTab(preview_size=100)
+        old_max_entries = preview_module.PREVIEW_CACHE_MAX_ENTRIES
+        preview_module.PREVIEW_CACHE_MAX_ENTRIES = 2
+        image = QtGui.QImage(2, 2, QtGui.QImage.Format.Format_ARGB32)
+        payload = [{"image": image}]
+        try:
+            preview._store_cached("guid-1", payload)
+            preview._store_cached("guid-2", payload)
+            preview._cached_previews("guid-1")
+            preview._store_cached("guid-3", payload)
+        finally:
+            preview_module.PREVIEW_CACHE_MAX_ENTRIES = old_max_entries
+
+        self.assertEqual(list(preview.cache), ["guid-1", "guid-3"])
+        self.assertEqual(preview.cache_bytes, image.sizeInBytes() * 2)
 
     def test_preview_sampling_is_limited_without_result_count(self):
         old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -599,6 +599,37 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         self.assertNotIn("run-guid", preview.errors)
         self.assertIn("run-guid", preview.queue)
 
+    def test_preview_signature_tracks_shape_but_not_storage_metadata(self):
+        preview = PreviewTab(preview_size=100)
+        metadata = {
+            "result_table_name": "results",
+            "result_count": 10,
+            "run_description": '{"shapes": {"signal": [2, 5]}}',
+            "measure_parameters": ["signal"],
+            "sweep_parameters": ["x", "y"],
+            "setpoint_shape": [2, 5],
+            "point_shape": [2, 5],
+            "storage_bytes": 100,
+            }
+
+        signature = preview._metadata_signature(metadata)
+
+        self.assertEqual(
+            signature,
+            preview._metadata_signature({**metadata, "storage_bytes": 999}),
+            )
+        self.assertNotEqual(
+            signature,
+            preview._metadata_signature({**metadata, "setpoint_shape": [5, 2]}),
+            )
+        self.assertNotEqual(
+            signature,
+            preview._metadata_signature({
+                **metadata,
+                "run_description": '{"shapes": {"signal": [5, 2]}}',
+                }),
+            )
+
     def test_preview_tab_can_update_metadata_without_queueing_preview(self):
         preview = PreviewTab(preview_size=100)
         preview.database_path = "previews.db"
@@ -1235,6 +1266,36 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             ["x", "y"],
             ])
         self.assertTrue(all(preview["image"].width() == PREVIEW_SIZE for preview in previews))
+
+    def test_generate_run_previews_rejects_three_dimensional_measurement(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "previews.db")
+            conn = sqlite3.connect(database_path)
+            try:
+                conn.execute(
+                    "CREATE TABLE results (x REAL, y REAL, z REAL, signal REAL)"
+                    )
+                conn.execute("INSERT INTO results VALUES (0, 0, 0, 1)")
+                conn.commit()
+            finally:
+                conn.close()
+
+            previews = generate_run_previews(database_path, {
+                "result_table_name": "results",
+                "result_count": 1,
+                "run_description": """
+                {
+                  "interdependencies_": {
+                    "dependencies": {"signal": ["x", "y", "z"]}
+                  }
+                }
+                """,
+                })
+
+        self.assertEqual(len(previews), 1)
+        self.assertTrue(previews[0]["unsupported"])
+        self.assertEqual(previews[0]["dimension_count"], 3)
+        self.assertNotIn("image", previews[0])
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -986,6 +986,25 @@ class RunListTooltipTestCase(unittest.TestCase):
 
             self.assertEqual(export_requested, [("run-guid", "signal")])
             self.assertIs(run_list.currentItem(), item)
+
+            run_list.set_run_previews("run-guid", [{
+                "parameter": "signal",
+                "axes": ["x", "y", "z"],
+                "dimension_count": 3,
+                "title": "signal has 3 independent axes",
+                "unsupported": True,
+                }])
+            unsupported = cell.findChildren(
+                qtw.QLabel,
+                "measurementPreviewUnsupported",
+                )
+            self.assertEqual(len(unsupported), 1)
+            self.assertEqual(unsupported[0].text(), "3D")
+            self.assertEqual(
+                unsupported[0].accessibleName(),
+                "3D measurement unsupported",
+                )
+            self.assertIn("3 independent axes", unsupported[0].toolTip())
         finally:
             treeWidgets.isfile = old_isfile
 

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
@@ -663,6 +663,13 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         self.assertIs(harness.dataset_holder[key_b].dataset, dataset_b)
 
     def test_same_label_plot_from_another_database_is_a_merge_candidate(self):
+        class Combo:
+            def __init__(self, text):
+                self._text = text
+
+            def currentText(self):
+                return self._text
+
         key_a = DatasetKey("database-a.db", "shared-guid")
         key_b = DatasetKey("database-b.db", "shared-guid")
         param_a = self.Param()
@@ -676,6 +683,7 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         target.label = "ID:1 signal"
         target.line = object()
         target.lines = {target.label: target.line}
+        target.axis_dropdown = {"x": Combo("x"), "y": Combo("signal")}
         candidates = []
         target.update_line_picker = lambda wins: candidates.extend(wins)
 
@@ -683,6 +691,7 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         source._trace_key = TraceKey(key_b, param_b.name)
         source.param = param_b
         source.label = target.label
+        source.axis_dropdown = {"x": Combo("x"), "y": Combo("signal")}
 
         harness = type("Harness", (PlotActionsMixin,), {})()
         harness.windows = [target, source]
@@ -692,6 +701,13 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         self.assertEqual(candidates, [source])
 
     def test_sibling_heatmap_cuts_remain_distinct_merge_candidates(self):
+        class Combo:
+            def __init__(self, text):
+                self._text = text
+
+            def currentText(self):
+                return self._text
+
         dataset_key = DatasetKey("database.db", "guid")
 
         target_param = self.Param()
@@ -702,6 +718,10 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
         target.param = target_param
         target.label = "ID:1 line_signal"
         target.line = object()
+        target.axis_dropdown = {
+            "x": Combo("gate"),
+            "y": Combo("line_signal"),
+            }
 
         heatmap_param = self.Param()
         heatmap_param.name = "heatmap_signal"
@@ -1855,9 +1875,10 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
             self.assertTrue(harness._database_load_active)
             self.assertEqual(harness._database_load_state["abspath"], "database-b.db")
             self.assertEqual(len(harness.databaseLoadThreadPool.started), 1)
-            self.assertTrue(harness.refreshDatabaseButton.enabled)
-            self.assertTrue(harness.databaseInfoButton.enabled)
-            self.assertTrue(harness.openDatabaseFolderButton.enabled)
+            self.assertFalse(harness.loadDatabaseButton.enabled)
+            self.assertFalse(harness.refreshDatabaseButton.enabled)
+            self.assertFalse(harness.databaseInfoButton.enabled)
+            self.assertFalse(harness.openDatabaseFolderButton.enabled)
         finally:
             set_qcodes_database_location(active_database)
 
@@ -2397,6 +2418,29 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
             ("Database refresh queued.", 3000),
             )
 
+    def test_refresh_request_during_error_dialog_is_coalesced(self):
+        harness = self.Harness()
+        harness.refreshMain()
+
+        def show_error(_title, _message, _details=None):
+            harness.refreshMain()
+
+        harness.show_error = show_error
+        with patch(
+                "qplot.windows._database_actions.QtCore.QTimer.singleShot",
+                side_effect=lambda _delay, callback: callback(),
+                ):
+            harness.database_refresh_finished(
+                harness._database_refresh_generation,
+                "empty.db",
+                {},
+                {},
+                RuntimeError("database temporarily unavailable"),
+                )
+
+        self.assertEqual(len(harness.databaseRefreshThreadPool.workers), 2)
+        self.assertTrue(harness._database_refresh_active)
+
 
 class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
     class RunList:
@@ -2855,15 +2899,21 @@ class DatabaseRefreshWorkerTestCase(unittest.TestCase):
             ):
             worker.run()
 
-        find_runs.assert_called_once_with(10, database_path="example.db")
+        find_runs.assert_called_once_with(
+            10,
+            database_path="example.db",
+            cancelled_callback=ANY,
+            )
         self.assertEqual(seen_status_calls, [
             ("guid-1", {
                 "database_path": "example.db",
                 "include_storage_bytes": False,
+                "cancelled_callback": ANY,
                 }),
             ("guid-2", {
                 "database_path": "example.db",
                 "include_storage_bytes": False,
+                "cancelled_callback": ANY,
                 }),
             ])
         self.assertEqual(results, [(
@@ -2888,7 +2938,8 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             calls.append(("access", database_path))
             return None
 
-        def get_runs(database_path):
+        def get_runs(database_path, cancelled_callback=None):
+            self.assertTrue(callable(cancelled_callback))
             calls.append(("basic_runs", database_path))
             return {1: {"guid": "guid-1", "run_timestamp": 123.0}}
 
@@ -2945,7 +2996,8 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
         set_qcodes_database_location("active.db")
         database_module.database_access_error = lambda _path: None
 
-        def fail_to_get_runs(_database_path):
+        def fail_to_get_runs(_database_path, cancelled_callback=None):
+            self.assertTrue(callable(cancelled_callback))
             raise RuntimeError("broken run table")
 
         database_module.get_runs_basic_via_sql = fail_to_get_runs
@@ -2969,7 +3021,8 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
         try:
             worker = main_window.DatabaseLoadWorker(11, "cancelled.db")
 
-            def cancel_while_getting_runs(_database_path):
+            def cancel_while_getting_runs(_database_path, cancelled_callback=None):
+                self.assertTrue(callable(cancelled_callback))
                 worker.cancel()
                 return {}
 
@@ -2989,7 +3042,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
 
         set_qcodes_database_location("active.db")
         database_module.database_access_error = lambda _path: None
-        database_module.get_runs_basic_via_sql = lambda _path: {}
+        database_module.get_runs_basic_via_sql = lambda _path, **_kwargs: {}
         try:
             harness = DatabaseLoadUiTestCase.Harness()
             harness._database_load_generation = 13
@@ -3014,7 +3067,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
 
         set_qcodes_database_location("active.db")
         database_module.database_access_error = lambda _path: None
-        database_module.get_runs_basic_via_sql = lambda _path: runs
+        database_module.get_runs_basic_via_sql = lambda _path, **_kwargs: runs
         try:
             harness = DatabaseLoadUiTestCase.Harness()
             harness._database_load_generation = 14
@@ -3137,7 +3190,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
         database_module.database_cloud_storage_label = lambda _path: "OneDrive"
         database_module.database_is_likely_cloud_placeholder = lambda _path: False
         database_module.prefetch_database_file_with_timeout = prefetch
-        database_module.get_runs_basic_via_sql = lambda _path: {}
+        database_module.get_runs_basic_via_sql = lambda _path, **_kwargs: {}
         try:
             with tempfile.NamedTemporaryFile(suffix=".db") as database:
                 worker = main_window.DatabaseLoadWorker(9, database.name, 12)
@@ -3175,7 +3228,9 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 include_storage_bytes=True,
                 include_storage_estimate=False,
                 include_read_setpoint_count=True,
+                cancelled_callback=None,
                 ):
+            self.assertTrue(callable(cancelled_callback))
             calls.append((
                 database_path,
                 run_ids,
@@ -3185,8 +3240,17 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 include_storage_estimate,
                 include_read_setpoint_count,
                 ))
-            yield {2: {"guid": "guid-2", "result_count": 20, "storage_bytes": 1000}}
-            yield {1: {"guid": "guid-1", "result_count": 10}}
+            for run_id in run_ids:
+                if run_id == 2:
+                    yield {
+                        2: {
+                            "guid": "guid-2",
+                            "result_count": 20,
+                            "storage_bytes": 1000,
+                            }
+                        }
+                elif run_id == 1:
+                    yield {1: {"guid": "guid-1", "result_count": 10}}
 
         database_module.iter_run_detail_batches_via_sql = iter_details
         try:
@@ -3208,10 +3272,13 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
         finally:
             database_module.iter_run_detail_batches_via_sql = old_iter_details
 
-        self.assertEqual(calls, [("details.db", [2, 1], 1, False, False, True, False)])
+        self.assertEqual(calls, [
+            ("details.db", [1], 1, False, False, True, False),
+            ("details.db", [2], 1, False, False, True, False),
+            ])
         self.assertEqual(batches, [
-            (11, "details.db", {2: {"guid": "guid-2", "result_count": 20, "storage_bytes": 1000}}),
             (11, "details.db", {1: {"guid": "guid-1", "result_count": 10}}),
+            (11, "details.db", {2: {"guid": "guid-2", "result_count": 20, "storage_bytes": 1000}}),
             ])
         self.assertEqual(statuses, [
             (11, "Loading run details... 0/2"),
@@ -3225,12 +3292,24 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
         old_iter_storage = database_module.iter_run_storage_batches_via_sql
         calls = []
 
-        def iter_shapes(database_path, run_ids, batch_size=1):
+        def iter_shapes(
+                database_path,
+                run_ids,
+                batch_size=1,
+                cancelled_callback=None,
+                ):
+            self.assertTrue(callable(cancelled_callback))
             calls.append(("shapes", database_path, run_ids, batch_size))
             if 1 in run_ids:
                 yield {1: {"guid": "guid-1", "setpoint_shape": [10], "setpoint_count": 10}}
 
-        def iter_storage(database_path, run_ids, batch_size=25):
+        def iter_storage(
+                database_path,
+                run_ids,
+                batch_size=25,
+                cancelled_callback=None,
+                ):
+            self.assertTrue(callable(cancelled_callback))
             calls.append(("storage", database_path, run_ids, batch_size))
             if 1 in run_ids:
                 yield {1: {"guid": "guid-1", "storage_bytes": 2000}}

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -86,6 +86,21 @@ class MeasurementExportDataFrameTestCase(unittest.TestCase):
 
 
 class DatasetHandleTestCase(unittest.TestCase):
+    def test_close_is_idempotent_and_closes_backing_connection(self):
+        class Connection:
+            def __init__(self):
+                self.close_count = 0
+
+            def close(self):
+                self.close_count += 1
+
+        dataset = type("Dataset", (), {"conn": Connection()})()
+        handle = DatasetHandle(dataset)
+
+        self.assertTrue(handle.close())
+        self.assertFalse(handle.close())
+        self.assertEqual(dataset.conn.close_count, 1)
+
     def test_retain_cancels_pending_delete_timer(self):
         class Timer:
             def __init__(self):
@@ -138,6 +153,53 @@ class DatasetHandleTestCase(unittest.TestCase):
 
         harness.remove_ds_at(dataset_key)
         self.assertEqual(harness.dataset_holder, {})
+
+    def test_evicting_unselected_handle_closes_connection(self):
+        class Config:
+            def get(self, key):
+                self.assert_key = key
+                return 0
+
+        class Connection:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        dataset = type("Dataset", (), {"guid": "guid", "conn": Connection()})()
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.config = Config()
+        harness.dataset_holder = {}
+        harness.ds = None
+        harness.show_status = lambda *args: None
+        key = DatasetKey("database.db", "guid")
+        harness.dataset_holder[key] = DatasetHandle(dataset)
+
+        harness.remove_ds_at(key)
+
+        self.assertTrue(dataset.conn.closed)
+        self.assertEqual(harness.dataset_holder, {})
+
+    def test_replacing_selected_dataset_closes_only_unheld_previous_dataset(self):
+        class Connection:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        old_dataset = type("Dataset", (), {"conn": Connection()})()
+        new_dataset = type("Dataset", (), {"conn": Connection()})()
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.ds = old_dataset
+        harness.dataset_holder = {}
+
+        harness._replace_selected_dataset(
+            new_dataset,
+            DatasetKey("database.db", "new-guid"),
+            )
+
+        self.assertTrue(old_dataset.conn.closed)
+        self.assertFalse(new_dataset.conn.closed)
 
     def test_failed_plot_construction_preserves_existing_dataset_ownership(self):
         class Connection:
@@ -340,6 +402,22 @@ class OpenPlotDatasetOwnershipTestCase(unittest.TestCase):
         self.assertNotIn(dataset_key, harness.dataset_holder)
         self.assertEqual(harness.load_count, 1)
         self.assertEqual(harness.errors, [])
+
+    def test_three_dimensional_parameter_is_rejected_before_window_creation(self):
+        param = self.Param("volume")
+        param.depends_on = "x, y, z"
+        param.depends_on_ = ("x", "y", "z")
+        dataset = self.Dataset([param])
+        harness = self.Harness(dataset)
+        harness.open_win = lambda *args, **kwargs: self.fail(
+            "Unsupported parameter must not create a plot window"
+            )
+
+        harness.openPlot(harness._current_dataset_key(dataset.guid), show=False)
+
+        self.assertTrue(dataset.conn.closed)
+        self.assertEqual(harness.windows, [])
+        self.assertIn("3 independent axes", harness.status_messages[-1][0])
 
 
 class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
@@ -2235,19 +2313,32 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
 
 class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
+    class ThreadPool:
+        def __init__(self):
+            self.workers = []
+
+        def start(self, worker):
+            self.workers.append(worker)
+
     class RunList:
         def __init__(self):
             self.maxRunId = 0
             self.checked_watching = False
+            self.watching = []
 
-        def checkWatching(self):
+        def checkWatching(self, statuses=None):
             self.checked_watching = True
+            return {}
 
         def topLevelItemCount(self):
             return 0
 
     class Harness:
         refreshMain = main_window.MainWindow.refreshMain
+        database_refresh_finished = main_window.MainWindow.database_refresh_finished
+        _apply_database_refresh_result = (
+            main_window.MainWindow._apply_database_refresh_result
+            )
         _empty_database_refresh_status = (
             main_window.MainWindow._empty_database_refresh_status
             )
@@ -2260,6 +2351,7 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
             self.spinBox = DatabaseLoadUiTestCase.SpinBox(1.5)
             self.status_messages = []
             self.sync_count = 0
+            self.databaseRefreshThreadPool = RefreshMainEmptyDatabaseTestCase.ThreadPool()
 
         def _sync_empty_state(self):
             self.sync_count += 1
@@ -2271,14 +2363,15 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
             raise AssertionError((title, message, details))
 
     def test_refresh_empty_database_reports_waiting_state(self):
-        old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda last_run_id: {}
-
-        try:
-            harness = self.Harness()
-            harness.refreshMain()
-        finally:
-            database_actions.find_new_runs = old_find_new_runs
+        harness = self.Harness()
+        harness.refreshMain()
+        harness.database_refresh_finished(
+            harness._database_refresh_generation,
+            "empty.db",
+            {},
+            {},
+            None,
+            )
 
         self.assertTrue(harness.RunList.checked_watching)
         self.assertEqual(harness.sync_count, 1)
@@ -2287,7 +2380,21 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
             [
                 ("Checking for new runs...", 0),
                 ("No measurements found yet; still waiting for new runs.", 3000),
-                ],
+            ],
+            )
+
+    def test_repeated_refresh_requests_are_coalesced_while_worker_is_active(self):
+        harness = self.Harness()
+
+        harness.refreshMain()
+        harness.refreshMain()
+
+        self.assertEqual(len(harness.databaseRefreshThreadPool.workers), 1)
+        self.assertTrue(harness._database_refresh_active)
+        self.assertTrue(harness._database_refresh_pending)
+        self.assertEqual(
+            harness.status_messages[-1],
+            ("Database refresh queued.", 3000),
             )
 
 
@@ -2296,8 +2403,9 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
         def __init__(self, updated_runs):
             self.maxRunId = 3
             self.updated_runs = updated_runs
+            self.watching = []
 
-        def checkWatching(self):
+        def checkWatching(self, statuses=None):
             return self.updated_runs
 
         def topLevelItemCount(self):
@@ -2316,6 +2424,10 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
 
     class Harness:
         refreshMain = main_window.MainWindow.refreshMain
+        database_refresh_finished = main_window.MainWindow.database_refresh_finished
+        _apply_database_refresh_result = (
+            main_window.MainWindow._apply_database_refresh_result
+            )
 
         def __init__(self, updated_runs):
             self.fileTextbox = DatabaseLoadUiTestCase.Field("loaded.db")
@@ -2323,6 +2435,7 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
             self.infoBox = RefreshMainPreviewUpdateTestCase.InfoBox()
             self.status_messages = []
             self.sync_count = 0
+            self.databaseRefreshThreadPool = RefreshMainEmptyDatabaseTestCase.ThreadPool()
 
         def _sync_empty_state(self):
             self.sync_count += 1
@@ -2341,14 +2454,15 @@ class RefreshMainPreviewUpdateTestCase(unittest.TestCase):
                 "is_completed": True,
                 },
             }
-        old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda _last_run_id: {}
-
-        try:
-            harness = self.Harness(updated_runs)
-            harness.refreshMain()
-        finally:
-            database_actions.find_new_runs = old_find_new_runs
+        harness = self.Harness(updated_runs)
+        harness.refreshMain()
+        harness.database_refresh_finished(
+            harness._database_refresh_generation,
+            "loaded.db",
+            {},
+            {"guid-4": updated_runs[4]},
+            None,
+            )
 
         self.assertEqual(harness.infoBox.preview.added_runs, [updated_runs])
         self.assertEqual(
@@ -2363,12 +2477,17 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
             self.maxRunId = 10
             self.checked_watching = False
             self.added_runs = None
+            self.watching = []
 
-        def checkWatching(self):
+        def checkWatching(self, statuses=None):
             self.checked_watching = True
+            return {}
 
         def addRuns(self, runs):
             self.added_runs = runs
+
+        def topLevelItemCount(self):
+            return 1
 
     class Preview:
         def __init__(self):
@@ -2390,6 +2509,10 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
 
     class Harness:
         refreshMain = main_window.MainWindow.refreshMain
+        database_refresh_finished = main_window.MainWindow.database_refresh_finished
+        _apply_database_refresh_result = (
+            main_window.MainWindow._apply_database_refresh_result
+            )
 
         def __init__(self, auto_plot_checked):
             self.fileTextbox = DatabaseLoadUiTestCase.Field("loaded.db")
@@ -2401,6 +2524,7 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
             self.status_messages = []
             self.plotted_guids = []
             self.sync_count = 0
+            self.databaseRefreshThreadPool = RefreshMainEmptyDatabaseTestCase.ThreadPool()
 
         def _sync_empty_state(self):
             self.sync_count += 1
@@ -2420,21 +2544,17 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
             12: {"guid": "guid-12", "run_timestamp": 12.5},
             13: {"guid": "guid-13", "run_timestamp": 12.5},
             }
-        seen_last_run_ids = []
-        old_find_new_runs = database_actions.find_new_runs
-
-        def find_new_runs(last_run_id):
-            seen_last_run_ids.append(last_run_id)
-            return new_runs
-
-        database_actions.find_new_runs = find_new_runs
-        try:
-            harness = self.Harness(auto_plot_checked=True)
-            harness.refreshMain()
-        finally:
-            database_actions.find_new_runs = old_find_new_runs
-
-        self.assertEqual(seen_last_run_ids, [10])
+        harness = self.Harness(auto_plot_checked=True)
+        harness.refreshMain()
+        worker = harness.databaseRefreshThreadPool.workers[0]
+        self.assertEqual(worker.last_run_id, 10)
+        harness.database_refresh_finished(
+            harness._database_refresh_generation,
+            "loaded.db",
+            new_runs,
+            {},
+            None,
+            )
         self.assertTrue(harness.RunList.checked_watching)
         self.assertEqual(harness.RunList.maxRunId, 13)
         expected_runs = new_runs
@@ -2454,15 +2574,18 @@ class RefreshMainAutoPlotTestCase(unittest.TestCase):
             )
 
     def test_refresh_does_not_auto_plot_new_runs_when_disabled(self):
-        old_find_new_runs = database_actions.find_new_runs
-        database_actions.find_new_runs = lambda _last_run_id: {
+        new_runs = {
             11: {"guid": "guid-11", "run_timestamp": 11.0},
             }
-        try:
-            harness = self.Harness(auto_plot_checked=False)
-            harness.refreshMain()
-        finally:
-            database_actions.find_new_runs = old_find_new_runs
+        harness = self.Harness(auto_plot_checked=False)
+        harness.refreshMain()
+        harness.database_refresh_finished(
+            harness._database_refresh_generation,
+            "loaded.db",
+            new_runs,
+            {},
+            None,
+            )
 
         self.assertEqual(harness.plotted_guids, [])
         self.assertEqual(
@@ -2703,6 +2826,56 @@ class CloudDatabasePrefetchTestCase(unittest.TestCase):
             database_module.subprocess.Popen = old_popen
 
         self.assertEqual(killed, [True])
+
+
+class DatabaseRefreshWorkerTestCase(unittest.TestCase):
+    def test_worker_fetches_new_runs_and_lightweight_live_statuses(self):
+        results = []
+        seen_status_calls = []
+
+        def get_status(guid, **kwargs):
+            seen_status_calls.append((guid, kwargs))
+            return {"result_count": 12}
+
+        worker = database_module.DatabaseRefreshWorker(
+            4,
+            "example.db",
+            10,
+            ["guid-1", "guid-2"],
+            )
+        worker.signals.finished.connect(lambda *args: results.append(args))
+
+        with (
+            patch.object(
+                database_module,
+                "find_new_runs",
+                return_value={11: {"guid": "guid-11"}},
+                ) as find_runs,
+            patch.object(database_module, "get_run_status", side_effect=get_status),
+            ):
+            worker.run()
+
+        find_runs.assert_called_once_with(10, database_path="example.db")
+        self.assertEqual(seen_status_calls, [
+            ("guid-1", {
+                "database_path": "example.db",
+                "include_storage_bytes": False,
+                }),
+            ("guid-2", {
+                "database_path": "example.db",
+                "include_storage_bytes": False,
+                }),
+            ])
+        self.assertEqual(results, [(
+            4,
+            "example.db",
+            {11: {"guid": "guid-11"}},
+            {
+                "guid-1": {"result_count": 12},
+                "guid-2": {"result_count": 12},
+                },
+            None,
+            )])
 
 
 class DatabaseLoadWorkerTestCase(unittest.TestCase):

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -97,6 +97,18 @@ class SnapToTraceTestCase(unittest.TestCase):
         self.assertEqual(sample.y_value, 10.0)
         self.assertEqual(sample.point_number, 2)
 
+    def test_nearest_trace_sample_uses_y_to_disambiguate_duplicate_x_values(self):
+        sample = _nearest_trace_sample(
+            [0.0, 1.0, 1.0, 2.0],
+            [0.0, 10.0, 20.0, 30.0],
+            1.0,
+            cursor_y=19.0,
+            )
+
+        self.assertEqual(sample.x_value, 1.0)
+        self.assertEqual(sample.y_value, 20.0)
+        self.assertEqual(sample.point_number, 3)
+
     def test_axis_label_uses_power_scaled_units_for_auto_si_prefix(self):
         axis = plotwin_module._PowerScaledAxisItem("bottom")
         axis.setLabel(text="Gate ch2", units="V")
@@ -163,6 +175,24 @@ class SnapToTraceTestCase(unittest.TestCase):
         self.assertEqual(y_value, 4.0)
         self.assertIs(viewbox, plot_item.vb)
         self.assertEqual(point_number, 3)
+
+    def test_nearest_trace_point_uses_screen_distance_with_duplicate_x_values(self):
+        widget = pg.GraphicsLayoutWidget()
+        plot_item = widget.addPlot()
+        line = plot_item.plot(x=[1.0, 1.0], y=[10.0, 20.0])
+        window = plot1d.__new__(plot1d)
+        window.plot = plot_item
+        window.right_vb = None
+        window.lines = {"main": line}
+
+        scene_pos = plot_item.vb.mapViewToScene(QtCore.QPointF(1.0, 19.0))
+
+        _label, _x_value, y_value, _viewbox, point_number = (
+            window._nearest_trace_point(scene_pos)
+            )
+
+        self.assertEqual(y_value, 20.0)
+        self.assertEqual(point_number, 2)
 
     def test_nearest_trace_point_ignores_hidden_traces(self):
         widget = pg.GraphicsLayoutWidget()
@@ -1055,7 +1085,7 @@ class SnapToTraceTestCase(unittest.TestCase):
             )
         )
 
-    def test_subplot_axis_mapping_rejects_incompatible_cut_axis(self):
+    def test_subplot_axis_mapping_requires_source_to_match_host_displayed_x(self):
         self.assertEqual(
             _subplot_axis_order(
                 {"x": "gate", "y": "current"},
@@ -1064,20 +1094,20 @@ class SnapToTraceTestCase(unittest.TestCase):
             ),
             ("x", "y"),
         )
-        self.assertEqual(
+        self.assertIsNone(
             _subplot_axis_order(
                 {"x": "current", "y": "gate"},
                 {"x": "gate", "y": "field"},
                 source_is_cut=True,
-            ),
-            ("y", "x"),
+            )
         )
-        self.assertIsNone(
+        self.assertEqual(
             _subplot_axis_order(
                 {"x": "gate", "y": "current"},
                 {"x": "field", "y": "gate"},
                 source_is_cut=True,
-            )
+            ),
+            ("y", "x"),
         )
 
     def test_completed_cut_updates_and_clears_merged_subplot_immediately(self):

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -146,5 +146,27 @@ def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
 
         assert heatmap_window.dataGrid.shape == (7, 5)
         assert np.isfinite(heatmap_window.dataGrid).all()
+
+        source_x = np.asarray(heatmap_window.axis_data["x"]).copy()
+        source_y = np.asarray(heatmap_window.axis_data["y"]).copy()
+        source_grid = np.asarray(heatmap_window.dataGrid).copy()
+
+        heatmap_window.z_index = [2, 1]
+        heatmap_window.openSweep("h")
+        horizontal_cut = window.windows[-1]
+        wait_for(lambda: not getattr(horizontal_cut.worker, "running", False))
+
+        np.testing.assert_array_equal(horizontal_cut.axis_data["x"], source_x)
+        np.testing.assert_array_equal(horizontal_cut.axis_data["y"], source_grid[1, :])
+        assert horizontal_cut.sweep_id in heatmap_window.sweep_lines
+
+        heatmap_window.z_index = [2, 1]
+        heatmap_window.openSweep("v")
+        vertical_cut = window.windows[-1]
+        wait_for(lambda: not getattr(vertical_cut.worker, "running", False))
+
+        np.testing.assert_array_equal(vertical_cut.axis_data["x"], source_y)
+        np.testing.assert_array_equal(vertical_cut.axis_data["y"], source_grid[:, 2])
+        assert vertical_cut.sweep_id in heatmap_window.sweep_lines
     finally:
         close_main_window(window)

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -56,6 +56,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         window.load_calls = []
         window.restart_intervals = []
         window.load_data = lambda: window.load_calls.append("load")
+        window.show_status = lambda *args: None
         window.monitorIntervalChanged = lambda interval: (
             window.restart_intervals.append(interval)
             )
@@ -69,6 +70,21 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.load_calls, [])
         self.assertEqual(window.last_ds_len, 0)
         self.assertEqual(window.restart_intervals, [0.2])
+
+    def test_forced_refresh_while_busy_is_coalesced(self):
+        window = self._window(worker_running=True)
+
+        plotWidget.refreshWindow(window, force=True)
+        plotWidget.refreshWindow(window, force=True)
+
+        self.assertEqual(window.load_calls, [])
+        self.assertTrue(window._refresh_pending)
+
+        window.worker.running = False
+        plotWidget._run_pending_refresh(window)
+
+        self.assertEqual(window.load_calls, ["load"])
+        self.assertFalse(window._refresh_pending)
 
     def test_refresh_keeps_row_count_pending_until_worker_succeeds(self):
         window = self._window(worker_running=False)
@@ -1484,6 +1500,44 @@ class RunListParentLookupTestCase(unittest.TestCase):
         finally:
             host.deleteLater()
             widget.deleteLater()
+
+    def test_axis_scale_rejects_non_finite_and_reversed_manual_ranges(self):
+        window = plotWidget.__new__(plotWidget)
+        window.vb = pg.ViewBox()
+        minimum = qtw.QLineEdit("nan")
+        maximum = qtw.QLineEdit("1")
+        manual = qtw.QRadioButton()
+        ui = type(
+            "AxisControls",
+            (),
+            {"minText": minimum, "maxText": maximum, "manualRadio": manual},
+            )()
+        window._axis_scale_controls = {"x": ui}
+        window.show_status = lambda *args: window.__dict__.setdefault(
+            "statuses",
+            [],
+            ).append(args)
+        window.vb.setXRange(0, 1, padding=0)
+
+        try:
+            before = list(window.vb.viewRange()[0])
+            plotWidget._axis_scale_range_text_changed(window, "x")
+            self.assertEqual(list(window.vb.viewRange()[0]), before)
+            self.assertTrue(all(value not in {"nan", "inf"} for value in (
+                minimum.text(),
+                maximum.text(),
+                )))
+
+            minimum.setText("2")
+            maximum.setText("1")
+            plotWidget._axis_scale_range_text_changed(window, "x")
+            self.assertEqual(list(window.vb.viewRange()[0]), before)
+            self.assertIn("finite numbers", window.statuses[-1][0])
+        finally:
+            minimum.deleteLater()
+            maximum.deleteLater()
+            manual.deleteLater()
+            window.vb.deleteLater()
 
     def test_colorbar_scale_action_opens_dialog_without_nested_menu(self):
         class Bar:

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -112,27 +112,15 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.monitor.stopped, 1)
         self.assertEqual(window.restart_intervals, [0.2])
 
-    def test_refresh_detects_completion_without_a_new_result_row(self):
+    def test_refresh_schedules_final_worker_read_without_a_new_result_row(self):
         window = self._window(worker_running=False)
         window.last_ds_len = window.ds.number_of_results
         window.param = object()
-        completion_checks = []
 
-        old_prep = plot_refresh_module.load_param_data_from_db_prep
-        try:
-            def complete(cache, param):
-                completion_checks.append((cache, param))
-                window.ds.running = False
-                return True
+        plotWidget.refreshWindow(window)
 
-            plot_refresh_module.load_param_data_from_db_prep = complete
-            plotWidget.refreshWindow(window)
-        finally:
-            plot_refresh_module.load_param_data_from_db_prep = old_prep
-
-        self.assertEqual(completion_checks, [(window.ds.cache, window.param)])
-        self.assertEqual(window.load_calls, [])
-        self.assertEqual(window.restart_intervals, [])
+        self.assertEqual(window.load_calls, ["load"])
+        self.assertEqual(window.restart_intervals, [0.2])
 
     def test_secondary_trace_restart_does_not_depend_on_dictionary_order(self):
         window = self._window(worker_running=False)
@@ -191,6 +179,41 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertFalse(result)
         self.assertIn("Fill Below", window.statuses[-1][0])
         self.assertEqual(window.plot_states[-1][0][0], "Operations not applied")
+
+    def test_axis_swap_queues_a_fresh_worker_without_mutating_old_worker_data(self):
+        class Combo:
+            def __init__(self, items, current):
+                self.items = items
+                self.index = items.index(current)
+
+            def currentText(self):
+                return self.items[self.index]
+
+            def blockSignals(self, _blocked):
+                pass
+
+            def findText(self, text):
+                return self.items.index(text)
+
+            def setCurrentIndex(self, index):
+                self.index = index
+
+        window = plotWidget.__new__(plotWidget)
+        window.axis_dropdown = {
+            "x": Combo(["x", "y"], "y"),
+            "y": Combo(["x", "y"], "y"),
+            }
+        window._axis_selection = {"x": "x", "y": "y"}
+        old_worker = object()
+        window.worker = old_worker
+        refreshes = []
+        window.refreshWindow = lambda force=False: refreshes.append(force)
+
+        plotWidget.change_axis(window, "x")
+
+        self.assertEqual(window.axis_options, {"x": "y", "y": "x"})
+        self.assertIs(window.worker, old_worker)
+        self.assertEqual(refreshes, [True])
 
     def test_load_data_uses_sampled_sql_and_wires_originating_worker(self):
         class Signal:
@@ -301,23 +324,15 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
             )
 
         old_loader = plot_refresh_module.loader
-        old_prep = plot_refresh_module.load_param_data_from_db_prep
         try:
             plot_refresh_module.loader = Worker
-            plot_refresh_module.load_param_data_from_db_prep = (
-                lambda *_args: (_ for _ in ()).throw(
-                    AssertionError("completed cache prep should be skipped")
-                    )
-                )
-
             plotWidget.load_data(window)
         finally:
             plot_refresh_module.loader = old_loader
-            plot_refresh_module.load_param_data_from_db_prep = old_prep
 
         self.assertEqual(len(window.threadPool.started), 1)
         worker = window.threadPool.started[0]
-        self.assertTrue(worker.checked_large_heatmap)
+        self.assertFalse(worker.checked_large_heatmap)
         self.assertTrue(worker.read_data)
         self.assertFalse(worker.force_sql_heatmap)
         self.assertEqual(worker.operations, ["operation"])
@@ -837,9 +852,19 @@ class RunListParentLookupTestCase(unittest.TestCase):
 
             run_list = treeWidgets.RunList()
             main.setCentralWidget(run_list)
+            run_list.addRuns({
+                1: {"guid": "guid-1"},
+                2: {"guid": "guid-2"},
+                })
+            main.resize(900, 400)
+            main.show()
+            qtw.QApplication.processEvents()
+            run_list.setCurrentItem(run_list._item_for_guid("guid-1"))
+            item = run_list._item_for_guid("guid-2")
 
-            run_list.prepareMenu(QtCore.QPoint(0, 0))
+            run_list.prepareMenu(run_list.visualItemRect(item).center())
 
+            self.assertEqual(run_list.currentItem().guid, "guid-2")
             self.assertEqual(captured[0], "&Plot all")
             self.assertIn("&Plot all", captured)
             self.assertIn("  - signal", captured)


### PR DESCRIPTION
## Summary

- prepare qPlot `1.5.0b3`, including the release changelog, beta install instructions, and `v1.5.0-b3` tag guidance
- restore horizontal and vertical heatmap cut windows and verify both directions against a real QCoDeS heatmap
- reject measurements with more than two independent axes before plotting and show an accessible `nD` placeholder in the run table while preserving CSV export
- make shared plot-cache refreshes atomic, keep completion synchronized, and prevent stale workers from mutating shaped arrays
- keep large heatmaps responsive with worker-thread sizing, bounded operation behavior, float64 gridding, and interruptible SQL reads
- rerun operations after axis changes, restrict merged traces to the displayed X axis, and snap to the nearest point in screen space
- lazily prioritize selected and visible previews with bounded LRU caching and retry transient failures
- harden database loading and refresh cancellation, disable conflicting controls during loads, and coalesce reentrant polling
- correct CLI path handling and exit statuses, update maintenance scripts, and clarify Windows registry and AutoPlot documentation

## Important behavior changes

- Multidimensional datasets are deliberately not plotted. Their run-table entries show `nD` with explanatory accessible text.
- Heatmap operations that would require loading more than the configured full-data limit are rejected with a clear message instead of risking an out-of-memory failure.
- “Merged” 1D parameters are traces in the same plot window and now must share the displayed X axis.
- Refresh intervals support millisecond precision over a bounded, practical range.

## Release identity

- Package version: `1.5.0b3`
- Intended GitHub tag: `v1.5.0-b3`
- The changes since beta 2 are recorded under `1.5.0-b3` in the changelog.

## Validation

- `QT_QPA_PLATFORM=offscreen .venv-mac/bin/python -m pytest -q` — 487 passed, 13 subtests passed, 75% coverage
- `.venv-mac/bin/python -m ruff check src scripts tests` — passed
- `.venv-mac/bin/python -m mypy` — passed across 61 source files
- `.venv-mac/bin/python -m compileall -q src scripts` — passed
- `.venv-mac/bin/python -m build` — beta-3 sdist and wheel built successfully
- `.venv-mac/bin/python -m twine check dist/qplot-1.5.0b3.tar.gz dist/qplot-1.5.0b3-py3-none-any.whl` — passed
- `.venv-mac/bin/qplot-cfg -version` and `qplot.__version__` — both report `1.5.0b3`
- `QT_QPA_PLATFORM=offscreen .venv-mac/bin/python -m qplot` — startup smoke test passed