### PR TITLE
Fix audited correctness, scaling, and interface bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .venv/
 .venv-mac/
+.venv-linux/
 .venv-win/
 .pytest_cache/
 .ruff_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,22 @@ py -3.11 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 ```
 
-macOS/Linux:
+macOS:
 
 ```console
 python3 -m venv .venv-mac
 source .venv-mac/bin/activate
 ```
+
+Linux:
+
+```console
+python3 -m venv .venv-linux
+source .venv-linux/bin/activate
+```
+
+Linux is useful for source-level development, but it is not currently part of
+the supported desktop GUI test matrix.
 
 Install qPlot in editable mode with the development dependencies:
 
@@ -56,10 +66,16 @@ Windows:
 .\.venv\Scripts\python.exe -m pytest
 ```
 
-macOS/Linux:
+macOS:
 
 ```console
 ./.venv-mac/bin/python -m pytest
+```
+
+Linux:
+
+```console
+./.venv-linux/bin/python -m pytest
 ```
 
 Some local checkouts keep the virtual environment next to the repository rather
@@ -71,10 +87,16 @@ Windows:
 ..\.venv\Scripts\python.exe -m pytest
 ```
 
-macOS/Linux:
+macOS:
 
 ```console
 ../.venv-mac/bin/python -m pytest
+```
+
+Linux:
+
+```console
+../.venv-linux/bin/python -m pytest
 ```
 
 ## Checks

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ QCoDeS-Plotter requires Python 3.11 or newer.
 Runtime dependencies are declared in `pyproject.toml` and are installed
 automatically when qPlot is installed.
 
+Windows and macOS are the currently supported and GUI-tested desktop
+platforms. A source installation may work on Linux, but Linux is not currently
+part of the GUI test or support matrix.
+
 ## Install
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
@@ -50,12 +54,13 @@ python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.
 If the version check reports Python 3.10 or older, install Python 3.11 or newer
 first and use that launcher instead, for example `python3.12` on macOS.
 
-Virtual environments are not portable between Windows and macOS. If the
-checkout is synced between operating systems, make sure VS Code is using the
-interpreter for the current system:
+Virtual environments are not portable between operating systems. If the
+checkout is synced between systems, make sure VS Code is using the interpreter
+created for the current system:
 
 * Windows: `.\.venv\Scripts\python.exe`
 * macOS: `./.venv-mac/bin/python`
+* Linux development: `./.venv-linux/bin/python`
 
 Check the install:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,15 +14,25 @@ py -3.11 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 ```
 
-macOS/Linux:
+macOS:
 
 ```console
 python3.11 -m venv .venv-mac
 source .venv-mac/bin/activate
 ```
 
-Your prompt should start with the virtual environment name, such as `(.venv)` on
-Windows or `(.venv-mac)` on macOS/Linux.
+Linux development:
+
+```console
+python3.11 -m venv .venv-linux
+source .venv-linux/bin/activate
+```
+
+Your prompt should start with the virtual environment name, such as `(.venv)`
+on Windows, `(.venv-mac)` on macOS, or `(.venv-linux)` on Linux. Windows and
+macOS are the currently supported and GUI-tested desktop platforms. A source
+install may work on Linux, but Linux is not currently part of the GUI test or
+support matrix.
 
 ## Creating a Virtual Environment in VS Code
 
@@ -35,10 +45,9 @@ If you prefer VS Code to terminal setup:
 5. Choose a Python 3.11 or newer base interpreter.
 6. Open a new VS Code terminal with `Terminal -> New Terminal`.
 
-The terminal prompt should start with the virtual environment name, such as
-`(.venv)` on Windows or `(.venv-mac)` on macOS/Linux. Avoid choosing an
-interpreter inside `anaconda3`, `miniconda3`, or an `envs` folder unless you
-intentionally manage this project with Conda.
+The terminal prompt should start with the virtual environment name described
+above. Avoid choosing an interpreter inside `anaconda3`, `miniconda3`, or an
+`envs` folder unless you intentionally manage this project with Conda.
 
 ## VS Code Reports a Broken Virtual Environment
 
@@ -49,13 +58,15 @@ folder.
 
 ## `git` Is Not Found During Install
 
