### PR TITLE
Fix high-offset serpentine sweeps and preview shutdown

### DIFF
--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -1270,9 +1270,21 @@ class loader(QtCore.QRunnable):
         valid = np.isfinite(param_data) & np.isfinite(expected)
         if not np.any(valid):
             return True
+
+        # Compare positions relative to the sweep itself.  Using a relative
+        # tolerance on the raw coordinates makes the tolerance grow with an
+        # arbitrary offset (for example, a GHz carrier), and can therefore
+        # hide a genuine sub-Hz serpentine reversal.
+        finite_values = values[np.isfinite(values)]
+        origin = finite_values[0]
+        centred_values = finite_values - origin
+        span = float(np.max(np.abs(centred_values)))
+        if not np.isfinite(span) or span == 0:
+            span = 1.0
+
         return bool(np.all(np.isclose(
-            param_data[valid],
-            expected[valid],
+            (param_data[valid] - origin) / span,
+            (expected[valid] - origin) / span,
             rtol=1e-10,
             atol=1e-12,
             )))

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from collections import OrderedDict
 
 import numpy as np
@@ -68,11 +69,19 @@ class PreviewTab(qtw.QWidget):
         self.errors = {}
         self.queue = {}
         self.active: set[tuple[int, str]] = set()
+        self._workers = {}
         self.metadata_signatures = {}
         self._start_scheduled = False
+        self._shutting_down = False
 
-        self.thread_pool = QtCore.QThreadPool(self)
-        self.thread_pool.setMaxThreadCount(1)
+        # A widget-owned QThreadPool waits for its runnables in the QObject
+        # destructor.  If a Python QRunnable needs the GIL while SIP is
+        # deleting this widget, both threads can wait forever.  The shared Qt
+        # pool outlives the widget, so deletion never waits on preview work.
+        thread_pool = QtCore.QThreadPool.globalInstance()
+        if thread_pool is None:
+            raise RuntimeError("Qt global thread pool is unavailable")
+        self.thread_pool = thread_pool
 
         self.scroll_area = qtw.QScrollArea()
         self.scroll_area.setWidgetResizable(True)
@@ -91,6 +100,25 @@ class PreviewTab(qtw.QWidget):
         self.setLayout(layout)
 
         self._show_message("Select a run")
+
+
+    def shutdown(self):
+        """Stop scheduling preview work without waiting for active queries."""
+        if self._shutting_down:
+            return
+
+        self._shutting_down = True
+        self.generation += 1
+        self.queue = {}
+        self.active = set()
+        self._start_scheduled = False
+        for worker in tuple(self._workers.values()):
+            worker.cancel()
+
+
+    def closeEvent(self, event):
+        self.shutdown()
+        super().closeEvent(event)
 
 
     def preferred_tab_height(self):
@@ -315,6 +343,8 @@ class PreviewTab(qtw.QWidget):
 
 
     def _enqueue(self, guid, priority=0, allow_active=False):
+        if self._shutting_down:
+            return
         if guid in self.cache:
             return
         if guid in self.errors:
@@ -373,7 +403,7 @@ class PreviewTab(qtw.QWidget):
 
 
     def _schedule_start_next(self):
-        if self._start_scheduled:
+        if self._shutting_down or self._start_scheduled:
             return
 
         self._start_scheduled = True
@@ -386,7 +416,7 @@ class PreviewTab(qtw.QWidget):
 
 
     def _start_next(self):
-        if any(
+        if self._shutting_down or any(
                 generation == self.generation
                 for generation, _guid in self.active
                 ) or not self.queue:
@@ -411,14 +441,18 @@ class PreviewTab(qtw.QWidget):
             self.preview_size,
             )
         worker.signals.finished.connect(self._worker_finished)
+        self._workers[(self.generation, guid)] = worker
         self.thread_pool.start(worker)
 
 
     @QtCore.pyqtSlot(int, str, object, object)
     def _worker_finished(self, generation, guid, previews, error):
         active_key = (generation, guid)
+        self._workers.pop(active_key, None)
         was_active = active_key in self.active
         self.active.discard(active_key)
+        if self._shutting_down:
+            return
         if was_active and generation == self.generation:
             self.previewGenerationChanged.emit(guid, False)
 
@@ -705,15 +739,26 @@ class PreviewWorker(QtCore.QRunnable):
         self.guid = guid
         self.metadata = metadata
         self.preview_size = preview_size