-The GitHub install command requires Git:
+The GitHub install command requires Git. Use the explicit release tag from the
+README; for example, the current full release is:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@main
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.4.0
 ```
 
 Install Git, then open a new terminal before running the install command again.
+Do not substitute `@main` unless you intentionally want unreleased code.
 
 ## PowerShell Blocks Virtual Environment Activation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -300,7 +300,6 @@ Plot-window shortcuts:
 | `Ctrl+0` | Autoscale the plot view |
 | `Ctrl+C` / `Cmd+C` | Copy the plot image to the clipboard using the selected copy format/resolution |
 | `Ctrl+E` | Export the plot |
-| `Ctrl+Shift+O` | Show or hide the operations panel |
 | `Ctrl+Alt+R` | Show or hide the refresh toolbar |
 | `Ctrl+Alt+C` | Show or hide the coordinate toolbar |
 | `Ctrl+Alt+A` | Show or hide the axis control panel |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [

--- a/src/qplot/__main__.py
+++ b/src/qplot/__main__.py
@@ -51,7 +51,7 @@ def _database_path_from_arguments(args):
         if not positional_only and arg in QT_OPTIONS_WITH_VALUES:
             skip_next = True
             continue
-        if arg.startswith("-"):
+        if not positional_only and arg.startswith("-"):
             continue
         return arg
 

--- a/src/qplot/configuration/config.py
+++ b/src/qplot/configuration/config.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import stat
 import tempfile
@@ -16,6 +17,38 @@ THEME_CLASSES = {
     "dark": dark,
     "pyqt": pyqt,
 }
+
+
+def _strict_integer(_checker, instance):
+    return isinstance(instance, int) and not isinstance(instance, bool)
+
+
+def _finite_number(_checker, instance):
+    if isinstance(instance, bool) or not isinstance(instance, (int, float)):
+        return False
+    try:
+        return math.isfinite(instance)
+    except (OverflowError, TypeError, ValueError):
+        return False
+
+
+_STRICT_TYPE_CHECKER = (
+    jsonschema.Draft202012Validator.TYPE_CHECKER
+    .redefine("integer", _strict_integer)
+    .redefine("number", _finite_number)
+    )
+StrictConfigValidator = jsonschema.validators.extend(
+    jsonschema.Draft202012Validator,
+    type_checker=_STRICT_TYPE_CHECKER,
+    )
+
+
+def _reject_json_constant(value):
+    raise json.JSONDecodeError(
+        f"Non-standard JSON numeric constant {value!r}",
+        value,
+        0,
+        )
 
 class config:
     """
@@ -54,7 +87,7 @@ class config:
                     )
 
                 changed = self.add_missing_defaults(loaded_config)
-                jsonschema.validate(loaded_config, self.schema)
+                self.validate(loaded_config)
                 self.config = loaded_config
                 if changed:
                     self.save_config(self.default_file)
@@ -179,7 +212,7 @@ class config:
                 )
             target[keys[-1]] = value
 
-        jsonschema.validate(updated_config, self.schema)
+        self.validate(updated_config)
         previous_config = self.config
         self.config = updated_config
         try:
@@ -210,7 +243,7 @@ class config:
 
         """
         with open(path) as fp:
-            config = json.load(fp)
+            config = json.load(fp, parse_constant=_reject_json_constant)
         return config
 
 
@@ -240,7 +273,7 @@ class config:
             )
         try:
             with os.fdopen(file_descriptor, "w", encoding="utf-8") as fp:
-                json.dump(self.config, fp, indent=4)
+                json.dump(self.config, fp, indent=4, allow_nan=False)
                 fp.write("\n")
                 fp.flush()
                 os.fsync(fp.fileno())
@@ -290,11 +323,33 @@ class config:
             config[key] = subdict
         
         # Confirm reset worked
-        jsonschema.validate(config, self.schema)
+        self.validate(config)
         
         # Save reset to file
         self.config = config
         self.save_config(self.default_file)
+
+
+    def validate(self, candidate):
+        """Validate a config with strict Python integer and finite-number types."""
+
+        StrictConfigValidator(self.schema).validate(candidate)
+
+
+    def schema_for(self, key):
+        """Return the JSON-schema node for a supported dotted config key."""
+
+        keys = key.split(".")
+        if len(keys) != 2:
+            raise KeyError(
+                f"Key: {key}, not found. Please ensure you use a dot (.) seperated key"
+                )
+        try:
+            return self.schema["properties"][keys[0]]["properties"][keys[1]]
+        except KeyError as err:
+            raise KeyError(
+                f"Key: {key}, not found. Please ensure you use a dot (.) seperated key"
+                ) from err
 
 
     def backup_invalid_config(self):

--- a/src/qplot/configuration/config_schema.json
+++ b/src/qplot/configuration/config_schema.json
@@ -14,7 +14,11 @@
                 },
                 "main_frame_size": {
                     "type": "array",
-                    "items": { "type": "integer"},
+                    "items": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 16777215
+                    },
                     "minItems": 2,
                     "maxItems": 2,
                     "default": [780, 700]
@@ -162,6 +166,7 @@
                 "default_refresh_rate": {
                     "type": "number",
                     "minimum": 0,
+                    "maximum": 86400,
                     "default": 1
                 }
             },
@@ -175,6 +180,7 @@
                 "max_threads": {
                     "type": "integer",
                     "minimum": 1,
+                    "maximum": 999,
                     "default": 4
                 },
                 "max_full_heatmap_points": {

--- a/src/qplot/configuration/scripts.py
+++ b/src/qplot/configuration/scripts.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 from jsonschema import ValidationError
@@ -114,25 +115,10 @@ class sysHandle:
         #check if key is valid
         self.config.get(key)
 
-        convrt_value: object
-        if value.startswith(("[", "(")):
-            list_value = value[1:-1].strip()
-            convrt_value = (
-                []
-                if not list_value
-                else [try_as_num(item) for item in list_value.split(",")]
-                )
-        else:
-            if value.lower() == "true":
-                convrt_value = True
-            elif value.lower() == "false":
-                convrt_value = False
-            else:
-                convrt_value =  try_as_num(value)
-        
         try:
+            convrt_value = _config_value(value, self.config.schema_for(key))
             self.config.update(key, convrt_value)
-        except ValidationError as error:
+        except (TypeError, ValueError, json.JSONDecodeError, ValidationError) as error:
             err_key = f"Value: {value}, is invalid."
             err_key += str(error)
             raise ValidationError(err_key) from error
@@ -208,6 +194,46 @@ def try_as_num(item):
     except ValueError: #if cannot conver to int or float
         item = str(item)
     return item
+
+
+def _config_value(value, schema):
+    """Parse a command-line value according to its target config schema."""
+
+    value_type = schema.get("type")
+    stripped = value.strip()
+
+    if value_type == "string":
+        return value
+    if value_type == "boolean":
+        if stripped.lower() == "true":
+            return True
+        if stripped.lower() == "false":
+            return False
+        raise ValueError("expected true or false")
+    if value_type == "integer":
+        return int(stripped, 10)
+    if value_type == "number":
+        return float(stripped)
+    if value_type == "array":
+        if not (
+                (stripped.startswith("[") and stripped.endswith("]"))
+                or (stripped.startswith("(") and stripped.endswith(")"))
+                ):
+            raise ValueError("expected a bracketed list")
+        json_list = f"[{stripped[1:-1]}]"
+        try:
+            return json.loads(json_list)
+        except json.JSONDecodeError:
+            inner = stripped[1:-1].strip()
+            if not inner:
+                return []
+            item_schema = schema.get("items", {})
+            return [
+                _config_value(item.strip(), item_schema)
+                for item in inner.split(",")
+                ]
+
+    return try_as_num(value)
 
 
 def scripts():

--- a/src/qplot/configuration/themes/_base.py
+++ b/src/qplot/configuration/themes/_base.py
@@ -269,14 +269,6 @@ _STYLESHEET_TEMPLATE = Template(
         width: 14px;
         height: 14px;
     }
-    QCheckBox::indicator:checked {
-        border: 1px solid $accent;
-        background-color: $accent;
-    }
-    QCheckBox::indicator:unchecked {
-        border: 1px solid $border_strong;
-        background-color: transparent;
-    }
     QRadioButton {
         color: $text;
         background-color: $window_bg;

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -823,14 +823,17 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                 if self._is_cancelled():
                     return
 
-                batch = self._next_priority_batch(shape_done, batch_size=1)
+                batch = self._next_priority_batch(
+                    shape_done,
+                    batch_size=self.batch_size,
+                    )
                 if not batch:
                     break
 
                 for shapes in iter_run_shape_batches_via_sql(
                         self.database_path,
                         batch,
-                        batch_size=1,
+                        batch_size=self.batch_size,
                         cancelled_callback=self._is_cancelled,
                         ):
                     if self._is_cancelled():

--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -151,7 +151,11 @@ def iter_run_shape_batches_via_sql(
             rows = {
                 run_id: metadata
                 for run_id, metadata in (rows or {}).items()
-                if metadata.get("setpoint_shape") or metadata.get("point_shape")
+                if (
+                    metadata.get("setpoint_shape")
+                    or metadata.get("point_shape")
+                    or metadata.get("setpoint_count") is not None
+                    )
                 }
             if rows:
                 yield rows
@@ -320,16 +324,18 @@ def _add_run_basic_fields(metadata):
     metadata["sweep_parameters"] = sweep_parameters
     metadata["point_shape"] = _point_shape(run_description, measure_parameters)
     metadata["setpoint_shape"] = metadata["point_shape"]
+    shape_source = "planned" if metadata["setpoint_shape"] else None
+    metadata["setpoint_shape_source"] = shape_source
     expected_results = _expected_results_from_shapes(
         run_description,
         measure_parameters,
         )
-    metadata["expected_results"] = (
-        expected_results
-        if expected_results is not None
-        else _shape_size(metadata["point_shape"])
+    metadata["expected_results"] = expected_results
+    metadata["expected_results_source"] = (
+        "planned" if expected_results is not None else None
         )
     metadata["setpoint_count"] = _shape_size(metadata["setpoint_shape"])
+    metadata["setpoint_count_source"] = shape_source
 
 
 def _add_run_detail_fields(
@@ -345,35 +351,23 @@ def _add_run_detail_fields(
     sweep_parameters = metadata.get("sweep_parameters") or []
 
     metadata["result_count"] = _result_count(cursor, metadata.get("result_table_name"))
-    expected_results = metadata.get("expected_results")
+    observed_setpoints = None
     if infer_missing_shapes and not metadata["point_shape"]:
-        setpoint_shape = _setpoint_shape_from_result_table(
-            cursor,
-            metadata.get("result_table_name"),
-            sweep_parameters,
-            )
-        metadata["setpoint_shape"] = setpoint_shape
-        metadata["point_shape"] = _point_shape_from_setpoint_shape(
-            setpoint_shape,
-            measure_parameters,
-            metadata["result_count"],
-            )
-        expected_results = _shape_size(metadata["point_shape"])
-    metadata["expected_results"] = (
-        expected_results
-        if expected_results is not None
-        else _shape_size(metadata["point_shape"])
-        )
-    metadata["setpoint_count"] = _shape_size(metadata["setpoint_shape"])
+        observed_setpoints = _add_observed_shape_fields(cursor, metadata)
+    _add_completed_observed_result_count(metadata)
     if (
             include_read_setpoint_count
             and _is_keyboard_interrupt(metadata.get("measurement_exception"))
             ):
-        metadata["read_setpoint_count"] = _read_setpoint_count(
-            cursor,
-            metadata.get("result_table_name"),
-            sweep_parameters,
-            )
+        if observed_setpoints is None:
+            observed_setpoints = _run_setpoint_observation(
+                cursor,
+                metadata.get("result_table_name"),
+                _json_dict(metadata.get("run_description")),
+                measure_parameters,
+                sweep_parameters,
+                )
+        metadata["read_setpoint_count"] = observed_setpoints["count"]
     if include_storage_bytes:
         table_name = metadata.get("result_table_name")
         if storage_bytes_by_table is not None:
@@ -395,6 +389,46 @@ def _add_run_detail_fields(
         metadata["storage_bytes_estimated"] = True
 
 
+def _add_observed_shape_fields(cursor, metadata):
+    measure_parameters = metadata.get("measure_parameters") or []
+    sweep_parameters = metadata.get("sweep_parameters") or []
+    observed_setpoints = _run_setpoint_observation(
+        cursor,
+        metadata.get("result_table_name"),
+        _json_dict(metadata.get("run_description")),
+        measure_parameters,
+        sweep_parameters,
+        )
+    setpoint_shape = observed_setpoints["shape"]
+    metadata["setpoint_shape"] = setpoint_shape
+    metadata["point_shape"] = _point_shape_from_setpoint_shape(
+        setpoint_shape,
+        measure_parameters,
+        metadata.get("result_count"),
+        )
+    metadata["setpoint_shape_source"] = (
+        "observed" if setpoint_shape else None
+        )
+    metadata["setpoint_count"] = observed_setpoints["count"]
+    metadata["setpoint_count_source"] = (
+        "observed" if observed_setpoints["count"] is not None else None
+        )
+    metadata["expected_results"] = None
+    metadata["expected_results_source"] = None
+    _add_completed_observed_result_count(metadata)
+    return observed_setpoints
+
+
+def _add_completed_observed_result_count(metadata):
+    if (
+            metadata.get("expected_results") is None
+            and _run_is_complete(metadata)
+            and metadata.get("result_count") is not None
+            ):
+        metadata["expected_results"] = metadata["result_count"]
+        metadata["expected_results_source"] = "observed"
+
+
 def _json_dict(value):
     if not value:
         return {}
@@ -408,13 +442,7 @@ def _json_dict(value):
 
 
 def _parameter_roles(run_description, parameter_text):
-    dependencies = (
-        run_description
-        .get("interdependencies_", {})
-        .get("dependencies", {})
-        )
-    if not dependencies:
-        dependencies = _legacy_dependencies(run_description)
+    dependencies = _parameter_dependencies(run_description)
 
     measure_parameters = list(dependencies.keys())
     sweep_parameters = []
@@ -423,18 +451,35 @@ def _parameter_roles(run_description, parameter_text):
             if name not in sweep_parameters:
                 sweep_parameters.append(name)
 
-    if not measure_parameters:
-        parameters = [
-            parameter.strip()
-            for parameter in (parameter_text or "").split(",")
-            if parameter.strip()
-            ]
-        measure_parameters = [
-            parameter for parameter in parameters
-            if parameter not in sweep_parameters
-            ]
+    parameters = [
+        parameter.strip()
+        for parameter in (parameter_text or "").split(",")
+        if parameter.strip()
+        ]
+    for parameter in parameters:
+        if parameter not in sweep_parameters and parameter not in measure_parameters:
+            measure_parameters.append(parameter)
 
     return measure_parameters, sweep_parameters
+
+
+def _parameter_dependencies(run_description):
+    dependencies = (
+        run_description
+        .get("interdependencies_", {})
+        .get("dependencies", {})
+        )
+    if not isinstance(dependencies, dict) or not dependencies:
+        dependencies = _legacy_dependencies(run_description)
+
+    if not isinstance(dependencies, dict):
+        return {}
+
+    return {
+        parameter: list(setpoints)
+        for parameter, setpoints in dependencies.items()
+        if isinstance(setpoints, (list, tuple)) and setpoints
+        }
 
 
 def _legacy_dependencies(run_description):
@@ -534,6 +579,10 @@ def _is_keyboard_interrupt(value):
     return bool(value and "KeyboardInterrupt" in str(value))
 
 
+def _run_is_complete(metadata):
+    return bool(metadata.get("completed_timestamp") or metadata.get("is_completed"))
+
+
 def _point_shape_from_result_table(
     cursor,
     table_name,
@@ -572,33 +621,17 @@ def _setpoint_shape_from_result_table(cursor, table_name, sweep_parameters):
         return None
 
     quoted_table_name = _sqlite_identifier(table_name)
-    try:
-        cursor.execute(f"PRAGMA table_info({quoted_table_name})")
-        columns = {row[1] for row in cursor.fetchall()}
-    except Exception:
-        return None
-
+    columns = _result_table_columns(cursor, quoted_table_name)
     if not columns or any(parameter not in columns for parameter in sweep_parameters):
         return None
 
-    shape = []
-    for parameter in sweep_parameters:
-        quoted_parameter = _sqlite_identifier(parameter)
-        try:
-            cursor.execute(f"""
-              SELECT COUNT(DISTINCT {quoted_parameter})
-              FROM {quoted_table_name}
-              WHERE {quoted_parameter} IS NOT NULL
-            """)
-            count = int(cursor.fetchone()[0])
-        except Exception:
-            return None
-
-        if count <= 0:
-            return None
-        shape.append(count)
-
-    return shape
+    observation = _setpoint_observation(
+        cursor,
+        quoted_table_name,
+        sweep_parameters,
+        columns,
+        )
+    return observation["shape"]
 
 
 def _read_setpoint_count(cursor, table_name, sweep_parameters):
@@ -606,28 +639,173 @@ def _read_setpoint_count(cursor, table_name, sweep_parameters):
         return None
 
     quoted_table_name = _sqlite_identifier(table_name)
-    try:
-        cursor.execute(f"PRAGMA table_info({quoted_table_name})")
-        columns = {row[1] for row in cursor.fetchall()}
-        if any(parameter not in columns for parameter in sweep_parameters):
-            return None
+    columns = _result_table_columns(cursor, quoted_table_name)
+    if not columns or any(parameter not in columns for parameter in sweep_parameters):
+        return None
 
-        quoted_columns = ", ".join(
-            _sqlite_identifier(parameter)
-            for parameter in sweep_parameters
+    return _distinct_setpoint_count(
+        cursor,
+        quoted_table_name,
+        sweep_parameters,
+        )
+
+
+def _run_setpoint_observation(
+        cursor,
+        table_name,
+        run_description,
+        measure_parameters,
+        sweep_parameters,
+        ):
+    """Return a safe global shape and the largest per-dependent point count."""
+    empty = {"shape": None, "count": None}
+    if not table_name:
+        return empty
+
+    quoted_table_name = _sqlite_identifier(table_name)
+    columns = _result_table_columns(cursor, quoted_table_name)
+    if not columns:
+        return empty
+
+    dependencies = _parameter_dependencies(run_description)
+    observations = []
+    if dependencies:
+        for parameter in measure_parameters:
+            setpoints = dependencies.get(parameter)
+            if (
+                    not setpoints
+                    or parameter not in columns
+                    or any(setpoint not in columns for setpoint in setpoints)
+                    ):
+                continue
+            observation = _setpoint_observation(
+                cursor,
+                quoted_table_name,
+                setpoints,
+                columns,
+                dependent_parameter=parameter,
+                )
+            if observation["count"] is not None:
+                observations.append((tuple(setpoints), observation))
+    elif sweep_parameters and all(parameter in columns for parameter in sweep_parameters):
+        observation = _setpoint_observation(
+            cursor,
+            quoted_table_name,
+            sweep_parameters,
+            columns,
             )
-        not_null = " AND ".join(
-            f"{_sqlite_identifier(parameter)} IS NOT NULL"
-            for parameter in sweep_parameters
+        if observation["count"] is not None:
+            observations.append((tuple(sweep_parameters), observation))
+
+    if not observations:
+        return empty
+
+    observed_count = max(observation["count"] for _, observation in observations)
+    dependency_sets = {setpoints for setpoints, _ in observations}
+    observed_shapes = [observation["shape"] for _, observation in observations]
+    shared_shape = (
+        observed_shapes[0]
+        if (
+            len(dependency_sets) == 1
+            and observed_shapes[0] is not None
+            and all(shape == observed_shapes[0] for shape in observed_shapes)
             )
+        else None
+        )
+    return {"shape": shared_shape, "count": observed_count}
+
+
+def _setpoint_observation(
+        cursor,
+        quoted_table_name,
+        sweep_parameters,
+        columns,
+        dependent_parameter=None,
+        ):
+    empty = {"shape": None, "count": None}
+    required_columns = list(sweep_parameters)
+    if dependent_parameter is not None:
+        required_columns.append(dependent_parameter)
+    if not required_columns or any(column not in columns for column in required_columns):
+        return empty
+
+    observed_count = _distinct_setpoint_count(
+        cursor,
+        quoted_table_name,
+        sweep_parameters,
+        dependent_parameter=dependent_parameter,
+        )
+    if not observed_count:
+        return empty
+
+    conditions = _setpoint_not_null_conditions(
+        sweep_parameters,
+        dependent_parameter=dependent_parameter,
+        )
+    distinct_counts = ", ".join(
+        f"COUNT(DISTINCT {_sqlite_identifier(parameter)})"
+        for parameter in sweep_parameters
+        )
+    try:
         cursor.execute(f"""
-          SELECT DISTINCT {quoted_columns}
+          SELECT {distinct_counts}
           FROM {quoted_table_name}
-          WHERE {not_null}
+          WHERE {conditions}
         """)
-        return len(cursor.fetchall())
+        shape = [int(count) for count in cursor.fetchone()]
+    except Exception:
+        return {"shape": None, "count": observed_count}
+
+    if any(count <= 0 for count in shape) or _shape_size(shape) != observed_count:
+        return {"shape": None, "count": observed_count}
+    return {"shape": shape, "count": observed_count}
+
+
+def _distinct_setpoint_count(
+        cursor,
+        quoted_table_name,
+        sweep_parameters,
+        dependent_parameter=None,
+        ):
+    quoted_columns = ", ".join(
+        _sqlite_identifier(parameter)
+        for parameter in sweep_parameters
+        )
+    conditions = _setpoint_not_null_conditions(
+        sweep_parameters,
+        dependent_parameter=dependent_parameter,
+        )
+    try:
+        cursor.execute(f"""
+          SELECT COUNT(*)
+          FROM (
+              SELECT DISTINCT {quoted_columns}
+              FROM {quoted_table_name}
+              WHERE {conditions}
+          ) AS qplot_distinct_setpoints
+        """)
+        count = int(cursor.fetchone()[0])
     except Exception:
         return None
+    return count if count > 0 else None
+
+
+def _setpoint_not_null_conditions(sweep_parameters, dependent_parameter=None):
+    parameters = list(sweep_parameters)
+    if dependent_parameter is not None:
+        parameters.append(dependent_parameter)
+    return " AND ".join(
+        f"{_sqlite_identifier(parameter)} IS NOT NULL"
+        for parameter in parameters
+        )
+
+
+def _result_table_columns(cursor, quoted_table_name):
+    try:
+        cursor.execute(f"PRAGMA table_info({quoted_table_name})")
+        return {row[1] for row in cursor.fetchall()}
+    except Exception:
+        return set()
 
 
 def _result_count(cursor, table_name):
@@ -814,14 +992,40 @@ def get_run_status(
         for index, column in enumerate(optional_columns, start=5):
             status[column] = value[index]
 
+        shape_metadata = {
+            "completed_timestamp": value[0],
+            "is_completed": value[1],
+            "result_table_name": value[2],
+            "run_description": value[3],
+            "parameters": value[4],
+            "result_count": status["result_count"],
+            }
+        _add_run_basic_fields(shape_metadata)
+        observed_setpoints = None
+        if not shape_metadata["point_shape"]:
+            observed_setpoints = _add_observed_shape_fields(cursor, shape_metadata)
+        _add_completed_observed_result_count(shape_metadata)
+        for field in (
+                "point_shape",
+                "setpoint_shape",
+                "setpoint_shape_source",
+                "setpoint_count",
+                "setpoint_count_source",
+                "expected_results",
+                "expected_results_source",
+                ):
+            status[field] = shape_metadata.get(field)
+
         if _is_keyboard_interrupt(status.get("measurement_exception")):
-            run_description = _json_dict(value[3])
-            _, sweep_parameters = _parameter_roles(run_description, value[4])
-            status["read_setpoint_count"] = _read_setpoint_count(
-                cursor,
-                value[2],
-                sweep_parameters,
-                )
+            if observed_setpoints is None:
+                observed_setpoints = _run_setpoint_observation(
+                    cursor,
+                    value[2],
+                    _json_dict(value[3]),
+                    shape_metadata["measure_parameters"],
+                    shape_metadata["sweep_parameters"],
+                    )
+            status["read_setpoint_count"] = observed_setpoints["count"]
 
         return status
     finally:

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -1175,6 +1175,7 @@ class loader(QtCore.QRunnable):
         axis_param = {}
         axis_dimension = {}
         valid = {}
+        shaped_axes_are_rectilinear = True
         depvarData = np.asarray(depvarData, dtype=float)
         
         # Find correct data for each axis
@@ -1184,12 +1185,31 @@ class loader(QtCore.QRunnable):
 
             param_data = np.asarray(data[name], dtype=float)
             dimension = self._shaped_axis_dimension(name, param_data, depvarData)
+            shaped_axes_are_rectilinear &= self._shaped_axis_is_rectilinear(
+                param_data,
+                dimension,
+                )
             param_data = self._shaped_axis_values(param_data, dimension)
 
             valid[axis] = np.isfinite(param_data)
             axis_data[axis] = param_data[valid[axis]]
             axis_param[axis] = param
             axis_dimension[axis] = dimension
+
+        # QCoDeS shaped data can still contain a serpentine (snake) scan.  In
+        # that case alternate rows of the fast coordinate run in the opposite
+        # direction and the raw result array is not a rectilinear image.  Map
+        # values by their recorded coordinates instead of silently mirroring
+        # those rows.
+        if (
+                not shaped_axes_are_rectilinear
+                or axis_dimension["x"] == axis_dimension["y"]
+                ):
+            valid_rows = np.isfinite(depvarData)
+            for axis in ("x", "y"):
+                name = self.axes_dict[axis]
+                valid_rows &= np.isfinite(np.asarray(data[name], dtype=float))
+            return self.for_unshaped_2d(data, valid_rows, depvarData)
 
         dataGrid = self._shaped_data_grid(
             data,
@@ -1240,6 +1260,22 @@ class loader(QtCore.QRunnable):
             return np.inf
 
         return float(np.nanmax(np.abs(param_data[valid] - expected[valid])))
+
+
+    def _shaped_axis_is_rectilinear(self, param_data, dimension):
+        values = self._shaped_axis_values(param_data, dimension)
+        shape = [1] * param_data.ndim
+        shape[dimension] = values.size
+        expected = np.broadcast_to(values.reshape(shape), param_data.shape)
+        valid = np.isfinite(param_data) & np.isfinite(expected)
+        if not np.any(valid):
+            return True
+        return bool(np.all(np.isclose(
+            param_data[valid],
+            expected[valid],
+            rtol=1e-10,
+            atol=1e-12,
+            )))
 
 
     def _shaped_data_grid(self, data, depvarData, axis_dimension, valid):

--- a/src/qplot/windows/_commands.py
+++ b/src/qplot/windows/_commands.py
@@ -258,8 +258,6 @@ COMMANDS: dict[str, CommandSpec] = {
         "plot.toggle_operations",
         "View Operations",
         "Show or hide the operations panel",
-        "Ctrl+Shift+O",
-        help_section="Plot Windows",
     ),
     "toolbar.refresh": CommandSpec(
         "toolbar.refresh",

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -873,7 +873,7 @@ class DatabaseActionsMixin:
         expensive_generation = self._database_expensive_detail_generation
         self._database_expensive_detail_active = True
 
-        worker = DatabaseDetailWorker(generation, abspath, run_ids, batch_size=10)
+        worker = DatabaseDetailWorker(generation, abspath, run_ids, batch_size=100)
         self._database_detail_worker = worker
         priority_run_ids = self._database_detail_priority_run_ids()
         worker.prioritize_run_ids(priority_run_ids)
@@ -891,7 +891,7 @@ class DatabaseActionsMixin:
             expensive_generation,
             abspath,
             run_ids,
-            batch_size=10,
+            batch_size=100,
             )
         self._database_expensive_detail_worker = expensive_worker
         expensive_worker.prioritize_run_ids(priority_run_ids)

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -267,11 +267,19 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         self.lineScroll = qtw.QScrollArea()
         self.lineScroll.setWidgetResizable(True)
         self.lineScroll.setMinimumSize(1, 1)
-        self.lineScroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.lineScroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.lineScroll.setSizePolicy(
+            qtw.QSizePolicy.Policy.Expanding,
+            qtw.QSizePolicy.Policy.Expanding,
+            )
         self.axes_dock.addWidget(self.lineScroll)
         
         # QScrollArea can only take 1 widget. That widget holds the layout.
         self.scrollWidget = qtw.QWidget()
+        self.scrollWidget.setSizePolicy(
+            qtw.QSizePolicy.Policy.Ignored,
+            qtw.QSizePolicy.Policy.Preferred,
+            )
         self.lineScroll.setWidget(self.scrollWidget)
         
         self.box_layout = qtw.QVBoxLayout()
@@ -301,27 +309,15 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
         
     def _resize_scrollArea(self) -> None:
         """
-        Updates the width of the dock widget to match the width of the largest
-        row in the Scroll area so all data is visible
+        Refresh the scroll area's geometry without preventing dock resizing.
 
-        Note. Prevents user from making dock widget any smaller.
-        Adding self.lineScroll.setMinimumWidth(1) should fix this but my attempts
-        have failed.
+        Trace controls provide a useful preferred size, but the containing dock
+        must remain shrinkable on smaller plot windows. A horizontal scrollbar
+        exposes any controls that cannot fit at the user's chosen width.
         """
         self.scrollWidget.adjustSize()
-        # Get scrollArea width
-        vertical_scrollbar = self.lineScroll.verticalScrollBar()
-        scrollbar_width = (
-            vertical_scrollbar.sizeHint().width()
-            if vertical_scrollbar is not None
-            else 0
-            )
-        scrollWidth = (
-            self.scrollWidget.sizeHint().width() +
-            2 *  self.lineScroll.frameWidth() +
-            scrollbar_width
-            )
-        self.lineScroll.setMinimumWidth(scrollWidth)
+        self.lineScroll.setMinimumWidth(1)
+        self.lineScroll.updateGeometry()
         
         
     def add_option_box(self, options: list[str] | None = None) -> None:

--- a/src/qplot/windows/_plot2d_colorbar_dialog.py
+++ b/src/qplot/windows/_plot2d_colorbar_dialog.py
@@ -31,8 +31,11 @@ if TYPE_CHECKING:
         colorbar_include_matplotlib_check: qtw.QCheckBox
         colorbar_manual_radio: qtw.QRadioButton
         colorbar_matplotlib_subtype_checks: dict[str, qtw.QCheckBox]
+        colorbar_max_label: qtw.QLabel
         colorbar_max_text: qtw.QLineEdit
+        colorbar_min_label: qtw.QLabel
         colorbar_min_text: qtw.QLineEdit
+        colorbar_scale_action: QtGui.QAction
         colorbar_scale_controls: qtw.QWidget
         colorbar_scale_dialog: qtw.QDialog
         relevel_refresh: qtw.QCheckBox
@@ -107,6 +110,8 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
 
         self.colorbar_manual_radio = qtw.QRadioButton("Manual")
         self.colorbar_auto_radio = qtw.QRadioButton("Auto")
+        self.colorbar_min_label = qtw.QLabel("Minimum")
+        self.colorbar_max_label = qtw.QLabel("Maximum")
         self.colorbar_min_text = qtw.QLineEdit()
         self.colorbar_max_text = qtw.QLineEdit()
         self.colorbar_colormap_table = qtw.QTableWidget()
@@ -125,6 +130,10 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
         validator = QtGui.QDoubleValidator(cast(QtCore.QObject, self))
         self.colorbar_min_text.setValidator(validator)
         self.colorbar_max_text.setValidator(validator)
+        self.colorbar_min_label.setBuddy(self.colorbar_min_text)
+        self.colorbar_max_label.setBuddy(self.colorbar_max_text)
+        self.colorbar_min_text.setAccessibleName("Color scale minimum")
+        self.colorbar_max_text.setAccessibleName("Color scale maximum")
         for line_edit in (self.colorbar_min_text, self.colorbar_max_text):
             line_edit.setMinimumWidth(80)
 
@@ -139,8 +148,10 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
         range_layout.setHorizontalSpacing(4)
         range_layout.setVerticalSpacing(4)
         range_layout.addWidget(self.colorbar_manual_radio, 0, 0)
-        range_layout.addWidget(self.colorbar_min_text, 0, 1)
-        range_layout.addWidget(self.colorbar_max_text, 0, 2)
+        range_layout.addWidget(self.colorbar_min_label, 0, 1)
+        range_layout.addWidget(self.colorbar_min_text, 0, 2)
+        range_layout.addWidget(self.colorbar_max_label, 0, 3)
+        range_layout.addWidget(self.colorbar_max_text, 0, 4)
         range_layout.addWidget(self.colorbar_auto_radio, 1, 0)
 
         filter_controls = self._init_colorbar_filter_controls()
@@ -151,6 +162,13 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
         layout.addWidget(range_controls)
 
         self.colorbar_scale_controls = controls
+
+        menu = getattr(self, "vbMenu", None)
+        if menu is not None:
+            self.colorbar_scale_action = QtGui.QAction("&Color Scale...", cast(QtCore.QObject, self))
+            self.colorbar_scale_action.triggered.connect(self.open_colorbar_scale_dialog)
+            before = getattr(self, "autoscaleSep", None)
+            menu.insertAction(before, self.colorbar_scale_action)
 
         self.colorbar_colormap_table.itemSelectionChanged.connect(
             self._colorbar_colormap_selection_changed

--- a/src/qplot/windows/_plot2d_sweeps.py
+++ b/src/qplot/windows/_plot2d_sweeps.py
@@ -1,6 +1,7 @@
 from itertools import count
 from typing import TYPE_CHECKING, Any, Literal
 
+import numpy as np
 import numpy.typing as npt
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
@@ -83,12 +84,19 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
             fixed_var = axes["x"]
             sweep_var = axes["y"]
             fixed_index = z_index[0]
+            fixed_axis: _SweepAxis = "x"
         elif side == "h":
             fixed_var = axes["y"]
             sweep_var = axes["x"]
             fixed_index = z_index[1]
+            fixed_axis = "y"
         else:
             raise KeyError(f"Invalid sweep side, {side=}, must be 'v' or 'h'.")
+
+        fixed_value = float(fixed_index)
+        geometry_getter = getattr(self, "_heatmap_geometry", None)
+        if callable(geometry_getter) and geometry_getter() is not None:
+            fixed_value = self.sweep_pixel_centre(fixed_axis, fixed_index)
             
         sweep_id = self._reserve_sweep_id()
 
@@ -100,19 +108,19 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
                 sweep_id,
                 sweep_var,
                 fixed_var,
-                fixed_index,
+                fixed_value,
                 self.param
                 )
             )
         
 
-    @QtCore.pyqtSlot(int, str, str, int, object)
+    @QtCore.pyqtSlot(int, str, str, float, object)
     def update_sweep_line(
             self,
             sweep_id: int,
             sweep_param: str,
             fixed_param: str,
-            fixed_index: int,
+            fixed_value: float,
             line_col: Any,
             ) -> None:
         """
@@ -129,8 +137,8 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
             that a cursor can be plotted
         fixed_param : str
             The static parameter and the parameter to place the line on.
-        fixed_index : int
-            index of on heatmap to place the line.
+        fixed_value : float
+            Physical fixed-axis coordinate at which to place the line.
         line_col : QPen
             The plen color of the line.
 
@@ -148,11 +156,24 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         if axis_name not in ("x", "y"):
             return
         axis: _SweepAxis = "x" if axis_name == "x" else "y"
-    
+
+        fixed_index = self.sweep_index_at_value(axis, fixed_value, clamp=False)
+        if fixed_index is None:
+            line = self.sweep_lines.get(sweep_id)
+            if line is not None:
+                line.sweep_index = None
+                set_visible = getattr(line, "setVisible", None)
+                if callable(set_visible):
+                    set_visible(False)
+            return
+
         at_value = self.sweep_pixel_centre(axis, fixed_index)
     
         if self.sweep_lines.get(sweep_id, None) is not None:
             line = self.sweep_lines[sweep_id]
+            set_visible = getattr(line, "setVisible", None)
+            if callable(set_visible):
+                set_visible(True)
             
             # Update line data
             line.angle = (90 if axis == "x" else 0)
@@ -287,7 +308,13 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         return axis_geometry.centre(index)
 
 
-    def sweep_index_at_value(self, axis: _SweepAxis, value: float) -> int | None:
+    def sweep_index_at_value(
+            self,
+            axis: _SweepAxis,
+            value: float,
+            *,
+            clamp: bool = True,
+            ) -> int | None:
         """
         Return the heatmap pixel index containing a plot coordinate.
 
@@ -296,7 +323,7 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         if geometry is None:
             return None
         axis_geometry = geometry.x if axis == "x" else geometry.y
-        return axis_geometry.index_at(value, clamp=True)
+        return axis_geometry.index_at(value, clamp=clamp)
 
 
     def line_sweep_axis(self, line: Any) -> _SweepAxis:
@@ -493,7 +520,7 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
         self.active_sweep_line_id = line.sweep_id
 
         if emit:
-            self.sweep_moved.emit(line.sweep_id, index)
+            self.sweep_moved.emit(line.sweep_id, float(line.value()))
 
 
     def _snap_sweep_lines_to_pixel_centres(self) -> None:
@@ -501,14 +528,27 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
             return
         for line in self.__dict__.get("sweep_lines", {}).values():
             axis = self.line_sweep_axis(line)
-            previous_index = getattr(line, "sweep_index", None)
-            index = self.sweep_index_at_value(axis, line.value())
-            if index is not None:
-                self.set_sweep_line_index(
-                    line,
-                    index,
-                    emit=previous_index is not None and index != previous_index,
-                    )
+            previous_value = float(line.value())
+            index = self.sweep_index_at_value(
+                axis,
+                previous_value,
+                clamp=False,
+                )
+            set_visible = getattr(line, "setVisible", None)
+            if index is None:
+                line.sweep_index = None
+                if callable(set_visible):
+                    set_visible(False)
+                continue
+
+            if callable(set_visible):
+                set_visible(True)
+            snapped_value = self.sweep_pixel_centre(axis, index)
+            self.set_sweep_line_index(
+                line,
+                index,
+                emit=not np.isclose(snapped_value, previous_value),
+                )
 
 
     def move_sweep_with_arrow_key(self, key: QtCore.Qt.Key) -> None:

--- a/src/qplot/windows/_plot2d_sweeps.py
+++ b/src/qplot/windows/_plot2d_sweeps.py
@@ -583,10 +583,15 @@ class Plot2DSweepMixin(_Plot2DSweepBase):
             return
 
         requested_delta = dragged_index - previous_index
-        group_lines = [
-            line for line in self.sweep_lines.values()
-            if self.line_sweep_axis(line) == axis
-            ]
+        try:
+            group_lines = [
+                line for line in self.sweep_lines.values()
+                if self.line_sweep_axis(line) == axis
+                ]
+        except (AttributeError, RuntimeError):
+            # A drag can arrive while a plot is still being initialised or torn
+            # down.  Treat the active cursor as a one-line group in that case.
+            group_lines = []
         if dragged_line not in group_lines:
             group_lines.append(dragged_line)
 

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -1,4 +1,4 @@
-from math import isfinite, log10
+from math import floor, isfinite, log10
 from os import path
 from typing import TYPE_CHECKING
 
@@ -806,7 +806,7 @@ class plotWidget(
         
         self.axes_dock.addWidget(sep)
         
-        if self.__class__.__name__ == "plot2d":
+        if getattr(self, "operation_kind", None) == "plot2d":
             self.axes_dock.content_layout.addStretch()
         
     
@@ -930,14 +930,19 @@ class plotWidget(
             return "-inf" if num < 0 else "inf"
 
         try: # Get number of leading/following zeros
-            log = int(log10(abs(num)))
+            exponent = floor(log10(abs(num)))
         except ValueError:
             return f"{0:.{sf}f}"
-        
-        if log >= sf or log < 0:
-            return f"{num:.{sf}e}"
-        else:
-            return f"{num:.{sf - log}f}"
+
+        precision = max(sf - 1, 0)
+        if exponent >= sf or exponent < 0:
+            return f"{num:.{precision}e}"
+
+        formatted = f"{num:.{max(sf - exponent - 1, 0)}f}"
+        rounded_exponent = floor(log10(abs(float(formatted))))
+        if rounded_exponent != exponent:
+            return f"{num:.{precision}e}"
+        return formatted
 
 
     def _set_cursor_index_label(self, text: str) -> None:

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -269,8 +269,8 @@ class plotWidget(
             self.setCentralWidget(w)
         
         #start refresh cycle if live
-        if self.ds.running: 
-            self.monitor.start(int(self.spinBox.value() * 1000))
+        if self.ds.running:
+            self.monitorIntervalChanged(self.spinBox.value())
 
 
     def _install_preview_drop_target(self):
@@ -1308,7 +1308,7 @@ class plotWidget(
         """
         self.monitor.stop()
         if interval > 0:
-            self.monitor.start(int(interval * 1000)) #convert to seconds
+            self.monitor.start(max(1, round(interval * 1000)))
             
             
     def add_or_remove_operations(self, key : str, func : callable = None):

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -183,13 +183,12 @@ class PlotActionsMixin:
                 show=show,
                 **kargs,
             )
-            if win.__class__.__name__ == "sweeper":
-                window_type = "sweeper"
-            elif isinstance(win, plot1d):
-                window_type = "plot1d"
-            elif isinstance(win, plot2d):
-                window_type = "plot2d"
-            else:
+            window_type = getattr(win, "operation_kind", None)
+            if window_type is None:
+                legacy_window_type = win.__class__.__name__
+                if legacy_window_type in {"plot1d", "plot2d", "sweeper"}:
+                    window_type = legacy_window_type
+            if window_type not in {"plot1d", "plot2d", "sweeper"}:
                 raise TypeError(f"Unknown window of type: {win.__class__.__name__}")
         except Exception:
             if loaded_for_construction:
@@ -254,7 +253,8 @@ class PlotActionsMixin:
             return
 
         for item in list(self.windows):
-            if item.__class__.__name__ != "sweeper":
+            window_type = getattr(item, "operation_kind", item.__class__.__name__)
+            if window_type != "sweeper":
                 continue
 
             try:
@@ -1012,7 +1012,10 @@ class PlotActionsMixin:
                 compatible = _subplot_axis_order(
                     win.axis_options,
                     item.axis_options,
-                    source_is_cut=item.__class__.__name__ == "sweeper",
+                    source_is_cut=(
+                        getattr(item, "operation_kind", item.__class__.__name__)
+                        == "sweeper"
+                        ),
                     )
                 if compatible is not None and not _plot_has_trace_window(win, item):
                     wins.append(item)

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -86,8 +86,15 @@ class PlotRefreshMixin(_PlotRefreshBase):
     def _sync_dataset_completion(self, dataset: Any) -> None:
         """Schedule a final worker read so completion and data commit together."""
 
-        if getattr(dataset, "running", False):
-            self.load_data()
+        if not getattr(dataset, "running", False):
+            return
+
+        worker = getattr(self, "worker", None)
+        if worker is not None and getattr(worker, "running", False):
+            self._refresh_pending = True
+            return
+
+        self.load_data()
 
     def load_data(
             self,

--- a/src/qplot/windows/_run_controls.py
+++ b/src/qplot/windows/_run_controls.py
@@ -425,7 +425,7 @@ class RunControlsMixin:
         """
         self.monitor.stop()
         if interval > 0:
-            self.monitor.start(int(interval * 1000))
+            self.monitor.start(max(1, round(interval * 1000)))
 
     def _save_refresh_interval(self, interval):
         """

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -22,7 +22,7 @@ class sweeper(plotWidget):
     their counterpart.
     """
     operation_kind = "sweeper"
-    sweep_moved = QtCore.pyqtSignal([int, str, str, int, object])
+    sweep_moved = QtCore.pyqtSignal([int, str, str, float, object])
     merge_compatibility_changed = QtCore.pyqtSignal()
     remove_sweep = QtCore.pyqtSignal([int])
     
@@ -31,14 +31,15 @@ class sweeper(plotWidget):
                  sweep_id : int,
                  sweep_indep : str,
                  fixed_indep : str, 
-                 fixed_index : int,
+                 fixed_value : float,
                  *args, 
                  **kargs
                  ):
         self.sweep_id = sweep_id
         self.sweep_indep = sweep_indep
         self.fixed_indep = fixed_indep
-        self.fixed_index = fixed_index
+        self.fixed_value = float(fixed_value)
+        self.fixed_index = 0
         
         self.line: Any = None
         
@@ -186,7 +187,7 @@ class sweeper(plotWidget):
             self.fixed_indep_data = fixed_data[:row_count]
             self.axis_data["x"] = x_data[:column_count]
             self.dataGrid = data_grid[:row_count, :column_count]
-            self.fixed_index = min(max(self.fixed_index, 0), row_count - 1)
+            self.fixed_index = self._fixed_index_for_value(self.fixed_value)
 
             # Get correct row and param for y data
             self.axis_param["y"] = getattr(self, "display_param", self.param)
@@ -252,6 +253,11 @@ class sweeper(plotWidget):
 
         """
         # Get correct row for y data
+        fixed_values = np.asarray(getattr(self, "fixed_indep_data", []))
+        if fixed_values.size > self.fixed_index:
+            self.fixed_value = float(fixed_values[self.fixed_index])
+        elif not hasattr(self, "fixed_value"):
+            self.fixed_value = float(self.fixed_index)
         self.axis_data["y"] = self.dataGrid[self.fixed_index, :]
         
         # update line
@@ -266,7 +272,7 @@ class sweeper(plotWidget):
             self.sweep_moved.emit(
                 self.sweep_id,
                 *self.axis_options.values(),
-                self.fixed_index,
+                self.fixed_value,
                 self.line.opts['pen']
                 )
 
@@ -290,6 +296,7 @@ class sweeper(plotWidget):
         
         # Update plot
         self.fixed_index = index
+        self.fixed_value = float(self.fixed_indep_data[index])
         self.update_sweep()
         
         self._set_param_axis_labels()
@@ -313,6 +320,7 @@ class sweeper(plotWidget):
         self.picker.slider.blockSignals(True)
         self.picker.slider.setValue(0)
         self.fixed_index = 0
+        self.fixed_value = 0.0
         self.picker.text_box.setText("") # Let refreshPlot know signal is blocked
         
         if self.picker.option_box.currentText() == self.axis_dropdown["x"].currentText():
@@ -348,6 +356,7 @@ class sweeper(plotWidget):
         self.picker.slider.blockSignals(True)
         self.picker.slider.setValue(0)
         self.fixed_index = 0
+        self.fixed_value = 0.0
         self.picker.text_box.setText("") # Let refreshPlot know signal is blocked
         
         if self.axis_dropdown["x"].currentText() == self.picker.option_box.currentText():
@@ -362,8 +371,8 @@ class sweeper(plotWidget):
         self.refreshWindow(force=True)
             
             
-    @QtCore.pyqtSlot(int, int)
-    def update_sweep_line(self, sweep_id, index):
+    @QtCore.pyqtSlot(int, float)
+    def update_sweep_line(self, sweep_id, fixed_value):
         """
         Event handler for moving sweep cursor on source plot.
 
@@ -372,23 +381,35 @@ class sweeper(plotWidget):
         sweep_id : int
             The sweep id of the line moved. Confirms that this is the intened
             plot to adjust
-        index : int
-            The index that the indep variable was set to.
+        fixed_value : float
+            The physical fixed-axis coordinate selected on the source plot.
 
         """
         if sweep_id != self.sweep_id:
             return
-        
-        self.fixed_index = index
+
+        self.fixed_value = float(fixed_value)
+        if not getattr(self, "fixed_indep_data", np.asarray([])).size:
+            return
+        self.fixed_index = self._fixed_index_for_value(self.fixed_value)
         
         self.picker.slider.blockSignals(True)
-        self.picker.slider.setValue(index)
+        self.picker.slider.setValue(self.fixed_index)
         self.picker.slider.blockSignals(False)
         self.picker.text_box.setText(
-            self.formatNum(self.fixed_indep_data[index])
+            self.formatNum(self.fixed_indep_data[self.fixed_index])
             )
         
         self.update_sweep(emit = False)
+
+
+    def _fixed_index_for_value(self, value: float) -> int:
+        values = np.asarray(self.fixed_indep_data, dtype=float)
+        finite = np.flatnonzero(np.isfinite(values))
+        if finite.size == 0:
+            return 0
+        nearest = int(np.argmin(np.abs(values[finite] - float(value))))
+        return int(finite[nearest])
 
     
 class fixed_var_picker(qtw.QWidget):

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -21,6 +21,7 @@ class sweeper(plotWidget):
     Both plots become linked, any changes to the cursor or sweep will update
     their counterpart.
     """
+    operation_kind = "sweeper"
     sweep_moved = QtCore.pyqtSignal([int, str, str, int, object])
     merge_compatibility_changed = QtCore.pyqtSignal()
     remove_sweep = QtCore.pyqtSignal([int])

--- a/src/qplot/windows/_widgets/_run_formatting.py
+++ b/src/qplot/windows/_widgets/_run_formatting.py
@@ -129,7 +129,14 @@ def progress_percent_value(metadata):
 
 
 def interrupted_progress_percent_value(metadata):
-    expected = metadata.get("setpoint_count") or metadata.get("expected_results")
+    expected = None
+    if metadata.get("setpoint_count_source") != "observed":
+        expected = metadata.get("setpoint_count")
+    if (
+            not expected
+            and metadata.get("expected_results_source") != "observed"
+            ):
+        expected = metadata.get("expected_results")
     count = metadata.get("read_setpoint_count")
     if count is None:
         count = metadata.get("result_count")
@@ -182,7 +189,10 @@ def format_complete_cell(metadata):
 def format_timestamp(timestamp):
     if not timestamp:
         return "unknown"
-    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    except (TypeError, ValueError, OSError, OverflowError):
+        return "unknown"
 
 
 def time_taken_seconds(metadata):

--- a/src/qplot/windows/_widgets/operations.py
+++ b/src/qplot/windows/_widgets/operations.py
@@ -37,8 +37,10 @@ class OperationsWindow(Protocol):
 def operations_widget(window: Any) -> "operations_options_base":
     """
     Entry point for getting the operation options.
-    Uses the window tupe to find the correct class to return.
-    Window is also passed to the class
+    Uses the plot kind declared by the window class to select the correct
+    options widget. Subclasses inherit this declaration, so instrumented or
+    otherwise specialised plot windows get the same operations as their base
+    plot type. Window is also passed to the class.
     
     PLEASE SEE BOTTOM OF FILE FOR WHICH OPTIONS ARE ADDED.
 
@@ -55,13 +57,19 @@ def operations_widget(window: Any) -> "operations_options_base":
         the inputted window type.
 
     """
-    options_dict: dict[str, type[operations_options_base]] = {
+    options_dict: dict[OperationKind, type[operations_options_base]] = {
         "plot1d" : operations_options_1d,
         "plot2d" : operations_options_2d,
         "sweeper": operations_options_sweep
         }
-    
-    out = options_dict[window.__class__.__name__](window)
+
+    operation_kind = getattr(window, "operation_kind", None)
+    if operation_kind not in options_dict:
+        raise TypeError(
+            "Plot windows must declare operation_kind as "
+            "'plot1d', 'plot2d', or 'sweeper'"
+            )
+    out = options_dict[cast(OperationKind, operation_kind)](window)
     
     return out
 

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -507,6 +507,7 @@ class PreviewCard(qtw.QWidget):
         image.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         image.setPixmap(QtGui.QPixmap.fromImage(preview["image"]))
         image.setToolTip(preview["title"])
+        image.set_preview_accessibility(preview["title"])
         image.plotRequested.connect(self.plotRequested)
         image.exportRequested.connect(self.exportRequested)
 
@@ -524,9 +525,20 @@ class PreviewImageLabel(qtw.QLabel):
         super().__init__(*args)
         self.parameter = parameter
         self._selected = False
-        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
         self.setProperty(PREVIEW_SELECTED_PROPERTY, False)
         self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.DefaultContextMenu)
+        self.set_preview_accessibility(parameter)
+
+
+    def set_preview_accessibility(self, title=None):
+        title = str(title or self.parameter or "").strip()
+        accessible_name = f"Plot preview: {title}" if title else "Plot preview"
+        self.setAccessibleName(accessible_name)
+        self.setAccessibleDescription(
+            "Press Enter or Space to plot. Press Menu or Shift+F10 for plot and "
+            "export actions."
+            )
 
 
     def set_selected(self, selected):
@@ -559,6 +571,12 @@ class PreviewImageLabel(qtw.QLabel):
         super().mousePressEvent(event)
 
 
+    def focusInEvent(self, event):
+        if self.parameter:
+            self.select_preview()
+        super().focusInEvent(event)
+
+
     def paintEvent(self, event):
         super().paintEvent(event)
 
@@ -581,12 +599,43 @@ class PreviewImageLabel(qtw.QLabel):
         super().mouseDoubleClickEvent(event)
 
 
+    def keyPressEvent(self, event):
+        key = event.key()
+        if self.parameter and key in (
+                QtCore.Qt.Key.Key_Return,
+                QtCore.Qt.Key.Key_Enter,
+                QtCore.Qt.Key.Key_Space,
+                ):
+            self.select_preview()
+            self.plotRequested.emit(self.parameter)
+            event.accept()
+            return
+
+        context_menu_key = key == QtCore.Qt.Key.Key_Menu
+        shift_f10 = (
+            key == QtCore.Qt.Key.Key_F10
+            and bool(event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier)
+            )
+        if self.parameter and (context_menu_key or shift_f10):
+            self.select_preview()
+            self._show_context_menu(self.mapToGlobal(self.rect().center()))
+            event.accept()
+            return
+
+        super().keyPressEvent(event)
+
+
     def contextMenuEvent(self, event):
         if not self.parameter:
             super().contextMenuEvent(event)
             return
 
         self.select_preview()
+        self._show_context_menu(event.globalPos())
+        event.accept()
+
+
+    def _show_context_menu(self, global_position):
         menu = qtw.QMenu(self)
 
         plot_action = QtGui.QAction("&Plot", menu)
@@ -597,7 +646,7 @@ class PreviewImageLabel(qtw.QLabel):
         export_action.triggered.connect(lambda: self.exportRequested.emit(self.parameter))
         menu.addAction(export_action)
 
-        menu.exec(event.globalPos())
+        menu.exec(global_position)
 
 
 class DraggablePreviewImageLabel(PreviewImageLabel):
@@ -744,7 +793,13 @@ def unsupported_preview_label(preview, size, object_name):
 
 
 def _preview_1d(cursor, table_name, metadata, parameter, axis, size):
-    x, y = _select_arrays(cursor, table_name, [axis, parameter], metadata)
+    x, y = _select_arrays(
+        cursor,
+        table_name,
+        [axis, parameter],
+        metadata,
+        eligible_columns=[axis, parameter],
+        )
     image = render_sparkline_preview(x, y, size=size)
     return {
         "parameter": parameter,
@@ -1584,12 +1639,23 @@ def _select_arrays(
         metadata,
         max_rows=None,
         sampling="stride",
+        eligible_columns=None,
         ):
     max_rows = int(max_rows or MAX_PREVIEW_ROWS)
     count = _metadata_result_count(metadata)
 
     selected_columns = ", ".join(_sqlite_identifier(column) for column in columns)
     table = _sqlite_identifier(table_name)
+    if eligible_columns:
+        rows = _select_eligible_rows(
+            cursor,
+            table,
+            selected_columns,
+            eligible_columns,
+            max_rows,
+            )
+        return _rows_to_float_arrays(rows, len(columns))
+
     rowid_span = _rowid_span(cursor, table_name)
     if rowid_span is None:
         cursor.execute(
@@ -1637,6 +1703,46 @@ def _select_arrays(
         return [np.array([], dtype=float) for _ in columns]
 
     return _rows_to_float_arrays(rows, len(columns))
+
+
+def _select_eligible_rows(
+        cursor,
+        table,
+        selected_columns,
+        eligible_columns,
+        max_rows,
+        ):
+    predicate = " AND ".join(
+        f"{_sqlite_identifier(column)} IS NOT NULL"
+        for column in dict.fromkeys(eligible_columns)
+        )
+    cursor.execute(f"SELECT COUNT(*) FROM {table} WHERE {predicate}")
+    eligible_count = int(cursor.fetchone()[0] or 0)
+    if eligible_count <= max_rows:
+        cursor.execute(
+            f"SELECT {selected_columns} FROM {table} "
+            f"WHERE {predicate} ORDER BY rowid"
+            )
+        return cursor.fetchall()
+
+    step = max(1, (eligible_count + max_rows - 1) // max_rows)
+    cursor.execute(
+        f"""
+        WITH eligible AS (
+            SELECT {selected_columns},
+                   ROW_NUMBER() OVER (ORDER BY rowid) AS qplot_preview_row_number
+            FROM {table}
+            WHERE {predicate}
+        )
+        SELECT {selected_columns}
+        FROM eligible
+        WHERE (qplot_preview_row_number - 1) % ? = 0
+        ORDER BY qplot_preview_row_number
+        LIMIT ?
+        """,
+        (step, max_rows),
+        )
+    return cursor.fetchall()
 
 
 def _select_stratified_rows(

--- a/src/qplot/windows/_widgets/run_list_items.py
+++ b/src/qplot/windows/_widgets/run_list_items.py
@@ -88,6 +88,7 @@ class RunPreviewCell(qtw.QWidget):
             label.setFixedSize(self.icon_size, self.icon_size)
             label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             label.setToolTip(preview.get("title", ""))
+            label.set_preview_accessibility(preview.get("title"))
             label.setPixmap(
                 QtGui.QPixmap.fromImage(image).scaled(
                     self.icon_size,

--- a/src/qplot/windows/_widgets/run_list_items.py
+++ b/src/qplot/windows/_widgets/run_list_items.py
@@ -178,6 +178,14 @@ class EqualsAlignedDelegate(qtw.QStyledItemDelegate):
         | QtCore.Qt.AlignmentFlag.AlignVCenter
         )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._right_width_cache = {}
+
+
+    def invalidate_width_cache(self):
+        self._right_width_cache.clear()
+
     def paint(self, painter, option, index):
         text = index.data(QtCore.Qt.ItemDataRole.DisplayRole)
         if text is None or text == "":
@@ -291,8 +299,12 @@ class EqualsAlignedDelegate(qtw.QStyledItemDelegate):
         if not isinstance(view, qtw.QTreeWidget):
             return 0
 
-        max_width = 0
         column = index.column()
+        cached = self._right_width_cache.get(column)
+        if cached is not None:
+            return cached
+
+        max_width = 0
         for row in range(view.topLevelItemCount()):
             item = view.topLevelItem(row)
             if item is None:
@@ -311,6 +323,7 @@ class EqualsAlignedDelegate(qtw.QStyledItemDelegate):
                 continue
 
             max_width = max(max_width, metrics.horizontalAdvance(right))
+        self._right_width_cache[column] = max_width
         return max_width
 
 

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -63,6 +63,9 @@ from .run_list_items import (
     SortableTreeWidgetItem,
 )
 
+MAX_RUN_PREVIEW_WIDGETS = 500
+MAX_SYNCHRONOUS_SETPOINT_SUMMARY_ROWS = 100_000
+
 
 class RunList(qtw.QTreeWidget):
     """
@@ -148,6 +151,7 @@ class RunList(qtw.QTreeWidget):
         self._items_by_guid: dict[str, SortableTreeWidgetItem] = {}
         self._resizing_columns = False
         self._manual_column_widths = False
+        self._preview_widgets_enabled = True
         self.maxRunId = 0
         
         self.setColumnCount(len(self.cols))
@@ -156,9 +160,10 @@ class RunList(qtw.QTreeWidget):
         self.setIndentation(0)
         self.setUniformRowHeights(False)
         self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._setpoints_delegate = EqualsAlignedDelegate(self)
         self.setItemDelegateForColumn(
             self.cols.index("Setpoints"),
-            EqualsAlignedDelegate(self)
+            self._setpoints_delegate,
             )
         self._resize_columns()
 
@@ -206,6 +211,12 @@ class RunList(qtw.QTreeWidget):
         """
         if not runs:
             return
+
+        if (
+                self._preview_widgets_enabled
+                and self.topLevelItemCount() + len(runs) > MAX_RUN_PREVIEW_WIDGETS
+                ):
+            self._disable_measurement_preview_widgets()
 
         self.setSortingEnabled(False) # Prevent constant restort on adding items
 
@@ -289,12 +300,16 @@ class RunList(qtw.QTreeWidget):
             
             # Add to top
             self.addTopLevelItem(item)
-            self._set_measurement_preview_cell(item, measurement_count)
+            if self._preview_widgets_enabled:
+                self._set_measurement_preview_cell(item, measurement_count)
+            else:
+                self._set_compact_measurement_cell(item, measurement_count)
             
             # If unfinished run
             if append_to_watching:
                 self.watching.append(item)
             
+        self._setpoints_delegate.invalidate_width_cache()
         self.setSortingEnabled(True)
 
 
@@ -310,7 +325,15 @@ class RunList(qtw.QTreeWidget):
             return {}
 
         updated = {}
-        self.setSortingEnabled(False)
+        sorting_enabled = self.isSortingEnabled()
+        sort_column = self.sortColumn()
+        mutable_columns = {
+            self.cols.index(name)
+            for name in ("Measurements", "Setpoints", "Status", "Duration", "Size")
+            }
+        suspend_sorting = sorting_enabled and sort_column in mutable_columns
+        if suspend_sorting:
+            self.setSortingEnabled(False)
         for run_id, metadata in runs.items():
             guid = metadata.get("guid")
             item = self._item_for_guid(guid)
@@ -331,7 +354,9 @@ class RunList(qtw.QTreeWidget):
             self._sync_watching_item(item)
             updated[run_id] = dict(item.run_metadata)
 
-        self.setSortingEnabled(True)
+        self._setpoints_delegate.invalidate_width_cache()
+        if suspend_sorting:
+            self.setSortingEnabled(True)
         return updated
 
 
@@ -355,8 +380,13 @@ class RunList(qtw.QTreeWidget):
             QtCore.QSize(0, MEASUREMENT_PREVIEW_SIZE + 6),
             )
         cell = self.preview_cells.get(item.guid)
-        if cell is None or cell.placeholder_count != measurement_count:
+        if (
+                self._preview_widgets_enabled
+                and (cell is None or cell.placeholder_count != measurement_count)
+                ):
             self._set_measurement_preview_cell(item, measurement_count)
+        elif not self._preview_widgets_enabled:
+            self._set_compact_measurement_cell(item, measurement_count)
 
         setpoints_col = self.cols.index("Setpoints")
         item.setText(setpoints_col, format_point_count(metadata))
@@ -407,6 +437,9 @@ class RunList(qtw.QTreeWidget):
     def clear(self):
         self.preview_cells = {}
         self._items_by_guid = {}
+        self._preview_widgets_enabled = True
+        self.setUniformRowHeights(False)
+        self._setpoints_delegate.invalidate_width_cache()
         super().clear()
 
 
@@ -425,6 +458,33 @@ class RunList(qtw.QTreeWidget):
             )
         self.preview_cells[item.guid] = cell
         self.setItemWidget(item, column, cell)
+
+
+    def _set_compact_measurement_cell(self, item, measurement_count):
+        column = self.cols.index("Measurements")
+        item.setText(column, str(measurement_count))
+        item.setSizeHint(column, QtCore.QSize(0, 22))
+        item.setToolTip(
+            column,
+            "Inline previews are disabled for this large run list. "
+            "Select the run to use the Preview tab.",
+            )
+
+
+    def _disable_measurement_preview_widgets(self):
+        column = self.cols.index("Measurements")
+        for guid, cell in tuple(self.preview_cells.items()):
+            item = self._items_by_guid.get(guid)
+            if item is not None:
+                self.removeItemWidget(item, column)
+                self._set_compact_measurement_cell(
+                    item,
+                    measured_parameter_count(item.run_metadata),
+                    )
+            cell.deleteLater()
+        self.preview_cells.clear()
+        self._preview_widgets_enabled = False
+        self.setUniformRowHeights(True)
 
 
     @QtCore.pyqtSlot(str, object)
@@ -995,6 +1055,7 @@ class moreInfo(qtw.QTabWidget):
     def __init__(self, *args, preview_size=None):
         super().__init__(*args)
         self.setObjectName("runDetailsTabs")
+        self._setpoint_summary_cache = {}
 
         self.overview = CopyableTableWidget()
         self.parameters = CopyableTableWidget()
@@ -1274,11 +1335,33 @@ class moreInfo(qtw.QTabWidget):
             run_metadata.get("result_table_name")
             or self._dataset_attr(dataset, "table_name")
             )
-        summaries = self._setpoint_summaries_from_sql(
+        try:
+            result_count = int(run_metadata.get("result_count") or 0)
+        except (TypeError, ValueError, OverflowError):
+            result_count = 0
+
+        cache_key = (
             database_path,
             table_name,
-            setpoint_names,
+            tuple(setpoint_names),
+            result_count,
             )
+        cached = self._setpoint_summary_cache.get(cache_key)
+        if cached is not None:
+            summaries = {name: dict(summary) for name, summary in cached.items()}
+        elif result_count > MAX_SYNCHRONOUS_SETPOINT_SUMMARY_ROWS:
+            summaries = {}
+        else:
+            summaries = self._setpoint_summaries_from_sql(
+                database_path,
+                table_name,
+                setpoint_names,
+                )
+            if len(self._setpoint_summary_cache) >= 32:
+                self._setpoint_summary_cache.clear()
+            self._setpoint_summary_cache[cache_key] = {
+                name: dict(summary) for name, summary in summaries.items()
+                }
         self._add_setpoint_shape_steps(summaries, setpoint_names, run_metadata)
         return summaries
 

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -145,6 +145,9 @@ class RunList(qtw.QTreeWidget):
         
         self.watching: list[SortableTreeWidgetItem] = []
         self.preview_cells: dict[str, RunPreviewCell] = {}
+        self._items_by_guid: dict[str, SortableTreeWidgetItem] = {}
+        self._resizing_columns = False
+        self._manual_column_widths = False
         self.maxRunId = 0
         
         self.setColumnCount(len(self.cols))
@@ -152,12 +155,18 @@ class RunList(qtw.QTreeWidget):
         self.setRootIsDecorated(False)
         self.setIndentation(0)
         self.setUniformRowHeights(False)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.setItemDelegateForColumn(
             self.cols.index("Setpoints"),
             EqualsAlignedDelegate(self)
             )
         self._resize_columns()
+
+        header = self.header()
+        if header is not None:
+            header.sectionResized.connect(self._column_resized)
+            header.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+            header.customContextMenuRequested.connect(self._open_header_menu)
         
         # Optional IDE convenience; MainWindow loads databases asynchronously.
         if initalize and isfile(get_DB_location()):
@@ -221,6 +230,7 @@ class RunList(qtw.QTreeWidget):
             item = SortableTreeWidgetItem(arr)
             item.set_guid(metadata["guid"])
             item.run_metadata = dict(metadata)
+            self._items_by_guid[item.guid] = item
             for col_name in ("ID", "Setpoints", "Size"):
                 item.setTextAlignment(
                     self.cols.index(col_name),
@@ -238,6 +248,11 @@ class RunList(qtw.QTreeWidget):
                 self.cols.index("Measurements"),
                 QtCore.Qt.ItemDataRole.UserRole,
                 measurement_count
+                )
+            item.setData(
+                self.cols.index("Measurements"),
+                QtCore.Qt.ItemDataRole.AccessibleTextRole,
+                self._measurement_accessible_text(metadata, measurement_count),
                 )
             item.setSizeHint(
                 self.cols.index("Measurements"),
@@ -281,7 +296,6 @@ class RunList(qtw.QTreeWidget):
                 self.watching.append(item)
             
         self.setSortingEnabled(True)
-        self._resize_columns()
 
 
     def updateRuns(self, runs):
@@ -318,7 +332,6 @@ class RunList(qtw.QTreeWidget):
             updated[run_id] = dict(item.run_metadata)
 
         self.setSortingEnabled(True)
-        self._resize_columns()
         return updated
 
 
@@ -331,6 +344,11 @@ class RunList(qtw.QTreeWidget):
             measurements_col,
             QtCore.Qt.ItemDataRole.UserRole,
             measurement_count,
+            )
+        item.setData(
+            measurements_col,
+            QtCore.Qt.ItemDataRole.AccessibleTextRole,
+            self._measurement_accessible_text(metadata, measurement_count),
             )
         item.setSizeHint(
             measurements_col,
@@ -388,6 +406,7 @@ class RunList(qtw.QTreeWidget):
 
     def clear(self):
         self.preview_cells = {}
+        self._items_by_guid = {}
         super().clear()
 
 
@@ -396,6 +415,14 @@ class RunList(qtw.QTreeWidget):
         cell = RunPreviewCell(item.guid, measurement_count, self)
         cell.plotRequested.connect(self._preview_plot_requested)
         cell.exportRequested.connect(self._preview_export_requested)
+        accessible_text = self._measurement_accessible_text(
+            item.run_metadata,
+            measurement_count,
+            )
+        cell.setAccessibleName(accessible_text)
+        cell.setAccessibleDescription(
+            "Measurement previews. Focus a preview for plot and export actions."
+            )
         self.preview_cells[item.guid] = cell
         self.setItemWidget(item, column, cell)
 
@@ -431,14 +458,48 @@ class RunList(qtw.QTreeWidget):
 
 
     def _item_for_guid(self, guid):
-        for row in range(self.topLevelItemCount()):
-            item = self.topLevelItem(row)
-            if isinstance(item, SortableTreeWidgetItem) and item.guid == guid:
-                return item
-        return None
+        return self._items_by_guid.get(guid)
 
 
-    def _resize_columns(self):
+    @staticmethod
+    def _measurement_accessible_text(metadata, measurement_count):
+        parameters = [
+            str(parameter)
+            for parameter in metadata.get("measure_parameters", [])
+            if parameter
+            ]
+        noun = "measurement" if measurement_count == 1 else "measurements"
+        summary = f"{measurement_count} {noun}"
+        if parameters:
+            summary += f": {', '.join(parameters)}"
+        return summary
+
+
+    def _column_resized(self, _column, old_size, new_size):
+        if not self._resizing_columns and old_size != new_size:
+            self._manual_column_widths = True
+
+
+    def reset_column_widths(self):
+        self._manual_column_widths = False
+        self._resize_columns(force=True)
+
+
+    def _open_header_menu(self, pos):
+        header = self.header()
+        if header is None:
+            return
+        menu = qtw.QMenu(self)
+        reset_action = menu.addAction("Reset column widths")
+        if reset_action is not None:
+            reset_action.triggered.connect(self.reset_column_widths)
+        menu.exec(header.mapToGlobal(pos))
+
+
+    def _resize_columns(self, force=False):
+        if self._manual_column_widths and not force:
+            return
+
         header = self.header()
         if header is not None:
             header.setStretchLastSection(False)
@@ -482,22 +543,20 @@ class RunList(qtw.QTreeWidget):
             widths["Setpoints"] += setpoints_extra
             widths["Started"] += extra_width - setpoints_extra
 
-        for col, name in enumerate(self.cols):
-            width = widths.get(name)
-            if width is not None:
-                self.setColumnWidth(col, width)
+        self._resizing_columns = True
+        try:
+            for col, name in enumerate(self.cols):
+                width = widths.get(name)
+                if width is not None:
+                    self.setColumnWidth(col, width)
+        finally:
+            self._resizing_columns = False
 
 
     def _grow_column_widths(self, base_widths, target_widths, available_width, order):
         widths = dict(base_widths)
         deficit = sum(widths.values()) - available_width
         if deficit > 0:
-            for name in self.compact_shrink_order:
-                shrink_by = min(max(0, widths.get(name, 0) - 32), deficit)
-                widths[name] = widths.get(name, 0) - shrink_by
-                deficit -= shrink_by
-                if deficit <= 0:
-                    break
             return widths
 
         extra_width = max(0, available_width - sum(widths.values()))
@@ -627,12 +686,36 @@ class RunList(qtw.QTreeWidget):
             if status.get("is_completed") is not None:
                 run.run_metadata["is_completed"] = bool(status["is_completed"])
 
+            shape_metadata_changed = False
+            for field in (
+                    "point_shape",
+                    "setpoint_shape",
+                    "setpoint_shape_source",
+                    "setpoint_count",
+                    "setpoint_count_source",
+                    "expected_results",
+                    "expected_results_source",
+                    ):
+                if field not in status:
+                    continue
+                if run.run_metadata.get(field) != status[field]:
+                    shape_metadata_changed = True
+                # None is meaningful here: it clears a stale early inference.
+                run.run_metadata[field] = status[field]
+
             if status.get("result_count") is not None:
                 run.run_metadata["result_count"] = status["result_count"]
-                if not run.run_metadata.get("expected_results"):
-                    points_col = self.cols.index("Setpoints")
-                    run.setText(points_col, format_point_count(run.run_metadata))
-                    run.setData(points_col, QtCore.Qt.ItemDataRole.UserRole, status["result_count"])
+
+            if status.get("result_count") is not None or shape_metadata_changed:
+                points_col = self.cols.index("Setpoints")
+                run.setText(points_col, format_point_count(run.run_metadata))
+                run.setData(
+                    points_col,
+                    QtCore.Qt.ItemDataRole.UserRole,
+                    run.run_metadata.get("setpoint_count")
+                    or run.run_metadata.get("expected_results")
+                    or run.run_metadata.get("result_count"),
+                    )
                 complete_col = self.cols.index("Status")
                 run.setText(complete_col, format_complete_cell(run.run_metadata))
                 run.setData(
@@ -962,7 +1045,7 @@ class moreInfo(qtw.QTabWidget):
     def setInfo(self, info, dataset=None, run_metadata=None, database_path=None):
         self.clear()
 
-        self._set_overview(info, dataset)
+        self._set_overview(info, dataset, run_metadata=run_metadata)
         self._set_parameters(info, dataset, run_metadata, database_path)
         self.preview.set_current_run(dataset)
         self.metadata.setInfo(info.get("MetaData", {}))
@@ -984,20 +1067,40 @@ class moreInfo(qtw.QTabWidget):
         self.raw.scrollToTop()
 
 
-    def _set_overview(self, info, dataset):
+    def _set_overview(self, info, dataset, run_metadata=None):
         structure = info.get("Data Structure", {})
         param_info = {
             key: value for key, value in structure.items()
             if isinstance(value, dict)
             }
-        measured = [
-            name for name, details in param_info.items()
-            if details.get("axes")
-            ]
-        setpoints = [
-            name for name, details in param_info.items()
-            if not details.get("axes")
-            ]
+        measured = list((run_metadata or {}).get("measure_parameters") or [])
+        setpoints = list((run_metadata or {}).get("sweep_parameters") or [])
+        if not measured and not setpoints and dataset is not None:
+            params = list(dataset.get_parameters())
+            setpoint_names = {
+                axis
+                for param in params
+                for axis in getattr(param, "depends_on_", ())
+                }
+            measured = [
+                getattr(param, "name", "")
+                for param in params
+                if getattr(param, "name", "") not in setpoint_names
+                ]
+            setpoints = [
+                getattr(param, "name", "")
+                for param in params
+                if getattr(param, "name", "") in setpoint_names
+                ]
+        elif not measured and not setpoints:
+            measured = [
+                name for name, details in param_info.items()
+                if details.get("axes")
+                ]
+            setpoints = [
+                name for name, details in param_info.items()
+                if not details.get("axes")
+                ]
 
         rows = [
             ("Status", self._status_text(dataset)),

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -560,7 +560,8 @@ class MainWindow(
         reply = qtw.QMessageBox.question(
             self,
             "Reset All Settings",
-            "Reset all qPlot settings to their defaults?",
+            "Reset all qPlot settings to their defaults? "
+            "This will also close the current database and all plot windows.",
             qtw.QMessageBox.StandardButton.Yes | qtw.QMessageBox.StandardButton.No,
             qtw.QMessageBox.StandardButton.No,
             )

--- a/src/qplot/windows/plot1d.py
+++ b/src/qplot/windows/plot1d.py
@@ -26,6 +26,7 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
     qplot.windows._plot1d_traces.
     
     """
+    operation_kind = "plot1d"
     get_mergables = QtCore.pyqtSignal()
     remove_dataset = QtCore.pyqtSignal([object])
     

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -36,7 +36,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
     """
     operation_kind = "plot2d"
     open_subplot = QtCore.pyqtSignal([object, object, tuple])
-    sweep_moved = QtCore.pyqtSignal([int, int])
+    sweep_moved = QtCore.pyqtSignal([int, float])
     close_sweeps_requested = QtCore.pyqtSignal([object, object])
     
     def __init__(

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -34,6 +34,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         refreshPlot
         
     """
+    operation_kind = "plot2d"
     open_subplot = QtCore.pyqtSignal([object, object, tuple])
     sweep_moved = QtCore.pyqtSignal([int, int])
     close_sweeps_requested = QtCore.pyqtSignal([object, object])

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -464,6 +464,267 @@ class RunSizeTestCase(unittest.TestCase):
             1010
             )
 
+    def test_parameter_roles_include_axisless_standalone_measurements(self):
+        run_description = {
+            "interdependencies_": {
+                "dependencies": {"signal": ["x"]},
+                "standalones": ["temperature"],
+                },
+            }
+
+        measure_parameters, sweep_parameters = readSQL._parameter_roles(
+            run_description,
+            "x,signal,temperature",
+            )
+
+        self.assertEqual(measure_parameters, ["signal", "temperature"])
+        self.assertEqual(sweep_parameters, ["x"])
+
+    def test_live_unshaped_status_refreshes_observed_count_until_completion(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "runs.db")
+            conn = sqlite3.connect(database_path)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    CREATE TABLE runs (
+                        guid TEXT,
+                        completed_timestamp REAL,
+                        is_completed INTEGER,
+                        result_table_name TEXT,
+                        run_description TEXT,
+                        parameters TEXT
+                    )
+                    """
+                    )
+                cursor.execute("CREATE TABLE results_1 (x REAL, signal REAL)")
+                run_description = json.dumps({
+                    "interdependencies_": {
+                        "dependencies": {"signal": ["x"]},
+                        },
+                    })
+                cursor.execute(
+                    "INSERT INTO runs VALUES (?, NULL, 0, ?, ?, ?)",
+                    ("guid", "results_1", run_description, "x,signal"),
+                    )
+                cursor.execute("INSERT INTO results_1 VALUES (0, 1)")
+                conn.commit()
+
+                old_connection = readSQL.qcodes_read_only_connection
+                readSQL.qcodes_read_only_connection = (
+                    lambda _database_path: sqlite3.connect(database_path)
+                    )
+                try:
+                    first_status = readSQL.get_run_status("guid")
+                    cursor.executemany(
+                        "INSERT INTO results_1 VALUES (?, ?)",
+                        [(index, index + 1) for index in range(1, 5)],
+                        )
+                    conn.commit()
+                    growing_status = readSQL.get_run_status("guid")
+                    cursor.execute(
+                        "UPDATE runs SET completed_timestamp = 123, is_completed = 1"
+                        )
+                    conn.commit()
+                    completed_status = readSQL.get_run_status("guid")
+                finally:
+                    readSQL.qcodes_read_only_connection = old_connection
+
+                self.assertEqual(first_status["setpoint_shape"], [1])
+                self.assertEqual(first_status["setpoint_count"], 1)
+                self.assertEqual(first_status["setpoint_count_source"], "observed")
+                self.assertIsNone(first_status["expected_results"])
+
+                self.assertEqual(growing_status["setpoint_shape"], [5])
+                self.assertEqual(growing_status["setpoint_count"], 5)
+                self.assertEqual(growing_status["result_count"], 5)
+                self.assertIsNone(growing_status["expected_results"])
+
+                self.assertEqual(completed_status["setpoint_shape"], [5])
+                self.assertEqual(completed_status["setpoint_count"], 5)
+                self.assertEqual(completed_status["expected_results"], 5)
+                self.assertEqual(
+                    completed_status["expected_results_source"],
+                    "observed",
+                    )
+            finally:
+                conn.close()
+
+    def test_heterogeneous_dependencies_do_not_form_a_cartesian_shape(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE results (x REAL, t REAL, a REAL, b REAL)")
+            cursor.executemany(
+                "INSERT INTO results VALUES (?, ?, ?, ?)",
+                [
+                    (0, None, 10, None),
+                    (1, None, 11, None),
+                    (2, None, 12, None),
+                    (3, None, 13, None),
+                    (None, 0, None, 20),
+                    (None, 1, None, 21),
+                    (None, 2, None, 22),
+                    (None, 3, None, 23),
+                    ],
+                )
+            metadata = {
+                "completed_timestamp": 123.0,
+                "is_completed": 1,
+                "parameters": "x,t,a,b",
+                "result_table_name": "results",
+                "run_description": json.dumps({
+                    "interdependencies_": {
+                        "dependencies": {
+                            "a": ["x"],
+                            "b": ["t"],
+                            },
+                        },
+                    }),
+                }
+
+            readSQL._add_run_basic_fields(metadata)
+            readSQL._add_run_detail_fields(
+                cursor,
+                metadata,
+                include_storage_bytes=False,
+                )
+
+            self.assertEqual(metadata["sweep_parameters"], ["x", "t"])
+            self.assertIsNone(metadata["setpoint_shape"])
+            self.assertIsNone(metadata["point_shape"])
+            self.assertEqual(metadata["setpoint_count"], 4)
+            self.assertEqual(metadata["setpoint_count_source"], "observed")
+            self.assertEqual(metadata["expected_results"], 8)
+            self.assertEqual(metadata["expected_results_source"], "observed")
+        finally:
+            conn.close()
+
+    def test_sparse_setpoints_do_not_form_a_cartesian_shape(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE results (x REAL, y REAL, signal REAL)")
+            cursor.executemany(
+                "INSERT INTO results VALUES (?, ?, ?)",
+                [(0, 0, 10), (1, 1, 11), (2, 2, 12)],
+                )
+
+            self.assertIsNone(
+                readSQL._setpoint_shape_from_result_table(
+                    cursor,
+                    "results",
+                    ["x", "y"],
+                    )
+                )
+            self.assertEqual(
+                readSQL._read_setpoint_count(cursor, "results", ["x", "y"]),
+                3,
+                )
+        finally:
+            conn.close()
+
+    def test_shape_batches_keep_sparse_runs_with_an_observed_count(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "runs.db")
+            conn = sqlite3.connect(database_path)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "CREATE TABLE experiments (exp_id INTEGER, name TEXT, sample_name TEXT)"
+                    )
+                cursor.execute(
+                    """
+                    CREATE TABLE runs (
+                        run_id INTEGER,
+                        exp_id INTEGER,
+                        name TEXT,
+                        run_timestamp REAL,
+                        completed_timestamp REAL,
+                        is_completed INTEGER,
+                        guid TEXT,
+                        result_table_name TEXT,
+                        parameters TEXT,
+                        run_description TEXT
+                    )
+                    """
+                    )
+                cursor.execute("CREATE TABLE results_1 (x REAL, y REAL, signal REAL)")
+                cursor.executemany(
+                    "INSERT INTO results_1 VALUES (?, ?, ?)",
+                    [(0, 0, 10), (1, 1, 11), (2, 2, 12)],
+                    )
+                run_description = json.dumps({
+                    "interdependencies_": {
+                        "dependencies": {"signal": ["x", "y"]},
+                        },
+                    })
+                cursor.execute("INSERT INTO experiments VALUES (1, 'exp', 'sample')")
+                cursor.execute(
+                    """
+                    INSERT INTO runs VALUES (
+                        1, 1, 'run', 100, 123, 1, 'guid',
+                        'results_1', 'x,y,signal', ?
+                    )
+                    """,
+                    (run_description, ),
+                    )
+                conn.commit()
+
+                old_connection = readSQL.qcodes_read_only_connection
+                readSQL.qcodes_read_only_connection = (
+                    lambda _database_path: sqlite3.connect(database_path)
+                    )
+                try:
+                    batches = list(readSQL.iter_run_shape_batches_via_sql(
+                        database_path,
+                        [1],
+                        ))
+                finally:
+                    readSQL.qcodes_read_only_connection = old_connection
+
+                self.assertEqual(len(batches), 1)
+                self.assertIsNone(batches[0][1]["setpoint_shape"])
+                self.assertEqual(batches[0][1]["setpoint_count"], 3)
+            finally:
+                conn.close()
+
+    def test_read_setpoint_count_is_aggregated_by_sql(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE results (x REAL, y REAL)")
+            cursor.executemany(
+                "INSERT INTO results VALUES (?, ?)",
+                [(index, index % 3) for index in range(100)],
+                )
+            statements = []
+            conn.set_trace_callback(statements.append)
+
+            count = readSQL._read_setpoint_count(
+                cursor,
+                "results",
+                ["x", "y"],
+                )
+            conn.set_trace_callback(None)
+
+            normalized_statements = [
+                " ".join(statement.upper().split())
+                for statement in statements
+                ]
+            self.assertEqual(count, 100)
+            self.assertTrue(any(
+                "SELECT COUNT(*) FROM ( SELECT DISTINCT" in statement
+                for statement in normalized_statements
+                ))
+            self.assertFalse(any(
+                statement.startswith("SELECT DISTINCT")
+                for statement in normalized_statements
+                ))
+        finally:
+            conn.close()
+
     def test_point_shape_falls_back_to_distinct_sweep_values(self):
         conn = sqlite3.connect(":memory:")
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,12 @@ class TemporaryConfigTestCase(unittest.TestCase):
             "notes.txt",
             )
 
+    def test_database_path_from_arguments_accepts_dash_path_after_separator(self):
+        self.assertEqual(
+            qplot_main._database_path_from_arguments(["-style", "Fusion", "--", "-data.db"]),
+            "-data.db",
+            )
+
     def test_application_identity_uses_qplot_name(self):
         app = qtw.QApplication.instance()
         old_name = app.applicationName()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,29 @@ class TemporaryConfigTestCase(unittest.TestCase):
         self.assertEqual(cfg.get("user_preference.theme"), "light")
         self.assertEqual(config().get("user_preference.theme"), "light")
 
+    def test_config_rejects_integral_floats_for_qt_integer_settings(self):
+        cfg = config()
+
+        with self.assertRaises(ValidationError):
+            cfg.update("runtime_settings.max_threads", 10.0)
+        with self.assertRaises(ValidationError):
+            cfg.update("GUI.main_frame_size", [900.0, 600.0])
+
+    def test_config_rejects_non_finite_numbers(self):
+        cfg = config()
+
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
+                cfg.update("GUI.plot_frame_fraction", value)
+
+    def test_config_rejects_values_outside_qt_widget_bounds(self):
+        cfg = config()
+
+        with self.assertRaises(ValidationError):
+            cfg.update("runtime_settings.max_threads", 1000)
+        with self.assertRaises(ValidationError):
+            cfg.update("GUI.main_frame_size", [2**31, 700])
+
     def test_config_write_failure_preserves_previous_file(self):
         cfg = config()
         previous_contents = Path(config.default_file).read_text(encoding="utf-8")
@@ -112,6 +135,16 @@ class TemporaryConfigTestCase(unittest.TestCase):
         self.assertEqual(cfg.get("GUI.preview_size"), 300)
         self.assertEqual(cfg.get("file.default_load_path"), "")
         self.assertEqual(cfg.get("file.recent_file_paths"), [])
+
+    def test_config_cli_rejects_integral_float_for_integer_setting(self):
+        with self.assertRaises(ValidationError):
+            sysHandle("-set_value", "runtime_settings.max_threads", "10.0")
+
+    def test_config_cli_preserves_numeric_strings(self):
+        with redirect_stdout(io.StringIO()):
+            sysHandle("-set_value", "file.default_load_path", "123")
+
+        self.assertEqual(config().get("file.default_load_path"), "123")
 
     def test_config_load_adds_new_defaults_to_existing_file(self):
         cfg = config()
@@ -160,6 +193,22 @@ class TemporaryConfigTestCase(unittest.TestCase):
         with open(reloaded.invalid_config_backup_file) as fp:
             backup = json.load(fp)
         self.assertEqual(backup["user_preference"]["theme"], "missing-theme")
+
+    def test_non_standard_json_number_is_backed_up_and_reset(self):
+        config()
+        invalid = Path(config.default_file).read_text(encoding="utf-8").replace(
+            '"plot_frame_fraction": 0.47',
+            '"plot_frame_fraction": NaN',
+            )
+        Path(config.default_file).write_text(invalid, encoding="utf-8")
+
+        reloaded = config()
+
+        self.assertEqual(reloaded.get("GUI.plot_frame_fraction"), 0.47)
+        self.assertIn(
+            '"plot_frame_fraction": NaN',
+            Path(reloaded.invalid_config_backup_file).read_text(encoding="utf-8"),
+            )
 
     def test_scripts_without_arguments_shows_command_info(self):
         old_argv = sys.argv

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,6 +89,32 @@ class ToolFunctionTestCase(unittest.TestCase):
         np.testing.assert_array_equal(axis_data["y"], np.array([0.0, 1.0]))
         np.testing.assert_array_equal(data_grid, np.array([[42.0], [43.0]]))
 
+    def test_shaped_2d_loader_maps_serpentine_rows_by_coordinates(self):
+        worker = loader.__new__(loader)
+        worker.axes_dict = {"x": "fast", "y": "slow"}
+        worker.param = type("Param", (), {"depends_on_": ("slow", "fast")})()
+        worker.param_dict = {
+            "slow": type("Param", (), {"name": "slow"})(),
+            "fast": type("Param", (), {"name": "fast"})(),
+            }
+
+        slow = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        fast = np.array([[0.0, 1.0, 2.0], [2.0, 1.0, 0.0]])
+        signal = np.array([[0.0, 1.0, 2.0], [12.0, 11.0, 10.0]])
+
+        axis_data, _axis_param, data_grid = loader.for_shaped_2d(
+            worker,
+            {"slow": slow, "fast": fast},
+            signal,
+            )
+
+        np.testing.assert_array_equal(axis_data["x"], np.array([0.0, 1.0, 2.0]))
+        np.testing.assert_array_equal(axis_data["y"], np.array([0.0, 1.0]))
+        np.testing.assert_array_equal(
+            data_grid,
+            np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0]]),
+            )
+
     def test_worker_canonicalizes_descending_heatmap_axes_and_grid(self):
         worker = loader.__new__(loader)
         worker.axis_data = {

--- a/tests/widgets/test_operations.py
+++ b/tests/widgets/test_operations.py
@@ -8,6 +8,7 @@ from qplot.tools.operation_registry import OperationValidationError, operation_s
 from qplot.windows._widgets.operations import (
     operations_options_1d,
     operations_options_2d,
+    operations_widget,
 )
 from qplot.windows._widgets.toolbar import QDock_context
 
@@ -47,6 +48,25 @@ class OperationsPanelTestCase(unittest.TestCase):
             if "Attempting to add QLayout" in message
             ]
         self.assertEqual(layout_warnings, [])
+
+    def test_operations_widget_uses_inherited_plot_kind(self):
+        class Plot2DWindow(qtw.QMainWindow):
+            operation_kind = "plot2d"
+
+            def __init__(self):
+                super().__init__()
+                self.oper_dock = QDock_context("Operations", self)
+
+        class TimedPlot2D(Plot2DWindow):
+            pass
+
+        window = TimedPlot2D()
+        try:
+            widget = operations_widget(window)
+
+            self.assertIsInstance(widget, operations_options_2d)
+        finally:
+            window.deleteLater()
 
     def test_operation_registry_lists_common_and_plot_specific_options(self):
         names = [spec.name for spec in operation_specs_for("plot2d")]

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
-from PyQt6 import QtCore, QtGui
+from PyQt6 import QtCore, QtGui, QtTest
 from PyQt6 import QtWidgets as qtw
 
 from qplot.windows._widgets import preview as preview_module
@@ -23,6 +23,43 @@ from qplot.windows._widgets.preview import (
 
 
 class RunDetailsTabsTestCase(unittest.TestCase):
+    def test_axisless_standalone_parameter_is_reported_as_measured(self):
+        class Param:
+            def __init__(self, name, axes=()):
+                self.name = name
+                self.label = name
+                self.unit = ""
+                self.depends_on_ = axes
+
+        class Dataset:
+            running = False
+
+            def get_parameters(self):
+                return [
+                    Param("x"),
+                    Param("signal", ("x",)),
+                    Param("standalone"),
+                    ]
+
+        widget = treeWidgets.moreInfo()
+        widget.setInfo(
+            {
+                "Data Structure": {
+                    "x": {},
+                    "signal": {"axes": ["x"]},
+                    "standalone": {},
+                    },
+                },
+            Dataset(),
+            )
+        overview = {
+            widget.overview.item(row, 0).text(): widget.overview.item(row, 1).text()
+            for row in range(widget.overview.rowCount())
+            }
+
+        self.assertEqual(overview["Measured parameters"], "signal, standalone")
+        self.assertEqual(overview["Setpoints"], "x")
+
     def test_run_details_show_overview_parameters_metadata_and_raw_tabs(self):
         class Param:
             def __init__(self, name, label, unit, axes=()):
@@ -834,6 +871,45 @@ class RunDetailsTabsTestCase(unittest.TestCase):
             conn.close()
             preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
 
+    def test_1d_preview_samples_only_rows_for_selected_measurement(self):
+        old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
+        preview_module.MAX_PREVIEW_ROWS = 3
+        conn = sqlite3.connect(":memory:")
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "CREATE TABLE results (x REAL, signal REAL, other REAL)"
+                )
+            values = []
+            for index in range(6):
+                values.extend([
+                    (float(index), None, float(index + 100)),
+                    (float(index), float(index * 10), None),
+                    ])
+            cursor.executemany("INSERT INTO results VALUES (?, ?, ?)", values)
+
+            with patch.object(
+                    preview_module,
+                    "render_sparkline_preview",
+                    side_effect=lambda x, y, size: (x, y),
+                    ):
+                preview = preview_module._preview_1d(
+                    cursor,
+                    "results",
+                    {"result_count": len(values)},
+                    "signal",
+                    "x",
+                    size=100,
+                    )
+
+            x, signal = preview["image"]
+            self.assertEqual(x.tolist(), [0.0, 2.0, 4.0])
+            self.assertEqual(signal.tolist(), [0.0, 20.0, 40.0])
+            self.assertTrue(np.isfinite(signal).all())
+        finally:
+            conn.close()
+            preview_module.MAX_PREVIEW_ROWS = old_max_preview_rows
+
     def test_2d_preview_reads_complete_modest_known_grid(self):
         old_max_preview_rows = preview_module.MAX_PREVIEW_ROWS
         old_max_grid_cells = preview_module.MAX_PREVIEW_GRID_CELLS
@@ -1140,6 +1216,78 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         qtw.QApplication.sendEvent(image, event)
 
         self.assertEqual(requested, ["dmm_v2"])
+
+    def test_preview_is_accessible_and_keyboard_activatable(self):
+        preview = PreviewTab(preview_size=100)
+        requested = []
+        preview.plotRequested.connect(requested.append)
+        preview._show_previews([{
+            "parameter": "signal",
+            "title": "signal vs x",
+            "image": render_sparkline_preview(
+                np.array([0, 1], dtype=float),
+                np.array([1, 2], dtype=float),
+                size=100,
+                ),
+            }])
+
+        image = preview.findChild(qtw.QLabel, "previewImage")
+        self.assertEqual(image.focusPolicy(), QtCore.Qt.FocusPolicy.StrongFocus)
+        self.assertEqual(image.accessibleName(), "Plot preview: signal vs x")
+        self.assertIn("Enter or Space", image.accessibleDescription())
+        self.assertIn("Shift+F10", image.accessibleDescription())
+
+        for key in (QtCore.Qt.Key.Key_Return, QtCore.Qt.Key.Key_Space):
+            QtTest.QTest.keyClick(image, key)
+
+        self.assertEqual(requested, ["signal", "signal"])
+        self.assertTrue(image.property(PREVIEW_SELECTED_PROPERTY))
+
+    def test_preview_keyboard_menu_keys_open_plot_and_export_actions(self):
+        old_exec = qtw.QMenu.exec
+        captured_action_texts = []
+        preview = PreviewTab(preview_size=100)
+        image = None
+
+        def capture_menu(menu, *_args, **_kwargs):
+            captured_action_texts.append([
+                action.text().replace("&", "")
+                for action in menu.actions()
+                ])
+
+        try:
+            qtw.QMenu.exec = capture_menu
+            preview._show_previews([{
+                "parameter": "signal",
+                "title": "signal vs x",
+                "image": render_sparkline_preview(
+                    np.array([0, 1], dtype=float),
+                    np.array([1, 2], dtype=float),
+                    size=100,
+                    ),
+                }])
+            image = preview.findChild(qtw.QLabel, "previewImage")
+
+            QtTest.QTest.keyClick(
+                image,
+                QtCore.Qt.Key.Key_Menu,
+                )
+            QtTest.QTest.keyClick(
+                image,
+                QtCore.Qt.Key.Key_F10,
+                QtCore.Qt.KeyboardModifier.ShiftModifier,
+                )
+        finally:
+            if image is not None:
+                # On macOS QtTest leaves the synthetic modifier globally
+                # pressed, changing selection behaviour in later table tests.
+                QtTest.QTest.keyRelease(image, QtCore.Qt.Key.Key_Shift)
+            qtw.QMenu.exec = old_exec
+
+        self.assertEqual(captured_action_texts, [
+            ["Plot", "Export CSV..."],
+            ["Plot", "Export CSV..."],
+            ])
 
     def test_right_clicking_preview_can_request_export(self):
         old_exec = qtw.QMenu.exec

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -12,6 +12,11 @@ from qplot.windows._widgets.preview import (
 
 
 class RunListTooltipTestCase(unittest.TestCase):
+    def test_format_timestamp_tolerates_malformed_database_values(self):
+        self.assertEqual(treeWidgets.format_timestamp("not-a-timestamp"), "unknown")
+        self.assertEqual(treeWidgets.format_timestamp(float("nan")), "unknown")
+        self.assertEqual(treeWidgets.format_timestamp(10**30), "unknown")
+
     def test_add_runs_displays_run_with_missing_timestamp(self):
         old_isfile = treeWidgets.isfile
         treeWidgets.isfile = lambda _: False
@@ -165,6 +170,24 @@ class RunListTooltipTestCase(unittest.TestCase):
             "Interrupted (40.00%)"
             )
         self.assertEqual(treeWidgets.complete_cell_sort_value(metadata), 40.0)
+
+    def test_unshaped_interrupted_run_does_not_report_observed_count_as_plan(self):
+        metadata = {
+            "is_completed": True,
+            "measurement_exception": "KeyboardInterrupt",
+            "result_count": 5,
+            "read_setpoint_count": 5,
+            "setpoint_count": 5,
+            "setpoint_count_source": "observed",
+            "expected_results": 5,
+            "expected_results_source": "observed",
+            }
+
+        self.assertEqual(
+            treeWidgets.format_run_status(metadata),
+            "Interrupted (unknown)",
+            )
+        self.assertIsNone(treeWidgets.complete_cell_sort_value(metadata))
 
     def test_completed_non_keyboard_measurement_exception_is_failed(self):
         metadata = {
@@ -496,6 +519,82 @@ class RunListTooltipTestCase(unittest.TestCase):
         finally:
             treeWidgets.isfile = old_isfile
 
+    def test_resize_columns_preserves_manual_width_until_reset(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.resize(780, 300)
+            run_list.show()
+            qtw.QApplication.processEvents()
+            column = run_list.cols.index("Started")
+            manual_width = run_list.columnWidth(column) + 37
+
+            run_list.setColumnWidth(column, manual_width)
+            run_list.resize(900, 300)
+            qtw.QApplication.processEvents()
+            run_list._resize_columns()
+
+            self.assertEqual(run_list.columnWidth(column), manual_width)
+
+            run_list.reset_column_widths()
+
+            self.assertFalse(run_list._manual_column_widths)
+            self.assertNotEqual(run_list.columnWidth(column), manual_width)
+            run_list.hide()
+        finally:
+            treeWidgets.isfile = old_isfile
+
+    def test_columns_do_not_shrink_below_declared_minimums(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            widths = run_list._grow_column_widths(
+                run_list.minimum_column_widths,
+                run_list.readable_column_widths,
+                available_width=100,
+                order=run_list.compact_growth_order,
+                )
+
+            self.assertEqual(widths, run_list.minimum_column_widths)
+            self.assertEqual(
+                run_list.horizontalScrollBarPolicy(),
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded,
+                )
+        finally:
+            treeWidgets.isfile = old_isfile
+
+    def test_guid_index_tracks_added_and_cleared_rows(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": 110.0,
+                    "is_completed": True,
+                    "guid": "indexed-guid",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 1,
+                    },
+                })
+            item = run_list.topLevelItem(0)
+
+            self.assertIs(run_list._item_for_guid("indexed-guid"), item)
+
+            run_list.clear()
+
+            self.assertIsNone(run_list._item_for_guid("indexed-guid"))
+            self.assertEqual(run_list._items_by_guid, {})
+        finally:
+            treeWidgets.isfile = old_isfile
+
     def test_unknown_completion_duration_uses_database_modified_time(self):
         self.assertEqual(
             treeWidgets.format_complete_cell({
@@ -595,7 +694,7 @@ class RunListTooltipTestCase(unittest.TestCase):
             self.assertEqual(run_list.indentation(), 0)
             self.assertEqual(
                 run_list.horizontalScrollBarPolicy(),
-                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
                 )
             self.assertTrue(
                 all(
@@ -611,9 +710,20 @@ class RunListTooltipTestCase(unittest.TestCase):
             self.assertEqual([item.guid for item in run_list.watching], ["unfinished-guid"])
             self.assertEqual(items["unfinished-guid"].text(1), "")
             self.assertEqual(items["unfinished-guid"].data(1, QtCore.Qt.ItemDataRole.UserRole), 1)
+            self.assertEqual(
+                items["unfinished-guid"].data(
+                    1,
+                    QtCore.Qt.ItemDataRole.AccessibleTextRole,
+                    ),
+                "1 measurement: y",
+                )
             self.assertIsInstance(
                 run_list.itemWidget(items["unfinished-guid"], 1),
                 treeWidgets.RunPreviewCell
+                )
+            self.assertEqual(
+                run_list.itemWidget(items["unfinished-guid"], 1).accessibleName(),
+                "1 measurement: y",
                 )
             self.assertEqual(
                 len(
@@ -629,6 +739,13 @@ class RunListTooltipTestCase(unittest.TestCase):
             self.assertEqual(items["unfinished-guid"].text(6), "100 KB")
             self.assertEqual(items["finished-guid"].text(1), "")
             self.assertEqual(items["finished-guid"].data(1, QtCore.Qt.ItemDataRole.UserRole), 2)
+            self.assertEqual(
+                items["finished-guid"].data(
+                    1,
+                    QtCore.Qt.ItemDataRole.AccessibleTextRole,
+                    ),
+                "2 measurements: z, w",
+                )
             self.assertEqual(
                 len(
                     run_list.itemWidget(
@@ -813,6 +930,72 @@ class RunListTooltipTestCase(unittest.TestCase):
         finally:
             treeWidgets.isfile = old_isfile
             treeWidgets.get_run_status = old_get_run_status
+
+    def test_check_watching_replaces_stale_observed_live_shape(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": None,
+                    "is_completed": False,
+                    "guid": "growing-guid",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 1,
+                    "point_shape": [1],
+                    "setpoint_shape": [1],
+                    "setpoint_shape_source": "observed",
+                    "setpoint_count": 1,
+                    "setpoint_count_source": "observed",
+                    "expected_results": 1,
+                    "expected_results_source": "observed",
+                    },
+                })
+            item = run_list.topLevelItem(0)
+
+            run_list.checkWatching({
+                "growing-guid": {
+                    "is_completed": False,
+                    "result_count": 5,
+                    "point_shape": [5],
+                    "setpoint_shape": [5],
+                    "setpoint_shape_source": "observed",
+                    "setpoint_count": 5,
+                    "setpoint_count_source": "observed",
+                    "expected_results": None,
+                    "expected_results_source": None,
+                    },
+                })
+
+            self.assertEqual(item.text(run_list.cols.index("Setpoints")), "5")
+            self.assertEqual(item.text(run_list.cols.index("Status")), "unknown")
+            self.assertIsNone(item.run_metadata["expected_results"])
+
+            run_list.checkWatching({
+                "growing-guid": {
+                    "completed_timestamp": 120.0,
+                    "is_completed": True,
+                    "result_count": 5,
+                    "point_shape": [5],
+                    "setpoint_shape": [5],
+                    "setpoint_shape_source": "observed",
+                    "setpoint_count": 5,
+                    "setpoint_count_source": "observed",
+                    "expected_results": 5,
+                    "expected_results_source": "observed",
+                    },
+                })
+
+            self.assertEqual(item.text(run_list.cols.index("Setpoints")), "5")
+            self.assertEqual(item.text(run_list.cols.index("Status")), "✓")
+            self.assertEqual(item.run_metadata["expected_results"], 5)
+            self.assertEqual(run_list.watching, [])
+        finally:
+            treeWidgets.isfile = old_isfile
 
     def test_check_watching_updates_finished_failed_run(self):
         old_isfile = treeWidgets.isfile

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -1233,3 +1233,164 @@ class RunListTooltipTestCase(unittest.TestCase):
                 )
         finally:
             treeWidgets.isfile = old_isfile
+
+    def test_large_run_list_uses_compact_cells_instead_of_widgets_per_run(self):
+        old_isfile = treeWidgets.isfile
+        old_limit = treeWidgets.MAX_RUN_PREVIEW_WIDGETS
+        treeWidgets.isfile = lambda _: False
+        treeWidgets.MAX_RUN_PREVIEW_WIDGETS = 2
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                run_id: {
+                    "run_timestamp": 100.0 + run_id,
+                    "completed_timestamp": 110.0 + run_id,
+                    "is_completed": True,
+                    "guid": f"guid-{run_id}",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 10,
+                    }
+                for run_id in range(1, 4)
+                })
+
+            self.assertFalse(run_list._preview_widgets_enabled)
+            self.assertEqual(run_list.preview_cells, {})
+            self.assertTrue(run_list.uniformRowHeights())
+            for row in range(run_list.topLevelItemCount()):
+                item = run_list.topLevelItem(row)
+                self.assertIsNone(run_list.itemWidget(item, 1))
+                self.assertEqual(item.text(1), "1")
+        finally:
+            treeWidgets.MAX_RUN_PREVIEW_WIDGETS = old_limit
+            treeWidgets.isfile = old_isfile
+
+    def test_setpoint_width_scan_is_cached_until_run_data_changes(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": 110.0,
+                    "is_completed": True,
+                    "guid": "guid-1",
+                    "sweep_parameters": ["x", "y"],
+                    "measure_parameters": ["signal"],
+                    "setpoint_count": 100,
+                    "setpoint_shape": [10, 10],
+                    "result_count": 100,
+                    },
+                })
+            item = run_list.topLevelItem(0)
+            column = run_list.cols.index("Setpoints")
+            index = run_list.indexFromItem(item, column)
+            delegate = run_list.itemDelegateForColumn(column)
+            metrics = QtGui.QFontMetrics(run_list.font())
+
+            first_width = delegate._max_right_width(index, metrics)
+            item.setText(column, "100 = 1000000 × 1000000")
+            cached_width = delegate._max_right_width(index, metrics)
+            delegate.invalidate_width_cache()
+            refreshed_width = delegate._max_right_width(index, metrics)
+
+            self.assertEqual(cached_width, first_width)
+            self.assertGreater(refreshed_width, first_width)
+        finally:
+            treeWidgets.isfile = old_isfile
+
+    def test_detail_batches_do_not_resort_when_sort_key_is_unchanged(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        class RecordingRunList(treeWidgets.RunList):
+            def __init__(self):
+                self.sorting_changes = []
+                super().__init__()
+
+            def setSortingEnabled(self, enabled):
+                self.sorting_changes.append(enabled)
+                super().setSortingEnabled(enabled)
+
+        try:
+            run_list = RecordingRunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": None,
+                    "is_completed": False,
+                    "guid": "guid-1",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    "result_count": 1,
+                    },
+                })
+            run_list.sortItems(0, QtCore.Qt.SortOrder.DescendingOrder)
+            run_list.sorting_changes.clear()
+
+            run_list.updateRuns({
+                1: {
+                    "guid": "guid-1",
+                    "result_count": 2,
+                    },
+                })
+
+            self.assertEqual(run_list.sorting_changes, [])
+            self.assertTrue(run_list.isSortingEnabled())
+        finally:
+            treeWidgets.isfile = old_isfile
+
+    def test_large_selected_run_skips_full_table_setpoint_grouping(self):
+        details = treeWidgets.moreInfo(preview_size=100)
+        sql_calls = []
+        details._setpoint_summaries_from_sql = (
+            lambda *args: sql_calls.append(args) or {"gate": {"steps": 5}}
+            )
+
+        summaries = details._setpoint_summaries(
+            None,
+            ["gate"],
+            run_metadata={
+                "result_table_name": "results",
+                "result_count": (
+                    treeWidgets.MAX_SYNCHRONOUS_SETPOINT_SUMMARY_ROWS + 1
+                    ),
+                "setpoint_shape": [1000],
+                },
+            database_path="large.db",
+            )
+
+        self.assertEqual(sql_calls, [])
+        self.assertEqual(summaries, {"gate": {"steps": 1000}})
+        details.deleteLater()
+
+    def test_selected_run_setpoint_summary_query_is_cached(self):
+        details = treeWidgets.moreInfo(preview_size=100)
+        sql_calls = []
+        details._setpoint_summaries_from_sql = (
+            lambda *args: sql_calls.append(args) or {"gate": {"steps": 5}}
+            )
+        metadata = {
+            "result_table_name": "results",
+            "result_count": 50,
+            }
+
+        first = details._setpoint_summaries(
+            None,
+            ["gate"],
+            run_metadata=metadata,
+            database_path="small.db",
+            )
+        second = details._setpoint_summaries(
+            None,
+            ["gate"],
+            run_metadata=metadata,
+            database_path="small.db",
+            )
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(sql_calls), 1)
+        details.deleteLater()

--- a/tests/widgets/test_themes.py
+++ b/tests/widgets/test_themes.py
@@ -53,6 +53,8 @@ class ThemeStylesheetTestCase(unittest.TestCase):
 
         self.assertIn("background-color: #010101", stylesheet)
         self.assertIn("border: 1px solid #151515", stylesheet)
+        self.assertNotIn("QCheckBox::indicator:checked", stylesheet)
+        self.assertNotIn("QCheckBox::indicator:unchecked", stylesheet)
         self.assertNotIn("$", stylesheet)
 
     def test_light_and_dark_stylesheets_parse_without_qt_warnings(self):
@@ -98,4 +100,3 @@ class ThemeStylesheetTestCase(unittest.TestCase):
             self.assertGreater(len(theme.main), 1000)
             self.assertEqual(len(theme.colors), 6)
             self.assertTrue(hasattr(theme, "style_plotItem"))
-

--- a/tests/windows/test_commands.py
+++ b/tests/windows/test_commands.py
@@ -47,6 +47,13 @@ class CommandRegistryTestCase(unittest.TestCase):
         self.assertEqual(spec.resolved_shortcuts()[0].toString(), "Ctrl+Alt+O")
         self.assertEqual(spec.status_tip, "Show or hide the operations dock")
 
+    def test_operations_panel_has_one_canonical_shortcut(self):
+        self.assertEqual(command_spec("plot.toggle_operations").resolved_shortcuts(), [])
+        self.assertEqual(
+            command_spec("toolbar.operations").resolved_shortcuts()[0].toString(),
+            "Ctrl+Alt+O",
+            )
+
     def test_shortcut_help_is_generated_from_registered_commands(self):
         html = shortcut_help_html()
 

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -1373,6 +1373,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
 
     def test_restore_default_settings_resets_and_applies_defaults(self):
         old_question = qtw.QMessageBox.question
+        questions = []
 
         class FakeConfig:
             def __init__(self):
@@ -1404,7 +1405,11 @@ class CloseAllPlotsTestCase(unittest.TestCase):
                 self.status_messages.append((message, timeout))
 
         try:
-            qtw.QMessageBox.question = lambda *args, **kwargs: qtw.QMessageBox.StandardButton.Yes
+            def answer_yes(*args, **kwargs):
+                questions.append((args, kwargs))
+                return qtw.QMessageBox.StandardButton.Yes
+
+            qtw.QMessageBox.question = answer_yes
             harness = Harness()
             harness.restore_default_settings()
         finally:
@@ -1415,6 +1420,8 @@ class CloseAllPlotsTestCase(unittest.TestCase):
         self.assertEqual(harness.closed_plots, [(False, False)])
         self.assertEqual(harness.closed_database, [False])
         self.assertEqual(harness.status_messages[-1][0], "Settings reset to defaults.")
+        self.assertIn("close the current database", questions[0][0][2])
+        self.assertIn("all plot windows", questions[0][0][2])
 
 
     def test_close_database_clears_loaded_database_state(self):
@@ -3321,7 +3328,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 12,
                 "details.db",
                 [2, 1],
-                batch_size=1,
+                batch_size=2,
                 )
             statuses = []
             batches = []
@@ -3337,8 +3344,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             database_module.iter_run_storage_batches_via_sql = old_iter_storage
 
         self.assertEqual(calls, [
-            ("shapes", "details.db", [1], 1),
-            ("shapes", "details.db", [2], 1),
+            ("shapes", "details.db", [1, 2], 2),
             ("storage", "details.db", [1, 2], 25),
             ])
         self.assertEqual(batches, [
@@ -3347,7 +3353,6 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             ])
         self.assertEqual(statuses, [
             (12, "Loading setpoint shapes... 0/2"),
-            (12, "Loading setpoint shapes... 1/2"),
             (12, "Loading setpoint shapes... 2/2"),
             (12, "Loading exact run sizes... 0/2"),
             (12, "Loading exact run sizes... 2/2"),

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -22,6 +22,18 @@ from qplot.windows.plot1d import plot1d
 
 
 class SnapToTraceTestCase(unittest.TestCase):
+    def test_trace_scroll_area_does_not_lock_dock_width(self):
+        host = Plot1DTraceMixin.__new__(Plot1DTraceMixin)
+        host.lineScroll = qtw.QScrollArea()
+        host.lineScroll.setMinimumWidth(500)
+        host.scrollWidget = qtw.QWidget()
+        host.scrollWidget.setMinimumWidth(600)
+        host.lineScroll.setWidget(host.scrollWidget)
+
+        host._resize_scrollArea()
+
+        self.assertEqual(host.lineScroll.minimumWidth(), 1)
+
     def test_nearest_trace_sample_returns_none_without_finite_points(self):
         self.assertIsNone(_nearest_trace_sample([], [], 0.0))
         self.assertIsNone(
@@ -1621,8 +1633,8 @@ class SnapToTraceTestCase(unittest.TestCase):
 
         stats_text = window._marquee_stats_text()
 
-        self.assertIn("X range: 1.000 to 4.000", stats_text)
-        self.assertIn("Y range: 2.000 to 6.000", stats_text)
+        self.assertIn("X range: 1.00 to 4.00", stats_text)
+        self.assertIn("Y range: 2.00 to 6.00", stats_text)
 
     def test_zoom_marquee_sets_selected_axes_without_padding(self):
         class ViewBox:

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -1072,8 +1072,8 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         self.assertEqual(len(opened), 1)
         self.assertIn("2×2 points", opened[0])
-        self.assertIn("X range: 1.000 to 3.000", opened[0])
-        self.assertIn("Y range: 1.000 to 3.000", opened[0])
+        self.assertIn("X range: 1.00 to 3.00", opened[0])
+        self.assertIn("Y range: 1.00 to 3.00", opened[0])
         self.assertEqual(qtw.QApplication.clipboard().text(), "")
         self.assertIsNone(window.marquee)
 

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -110,6 +110,50 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
         self.assertEqual(cut.trace_updated.emissions, [()])
         self.assertEqual(cut.sweep_moved.emissions, [])
 
+    def test_cut_maps_source_coordinate_against_its_full_axis(self):
+        class Signal:
+            def emit(self, *_args):
+                pass
+
+        class Line:
+            def setData(self, *, x, y):
+                self.data = (x, y)
+
+        class Slider:
+            def blockSignals(self, _blocked):
+                pass
+
+            def setValue(self, value):
+                self.value = value
+
+        class TextBox:
+            def setText(self, value):
+                self.value = value
+
+        cut = sweeper.__new__(sweeper)
+        cut.sweep_id = 7
+        cut.fixed_index = 0
+        cut.fixed_value = 0.0
+        cut.fixed_indep_data = np.arange(10.0)
+        cut.dataGrid = np.column_stack((np.arange(10.0), np.arange(10.0) + 100))
+        cut.axis_data = {"x": np.array([0.0, 1.0]), "y": np.asarray([])}
+        cut.line = Line()
+        cut.trace_updated = Signal()
+        cut.picker = type(
+            "Picker",
+            (),
+            {"slider": Slider(), "text_box": TextBox()},
+            )()
+        cut.formatNum = str
+
+        # Index 3 in a visible [5, 6, 7, 8, 9] heatmap is coordinate 8,
+        # which must remain index 8 in this cut's full coordinate array.
+        sweeper.update_sweep_line(cut, 7, 8.0)
+
+        self.assertEqual(cut.fixed_index, 8)
+        self.assertEqual(cut.picker.slider.value, 8)
+        np.testing.assert_array_equal(cut.axis_data["y"], [8.0, 108.0])
+
     def test_cut_axis_changes_publish_merge_compatibility_updates(self):
         class Signal:
             def __init__(self):
@@ -511,6 +555,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
             self.drag_events = []
             self.hover_events = []
             self.mouseHovering = False
+            self.visible = True
 
         def setBounds(self, bounds):
             self.bounds = bounds
@@ -520,6 +565,9 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         def value(self):
             return self._value
+
+        def setVisible(self, visible):
+            self.visible = visible
 
         def setCursor(self, shape):
             self.cursor_shape = shape
@@ -1259,7 +1307,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         self.assertEqual(line.sweep_index, 2)
         self.assertEqual(line.value(), 4.0)
         self.assertEqual(line.bounds, (0.0, 4.0))
-        self.assertEqual(window.sweep_moved.calls, [(5, 2)])
+        self.assertEqual(window.sweep_moved.calls, [(5, 4.0)])
 
     def test_geometry_refresh_remaps_sweep_from_its_physical_coordinate(self):
         window = plot2d.__new__(plot2d)
@@ -1282,7 +1330,31 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         self.assertEqual(line.sweep_index, 1)
         self.assertEqual(line.value(), 2.0)
-        self.assertEqual(window.sweep_moved.calls, [(5, 1)])
+        self.assertEqual(window.sweep_moved.calls, [])
+
+    def test_visible_range_reload_does_not_clamp_cut_outside_range(self):
+        window = plot2d.__new__(plot2d)
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(10.0),
+            y_centres=[0.0, 1.0],
+            )
+        line = self.SweepLine(sweep_id=5, angle=90, value=8.0)
+        line.sweep_index = 8
+        window.__dict__["sweep_lines"] = {5: line}
+        window.__dict__["sweep_moved"] = self.SignalCatcher()
+        self.configure_geometry(
+            window,
+            x_centres=np.arange(5.0),
+            y_centres=[0.0, 1.0],
+            )
+
+        window._snap_sweep_lines_to_pixel_centres()
+
+        self.assertEqual(line.value(), 8.0)
+        self.assertIsNone(line.sweep_index)
+        self.assertFalse(line.visible)
+        self.assertEqual(window.sweep_moved.calls, [])
 
     def test_sweep_events_are_noops_without_geometry(self):
         window = plot2d.__new__(plot2d)
@@ -1354,7 +1426,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         self.assertEqual(window.active_sweep_line_id, 5)
         self.assertAlmostEqual(line.value(), 2.5)
         self.assertEqual(line.bounds, (0.5, 3.5))
-        self.assertEqual(window.sweep_moved.calls, [(5, 2)])
+        self.assertEqual(window.sweep_moved.calls, [(5, 2.5)])
 
     def test_shift_drag_moves_same_orientation_sweep_lines_together(self):
         window = plot2d.__new__(plot2d)
@@ -1386,7 +1458,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
         self.assertAlmostEqual(companion_line.value(), 4.5)
         self.assertAlmostEqual(horizontal_line.value(), 11.5)
         self.assertEqual(window.active_sweep_line_id, 1)
-        self.assertEqual(window.sweep_moved.calls, [(1, 2), (2, 4)])
+        self.assertEqual(window.sweep_moved.calls, [(1, 2.5), (2, 4.5)])
 
     def test_shift_drag_keeps_sweep_group_spacing_at_heatmap_edge(self):
         window = plot2d.__new__(plot2d)
@@ -1542,7 +1614,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         self.assertEqual(line.sweep_index, 2)
         self.assertAlmostEqual(line.value(), 2.5)
-        self.assertEqual(window.sweep_moved.calls, [(8, 2)])
+        self.assertEqual(window.sweep_moved.calls, [(8, 2.5)])
 
     def test_arrow_key_clamps_sweep_line_to_heatmap_edge(self):
         window = plot2d.__new__(plot2d)
@@ -1561,7 +1633,7 @@ class HeatmapHoverOutlineTestCase(unittest.TestCase):
 
         self.assertEqual(line.sweep_index, 3)
         self.assertAlmostEqual(line.value(), 3.5)
-        self.assertEqual(window.sweep_moved.calls, [(8, 3)])
+        self.assertEqual(window.sweep_moved.calls, [(8, 3.5)])
 
     def test_manual_colorbar_range_sets_levels_and_disables_refresh_autoscale(self):
         window = plot2d.__new__(plot2d)

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -128,6 +128,20 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertEqual(window.load_calls, ["load"])
         self.assertEqual(window.restart_intervals, [0.2])
 
+    def test_completion_sync_is_coalesced_while_worker_is_busy(self):
+        window = self._window(worker_running=True)
+        window.last_ds_len = window.ds.number_of_results
+
+        plotWidget.refreshWindow(window)
+
+        self.assertEqual(window.load_calls, [])
+        self.assertTrue(window._refresh_pending)
+
+        window.worker.running = False
+        plotWidget._run_pending_refresh(window)
+
+        self.assertEqual(window.load_calls, ["load"])
+
     def test_secondary_trace_restart_does_not_depend_on_dictionary_order(self):
         window = self._window(worker_running=False)
         window.ds.running = False

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -44,6 +44,12 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         def __init__(self, running):
             self.running = running
 
+    def test_format_num_uses_requested_significant_figures(self):
+        self.assertEqual(plotWidget.formatNum(12.345, sf=3), "12.3")
+        self.assertEqual(plotWidget.formatNum(0.012345, sf=3), "1.23e-02")
+        self.assertEqual(plotWidget.formatNum(999.9, sf=3), "1.00e+03")
+        self.assertEqual(plotWidget.formatNum(12345.0, sf=3), "1.23e+04")
+
     def _window(self, *, worker_running):
         window = plotWidget.__new__(plotWidget)
         window.monitor = self.Timer()
@@ -1691,7 +1697,19 @@ class RunListParentLookupTestCase(unittest.TestCase):
             host._init_colorbar_scale_controls()
             action_texts = [action.text().replace("&", "") for action in host.vbMenu.actions()]
 
-            self.assertNotIn("Color Scale...", action_texts)
+            self.assertIn("Color Scale...", action_texts)
+            self.assertEqual(host.colorbar_min_label.text(), "Minimum")
+            self.assertEqual(host.colorbar_max_label.text(), "Maximum")
+            self.assertIs(host.colorbar_min_label.buddy(), host.colorbar_min_text)
+            self.assertIs(host.colorbar_max_label.buddy(), host.colorbar_max_text)
+            self.assertEqual(
+                host.colorbar_min_text.accessibleName(),
+                "Color scale minimum",
+                )
+            self.assertEqual(
+                host.colorbar_max_text.accessibleName(),
+                "Color scale maximum",
+                )
             self.assertGreater(host._colorbar_colormap_row("Greys"), -1)
             self.assertGreater(host._colorbar_colormap_row("Purples"), -1)
             self.assertGreater(host._colorbar_colormap_row("CET-C1"), -1)


### PR DESCRIPTION
## Summary

- Correct live and completed run metadata for unplanned, sparse, interrupted, and heterogeneous acquisitions. Shape/count provenance is explicit, stale observations are replaced, standalone measurements are classified correctly, and distinct tuple counts stay in SQL.
- Fix shaped serpentine heatmaps by detecting non-rectilinear coordinate grids and rebuilding them from recorded coordinates instead of mirroring alternate rows.
- Keep 2D cut windows synchronized by physical setpoint coordinate, including after large heatmaps reload a visible subset; cuts outside the loaded range are preserved without being clamped to an unrelated edge.
- Coalesce live refresh work while a worker is active and respect a manual 0 s refresh interval from startup. Positive sub-millisecond intervals no longer create an accidental zero-millisecond timer.
- Harden configuration and CLI updates: reject non-finite/non-standard JSON numbers, require real integers for Qt integer settings, enforce Qt/UI bounds, preserve numeric strings, and save strict JSON atomically.
- Bound large-database UI work: compact run rows replace per-run preview widgets above 500 runs, setpoint-width scans and selected-run summaries are cached, full-table setpoint grouping is skipped above 100,000 results, unchanged sort keys avoid full-list resorts, and detail batches are larger.
- Preserve the earlier preview, accessibility, responsive-layout, formatting, CLI-path, shortcut, documentation, and packaging fixes already included in this branch.

## Root causes and impact

Shaped QCoDeS data may describe a serpentine acquisition even though its array shape looks image-like. Treating the dependent array as a rectilinear image silently reversed alternate rows. Large-heatmap detail reloads introduced a related ambiguity by sharing local array indices between a visible subset and a full cut window. Both paths now use recorded physical coordinates as the source of truth.

Refresh completion checks could start a replacement worker while another read was still active, and startup bypassed the normal “0 means manual” timer path. Configuration validation also followed permissive JSON/JSON Schema numeric semantics that do not match Qt’s integer APIs.

The database browser performed several O(rows) or O(runs) operations repeatedly on the GUI thread. The new bounds and caches retain full inline previews and From/To summaries for normal databases; oversized databases use compact rows and shape-derived step counts so selection and scrolling remain responsive.

## Validation

- `QT_QPA_PLATFORM=offscreen .venv-mac/bin/python -m pytest -W error` — 523 passed
- `.venv-mac/bin/python -m ruff check .`
- `.venv-mac/bin/python -m mypy`
- `.venv-mac/bin/python -m build`
- `.venv-mac/bin/python -m twine check dist/*`
- Offscreen `.venv-mac/bin/python -m qplot` launch smoke test

## Follow-up consideration

For selected runs above 100,000 results, the details panel intentionally omits SQL-derived setpoint From/To values rather than running a full-table distinct grouping on the GUI thread. Shape-derived step counts remain available. A future background summary worker could restore those optional values without reintroducing UI freezes.