+        self._cancelled = threading.Event()
+
+
+    def cancel(self):
+        self._cancelled.set()
 
 
     def run(self):
         try:
-            previews = generate_run_previews(
-                self.database_path,
-                self.metadata,
-                size=self.preview_size,
-            )
+            if self._cancelled.is_set():
+                previews = []
+            else:
+                previews = generate_run_previews(
+                    self.database_path,
+                    self.metadata,
+                    size=self.preview_size,
+                    is_cancelled=self._cancelled.is_set,
+                )
+            if self._cancelled.is_set():
+                previews = []
             self.signals.finished.emit(self.generation, self.guid, previews, None)
         except Exception as error:
             log_exception("Preview generation failed", error, __name__)
@@ -724,7 +769,15 @@ class PreviewSignals(QtCore.QObject):
     finished = QtCore.pyqtSignal(int, str, object, object)
 
 
-def generate_run_previews(database_path, metadata, size=PREVIEW_SIZE):
+def generate_run_previews(
+        database_path,
+        metadata,
+        size=PREVIEW_SIZE,
+        is_cancelled=None,
+        ):
+    if is_cancelled is not None and is_cancelled():
+        return []
+
     table_name = metadata.get("result_table_name")
     if not database_path or not table_name:
         return []
@@ -740,6 +793,8 @@ def generate_run_previews(database_path, metadata, size=PREVIEW_SIZE):
         cursor = conn.cursor()
         available_columns = _table_columns(cursor, table_name)
         for parameter, axes in dependencies.items():
+            if is_cancelled is not None and is_cancelled():
+                break
             if parameter not in available_columns:
                 continue
 

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -409,6 +409,9 @@ class MainWindow(
                 event.ignore()
                 return
 
+        preview = getattr(getattr(self, "infoBox", None), "preview", None)
+        if preview is not None:
+            preview.shutdown()
         self.startupDatabaseTimer.stop()
         worker = getattr(self, "_database_load_worker", None)
         if worker is not None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -115,6 +115,42 @@ class ToolFunctionTestCase(unittest.TestCase):
             np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0]]),
             )
 
+    def test_shaped_2d_loader_maps_high_offset_serpentine_rows(self):
+        worker = loader.__new__(loader)
+        worker.axes_dict = {"x": "frequency", "y": "slow"}
+        worker.param = type(
+            "Param",
+            (),
+            {"depends_on_": ("slow", "frequency")},
+            )()
+        worker.param_dict = {
+            "slow": type("Param", (), {"name": "slow"})(),
+            "frequency": type("Param", (), {"name": "frequency"})(),
+            }
+
+        frequency = 5e9 + np.array([
+            [0.0, 0.1, 0.2],
+            [0.2, 0.1, 0.0],
+            ])
+        slow = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        signal = np.array([[0.0, 1.0, 2.0], [12.0, 11.0, 10.0]])
+
+        axis_data, _axis_param, data_grid = loader.for_shaped_2d(
+            worker,
+            {"slow": slow, "frequency": frequency},
+            signal,
+            )
+
+        np.testing.assert_array_equal(
+            axis_data["x"],
+            5e9 + np.array([0.0, 0.1, 0.2]),
+            )
+        np.testing.assert_array_equal(axis_data["y"], np.array([0.0, 1.0]))
+        np.testing.assert_array_equal(
+            data_grid,
+            np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0]]),
+            )
+
     def test_worker_canonicalizes_descending_heatmap_axes_and_grid(self):
         worker = loader.__new__(loader)
         worker.axis_data = {

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -1,6 +1,9 @@
 import os
 import sqlite3
+import subprocess
+import sys
 import tempfile
+import textwrap
 import unittest
 from unittest.mock import patch
 
@@ -12,6 +15,7 @@ from qplot.windows._widgets import preview as preview_module
 from qplot.windows._widgets import treeWidgets
 from qplot.windows._widgets.preview import (
     PREVIEW_BACKGROUND_COLOR,
+    PREVIEW_SELECTED_PRIORITY,
     PREVIEW_SELECTED_PROPERTY,
     PREVIEW_SIZE,
     DraggablePreviewImageLabel,
@@ -709,6 +713,70 @@ class RunDetailsTabsTestCase(unittest.TestCase):
 
         self.assertEqual(preview.queue, {})
         self.assertEqual(generation_changes, [])
+
+    def test_preview_tab_shutdown_cancels_workers_without_waiting(self):
+        preview = PreviewTab(preview_size=100)
+
+        class Worker:
+            cancelled = False
+
+            def cancel(self):
+                self.cancelled = True
+
+        worker = Worker()
+        preview.queue = {"queued-guid": PREVIEW_SELECTED_PRIORITY}
+        preview.active = {(preview.generation, "active-guid")}
+        preview._workers = {
+            (preview.generation, "active-guid"): worker,
+            }
+
+        preview.shutdown()
+
+        self.assertTrue(preview._shutting_down)
+        self.assertTrue(worker.cancelled)
+        self.assertEqual(preview.queue, {})
+        self.assertEqual(preview.active, set())
+
+    def test_deleting_preview_does_not_wait_for_python_worker(self):
+        script = textwrap.dedent("""
+            import threading
+            import time
+
+            from PyQt6 import QtCore, QtWidgets, sip
+
+            from qplot.windows._widgets.preview import PreviewTab
+
+            app = QtWidgets.QApplication([])
+            started = threading.Event()
+
+            class Worker(QtCore.QRunnable):
+                def run(self):
+                    started.set()
+                    time.sleep(0.2)
+
+            preview = PreviewTab(preview_size=100)
+            worker = Worker()
+            preview.thread_pool.start(worker)
+            if not started.wait(2):
+                raise RuntimeError("Preview worker did not start")
+
+            sip.delete(preview)
+            if not QtCore.QThreadPool.globalInstance().waitForDone(2000):
+                raise RuntimeError("Preview worker did not finish")
+            """)
+        env = os.environ.copy()
+        env["QT_QPA_PLATFORM"] = "offscreen"
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=False,
+            env=env,
+            text=True,
+            timeout=5,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_preview_tab_marks_only_active_worker_as_generating(self):
         preview = PreviewTab(preview_size=100)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -1214,6 +1214,13 @@ class CloseAllPlotsTestCase(unittest.TestCase):
             def cancel(self):
                 self.cancelled = True
 
+        class Preview:
+            def __init__(self):
+                self.shut_down = False
+
+            def shutdown(self):
+                self.shut_down = True
+
         class Event:
             def __init__(self):
                 self.accepted = False
@@ -1236,6 +1243,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
                 self._database_load_active = True
                 self._database_load_state = {"loading": True}
                 self.monitor = Timer()
+                self.infoBox = type("InfoBox", (), {"preview": Preview()})()
 
         def fake_confirmation(window, title, message, config_key, *args):
             confirmations.append((title, message, config_key))
@@ -1266,6 +1274,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
         self.assertFalse(harness._database_load_active)
         self.assertIsNone(harness._database_load_state)
         self.assertIsNone(harness._database_load_worker)
+        self.assertTrue(harness.infoBox.preview.shut_down)
         self.assertTrue(harness.monitor.stopped)
         self.assertEqual(closed_all_windows, [True])
 


### PR DESCRIPTION
## Summary

- detect shaped serpentine sweeps using coordinates normalized to the sweep span, so large absolute offsets cannot hide real reversals
- run previews on Qt's shared thread pool so deleting the preview widget never waits on a Python runnable
- add non-blocking preview shutdown, cooperative worker cancellation, and main-window shutdown integration
- add regression coverage for a 5 GHz sweep with 0.1 Hz steps and for deleting a preview during active Python work

## Root cause

The rectilinearity check applied a relative tolerance directly to absolute coordinates. At GHz-scale offsets, that tolerance was larger than the sweep step and alternate serpentine rows were silently treated as rectilinear.

The preview widget owned its QThreadPool. QObject destruction waits for owned runnables, while an active Python runnable can require the GIL held by SIP during deletion, producing a shutdown deadlock.

## Impact

High-offset serpentine datasets now preserve their recorded coordinate ordering instead of mirroring alternate rows. Preview and application shutdown no longer block on widget-owned Python work; queued work is discarded and active preview workers are cancelled cooperatively.

## Validation

- 526 tests completed without failures with warnings treated as errors
- targeted serpentine and preview-lifecycle regressions pass
- `.venv-mac/bin/python -m ruff check .`
- configured mypy checks
- offscreen qPlot GUI smoke launch
