### PR TITLE
Prepare 1.5.0 beta 4 with test database generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+## 1.5.0-b4 - 2026-08-01
+
 ### Added
 
 - Add `qplot-generate-db` for creating 1D and 2D QCoDeS test runs with randomly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+### Added
+
+- Add `qplot-generate-db` for creating 1D and 2D QCoDeS test runs with randomly
+  phased and scaled sinusoidal data from spreadsheet-friendly CSV
+  specifications, including CLI and File-menu actions for writing a ready-to-use
+  example CSV, revealing its folder, and generating the database in the
+  background.
+
 ## 1.5.0-b3 - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ part of the GUI test or support matrix.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b3`; it is documented below but is not used for the default install.
+is `1.5.0-b4`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -48,7 +48,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b3
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b4
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,6 +176,11 @@ should call helpers such as `cache_data`, `cache_rundescriber`, and
 `set_parameter_complete` instead of reaching into `_data`, `_dataset`, or
 `_complete` directly.
 
+`src/qplot/testdata.py` validates spreadsheet-friendly CSV specifications and
+writes synthetic QCoDeS databases for testing. It backs the
+`qplot-generate-db` command and remains separate from qPlot's enforced
+read-only database-loading path.
+
 `src/qplot/tools/worker.py` defines the background loader used by plot windows.
 It loads data, reshapes it for the plot type, applies selected operations, and
 emits results back to the GUI thread.

--- a/docs/demo-data.md
+++ b/docs/demo-data.md
@@ -4,6 +4,37 @@ qPlot does not keep generated QCoDeS databases in the repository. For demos,
 screenshots, and manual live-refresh checks, use the local helper scripts from
 the repository root.
 
+## Generate a Test Database
+
+In qPlot, use `File -> Generate Test Data -> Create Example CSV...` to choose
+where to save a ready-to-use specification. qPlot creates the file, reveals it
+in Finder on macOS, or opens its containing folder in the platform file manager.
+Edit the CSV in a spreadsheet application, then use
+`File -> Generate Test Data -> Generate Database from CSV...` to choose the CSV
+and its output `.db` file. Generation runs in the background so qPlot remains
+responsive.
+
+The installed `qplot-generate-db` command provides the same workflow from a
+terminal. Start by writing an example CSV:
+
+```console
+qplot-generate-db --write-example test-runs.csv
+```
+
+Edit the CSV in a spreadsheet application, then generate the database:
+
+```console
+qplot-generate-db test-runs.csv test-runs.db
+```
+
+Every nonblank CSV row creates one run, named `run_1`, `run_2`, and so on. A 1D
+row sweeps `V_SD`; a 2D row sweeps both `V_SD` and `V_G`. Each run receives a
+random sinusoid amplitude and phase. The measured parameter name, label, unit,
+sweep ranges, and point counts are set in the CSV. Existing CSV or database
+files are not replaced unless `--overwrite` is supplied.
+
+Run `qplot-generate-db --help` for the complete command reference.
+
 ## Screenshots
 
 The committed screenshots below are generated from a small synthetic database.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,13 +27,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.0-b3`. The package metadata uses the PEP 440 normal
-form `1.5.0b3`; the GitHub release tag should be `v1.5.0-b3`.
+The current beta is `1.5.0-b4`. The package metadata uses the PEP 440 normal
+form `1.5.0b4`; the GitHub release tag should be `v1.5.0-b4`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b3
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b4
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b3`, even if the Git tag includes a separator,
-   such as `v1.5.0-b3`.
+   package form, such as `1.5.0b4`, even if the Git tag includes a separator,
+   such as `v1.5.0-b4`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -104,6 +104,12 @@ Common actions:
 * `File -> Refresh` checks the current database for new runs.
 * `File -> Open Database Folder` opens the folder containing the loaded
   database.
+* `File -> Generate Test Data -> Create Example CSV...` writes a spreadsheet
+  template, reveals it in Finder on macOS, or opens its containing folder in
+  the platform file manager.
+* `File -> Generate Test Data -> Generate Database from CSV...` creates a
+  QCoDeS test database from an edited specification without blocking the qPlot
+  interface.
 * `Options -> Preferences...` edits common theme, plot mouse mode, default
   load location, preview, refresh, confirmation, and runtime settings. On
   macOS this appears as `qPlot -> Preferences...`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b3"
+version = "1.5.0b4"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
 [project.scripts]
 qplot = "qplot.__main__:run"
 qplot-cfg = "qplot.configuration.scripts:scripts"
+qplot-generate-db = "qplot.testdata:main"
 
 [project.urls]
 Homepage = "https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git"
@@ -114,6 +115,7 @@ files = [
     "src/qplot/tools/operation_registry.py",
     "src/qplot/tools/plot_tools.py",
     "src/qplot/tools/worker.py",
+    "src/qplot/testdata.py",
     "src/qplot/windows/__init__.py",
     "src/qplot/windows/_commands.py",
     "src/qplot/windows/main.py",

--- a/src/qplot/testdata.py
+++ b/src/qplot/testdata.py
@@ -1,0 +1,484 @@
+"""Generate synthetic QCoDeS databases from CSV specifications."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import re
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from qcodes.dataset import Measurement, new_experiment
+from qcodes.dataset.sqlite.database import connect
+from qcodes.parameters import ManualParameter
+
+CSV_COLUMNS = (
+    "dimensions",
+    "measured_name",
+    "measured_label",
+    "measured_unit",
+    "v_sd_start",
+    "v_sd_stop",
+    "v_sd_points",
+    "v_g_start",
+    "v_g_stop",
+    "v_g_points",
+)
+
+EXAMPLE_ROWS = (
+    ("1", "current", "Current", "nA", "-0.01", "0.01", "101", "", "", ""),
+    (
+        "1",
+        "conductance",
+        "Conductance",
+        "uS",
+        "-0.1",
+        "0.1",
+        "501",
+        "",
+        "",
+        "",
+    ),
+    (
+        "2",
+        "current",
+        "Current",
+        "nA",
+        "-0.01",
+        "0.01",
+        "121",
+        "-1",
+        "1",
+        "81",
+    ),
+    (
+        "2",
+        "conductance",
+        "Conductance",
+        "uS",
+        "-0.1",
+        "0.1",
+        "201",
+        "-3",
+        "3",
+        "101",
+    ),
+)
+
+_PARAMETER_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_MINIMUM_AMPLITUDE = 0.5
+_MAXIMUM_AMPLITUDE = 1.5
+
+
+class SpecificationError(ValueError):
+    """Raised when a test-database CSV specification is invalid."""
+
+
+class GenerationCancelled(RuntimeError):
+    """Raised internally when test-database generation is cancelled."""
+
+
+@dataclass(frozen=True)
+class RunSpecification:
+    """Validated settings for one generated QCoDeS run."""
+
+    dimensions: int
+    measured_name: str
+    measured_label: str
+    measured_unit: str
+    v_sd_start: float
+    v_sd_stop: float
+    v_sd_points: int
+    v_g_start: float | None = None
+    v_g_stop: float | None = None
+    v_g_points: int | None = None
+
+    @property
+    def point_count(self):
+        """Return the number of measured points in the run."""
+        if self.dimensions == 1:
+            return self.v_sd_points
+        assert self.v_g_points is not None
+        return self.v_sd_points * self.v_g_points
+
+
+def _row_error(line_number, message):
+    return SpecificationError(f"CSV row {line_number}: {message}")
+
+
+def _required(row, column, line_number):
+    value = (row.get(column) or "").strip()
+    if not value:
+        raise _row_error(line_number, f"{column} is required")
+    return value
+
+
+def _finite_float(row, column, line_number):
+    value = _required(row, column, line_number)
+    try:
+        number = float(value)
+    except ValueError as error:
+        raise _row_error(line_number, f"{column} must be a number") from error
+    if not math.isfinite(number):
+        raise _row_error(line_number, f"{column} must be finite")
+    return number
+
+
+def _point_count(row, column, line_number):
+    value = _required(row, column, line_number)
+    try:
+        points = int(value)
+    except ValueError as error:
+        raise _row_error(line_number, f"{column} must be an integer") from error
+    if points < 2:
+        raise _row_error(line_number, f"{column} must be at least 2")
+    return points
+
+
+def _parse_row(row, line_number):
+    dimensions_value = _required(row, "dimensions", line_number)
+    try:
+        dimensions = int(dimensions_value)
+    except ValueError as error:
+        raise _row_error(line_number, "dimensions must be 1 or 2") from error
+    if dimensions not in (1, 2):
+        raise _row_error(line_number, "dimensions must be 1 or 2")
+
+    measured_name = _required(row, "measured_name", line_number)
+    if not _PARAMETER_NAME_PATTERN.fullmatch(measured_name):
+        raise _row_error(
+            line_number,
+            "measured_name must start with a letter or underscore and contain "
+            "only letters, numbers, and underscores",
+        )
+    if measured_name.lower() in {"v_sd", "v_g"}:
+        raise _row_error(
+            line_number,
+            "measured_name cannot be V_SD or V_G because those names are swept",
+        )
+
+    measured_label = _required(row, "measured_label", line_number)
+    measured_unit = (row.get("measured_unit") or "").strip()
+    v_sd_start = _finite_float(row, "v_sd_start", line_number)
+    v_sd_stop = _finite_float(row, "v_sd_stop", line_number)
+    if v_sd_start == v_sd_stop:
+        raise _row_error(line_number, "v_sd_start and v_sd_stop must differ")
+    v_sd_points = _point_count(row, "v_sd_points", line_number)
+
+    gate_values = tuple((row.get(column) or "").strip() for column in CSV_COLUMNS[7:])
+    if dimensions == 1:
+        if any(gate_values):
+            raise _row_error(
+                line_number,
+                "v_g_start, v_g_stop, and v_g_points must be blank for a 1D run",
+            )
+        return RunSpecification(
+            dimensions=dimensions,
+            measured_name=measured_name,
+            measured_label=measured_label,
+            measured_unit=measured_unit,
+            v_sd_start=v_sd_start,
+            v_sd_stop=v_sd_stop,
+            v_sd_points=v_sd_points,
+        )
+
+    v_g_start = _finite_float(row, "v_g_start", line_number)
+    v_g_stop = _finite_float(row, "v_g_stop", line_number)
+    if v_g_start == v_g_stop:
+        raise _row_error(line_number, "v_g_start and v_g_stop must differ")
+    v_g_points = _point_count(row, "v_g_points", line_number)
+    return RunSpecification(
+        dimensions=dimensions,
+        measured_name=measured_name,
+        measured_label=measured_label,
+        measured_unit=measured_unit,
+        v_sd_start=v_sd_start,
+        v_sd_stop=v_sd_stop,
+        v_sd_points=v_sd_points,
+        v_g_start=v_g_start,
+        v_g_stop=v_g_stop,
+        v_g_points=v_g_points,
+    )
+
+
+def read_specifications(csv_path):
+    """Read and validate all nonblank rows in a generator CSV file."""
+    csv_path = Path(csv_path)
+    try:
+        handle = csv_path.open("r", encoding="utf-8-sig", newline="")
+    except OSError as error:
+        raise SpecificationError(f"Could not open {csv_path}: {error}") from error
+
+    with handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames
+        if fieldnames is None:
+            raise SpecificationError("CSV file is empty")
+        fieldnames = [name.strip() for name in fieldnames]
+        reader.fieldnames = fieldnames
+        if len(fieldnames) != len(set(fieldnames)):
+            raise SpecificationError("CSV header contains duplicate columns")
+        missing = [column for column in CSV_COLUMNS if column not in fieldnames]
+        extra = [column for column in fieldnames if column not in CSV_COLUMNS]
+        if missing or extra:
+            details = []
+            if missing:
+                details.append(f"missing columns: {', '.join(missing)}")
+            if extra:
+                details.append(f"unexpected columns: {', '.join(extra)}")
+            raise SpecificationError("Invalid CSV header (" + "; ".join(details) + ")")
+
+        specifications = []
+        for line_number, row in enumerate(reader, start=2):
+            if None in row and any(str(value).strip() for value in row[None]):
+                raise _row_error(line_number, "contains more values than the header")
+            if not any((row.get(column) or "").strip() for column in CSV_COLUMNS):
+                continue
+            specifications.append(_parse_row(row, line_number))
+
+    if not specifications:
+        raise SpecificationError("CSV file contains no run specifications")
+    return specifications
+
+
+def write_example_csv(csv_path, overwrite=False):
+    """Write a ready-to-use example generator CSV and return its path."""
+    csv_path = Path(csv_path)
+    if csv_path.suffix.lower() != ".csv":
+        raise SpecificationError("Example output path must end in .csv")
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    mode = "w" if overwrite else "x"
+    try:
+        with csv_path.open(mode, encoding="utf-8-sig", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(CSV_COLUMNS)
+            writer.writerows(EXAMPLE_ROWS)
+    except FileExistsError as error:
+        raise SpecificationError(
+            f"{csv_path} already exists; use --overwrite to replace it"
+        ) from error
+    except OSError as error:
+        raise SpecificationError(f"Could not write {csv_path}: {error}") from error
+    return csv_path
+
+
+def _raise_if_cancelled(cancelled_callback):
+    if cancelled_callback is not None and cancelled_callback():
+        raise GenerationCancelled("Test-database generation was cancelled")
+
+
+def _write_run(
+        experiment,
+        run_number,
+        specification,
+        random_generator,
+        cancelled_callback=None,
+        ):
+    _raise_if_cancelled(cancelled_callback)
+    v_sd = ManualParameter("V_SD", label="Source-drain voltage", unit="V")
+    measured = ManualParameter(
+        specification.measured_name,
+        label=specification.measured_label,
+        unit=specification.measured_unit,
+    )
+    measurement = Measurement(exp=experiment, name=f"run_{run_number}")
+    measurement.register_parameter(v_sd)
+
+    v_sd_values = np.linspace(
+        specification.v_sd_start,
+        specification.v_sd_stop,
+        specification.v_sd_points,
+    )
+    v_sd_normalized = np.linspace(0.0, 1.0, specification.v_sd_points)
+    amplitude = random_generator.uniform(_MINIMUM_AMPLITUDE, _MAXIMUM_AMPLITUDE)
+    v_sd_phase = random_generator.uniform(0.0, 2.0 * np.pi)
+
+    if specification.dimensions == 1:
+        measurement.register_parameter(measured, setpoints=(v_sd,))
+        measured_values = amplitude * np.sin(
+            4.0 * np.pi * v_sd_normalized + v_sd_phase
+        )
+        with measurement.run() as datasaver:
+            for v_sd_value, measured_value in zip(
+                v_sd_values, measured_values, strict=True
+            ):
+                _raise_if_cancelled(cancelled_callback)
+                datasaver.add_result(
+                    (v_sd, float(v_sd_value)),
+                    (measured, float(measured_value)),
+                )
+        return
+
+    assert specification.v_g_start is not None
+    assert specification.v_g_stop is not None
+    assert specification.v_g_points is not None
+    v_g = ManualParameter("V_G", label="Gate voltage", unit="V")
+    measurement.register_parameter(v_g)
+    measurement.register_parameter(measured, setpoints=(v_sd, v_g))
+    v_g_values = np.linspace(
+        specification.v_g_start,
+        specification.v_g_stop,
+        specification.v_g_points,
+    )
+    v_g_normalized = np.linspace(0.0, 1.0, specification.v_g_points)
+    v_g_phase = random_generator.uniform(0.0, 2.0 * np.pi)
+
+    with measurement.run() as datasaver:
+        for v_sd_index, v_sd_value in enumerate(v_sd_values):
+            for v_g_index, v_g_value in enumerate(v_g_values):
+                _raise_if_cancelled(cancelled_callback)
+                measured_value = 0.5 * (
+                    amplitude
+                    * np.sin(
+                        4.0 * np.pi * v_sd_normalized[v_sd_index] + v_sd_phase
+                    )
+                    + amplitude
+                    * np.cos(
+                        4.0 * np.pi * v_g_normalized[v_g_index] + v_g_phase
+                    )
+                )
+                datasaver.add_result(
+                    (v_sd, float(v_sd_value)),
+                    (v_g, float(v_g_value)),
+                    (measured, float(measured_value)),
+                )
+
+
+def generate_database(
+        specifications,
+        database_path,
+        overwrite=False,
+        rng=None,
+        cancelled_callback=None,
+        ):
+    """Generate a complete QCoDeS database from validated specifications."""
+    specifications = list(specifications)
+    if not specifications:
+        raise SpecificationError("At least one run specification is required")
+
+    database_path = Path(database_path)
+    if database_path.suffix.lower() != ".db":
+        raise SpecificationError("Database output path must end in .db")
+    if database_path.exists() and not overwrite:
+        raise SpecificationError(
+            f"{database_path} already exists; use --overwrite to replace it"
+        )
+
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_handle = tempfile.NamedTemporaryFile(
+        prefix=f".{database_path.stem}-",
+        suffix=".db",
+        dir=database_path.parent,
+        delete=False,
+    )
+    temporary_path = Path(temporary_handle.name)
+    temporary_handle.close()
+    temporary_path.unlink()
+
+    random_generator = rng if rng is not None else np.random.default_rng()
+    try:
+        connection = connect(temporary_path)
+        try:
+            experiment = new_experiment(
+                "qplot_test_database",
+                sample_name="synthetic",
+                conn=connection,
+            )
+            for run_number, specification in enumerate(specifications, start=1):
+                _write_run(
+                    experiment,
+                    run_number,
+                    specification,
+                    random_generator,
+                    cancelled_callback=cancelled_callback,
+                )
+            _raise_if_cancelled(cancelled_callback)
+        finally:
+            connection.close()
+        os.replace(temporary_path, database_path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return database_path
+
+
+def generate_database_from_csv(
+        csv_path,
+        database_path,
+        overwrite=False,
+        rng=None,
+        cancelled_callback=None,
+        ):
+    """Validate a CSV and generate its QCoDeS database."""
+    specifications = read_specifications(csv_path)
+    path = generate_database(
+        specifications,
+        database_path,
+        overwrite=overwrite,
+        rng=rng,
+        cancelled_callback=cancelled_callback,
+    )
+    return path, specifications
+
+
+def _argument_parser():
+    parser = argparse.ArgumentParser(
+        prog="qplot-generate-db",
+        description="Generate sinusoidal test runs in a QCoDeS database.",
+    )
+    parser.add_argument("specification", nargs="?", help="input CSV specification")
+    parser.add_argument("database", nargs="?", help="output QCoDeS .db file")
+    parser.add_argument(
+        "--write-example",
+        metavar="CSV",
+        help="write a ready-to-use example CSV instead of generating a database",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace an existing output file",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None):
+    """Run the ``qplot-generate-db`` command-line interface."""
+    parser = _argument_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.write_example:
+            if args.specification or args.database:
+                parser.error("positional arguments cannot be used with --write-example")
+            output_path = write_example_csv(args.write_example, overwrite=args.overwrite)
+            print(f"Wrote example CSV: {output_path}")
+            return 0
+
+        if not args.specification or not args.database:
+            parser.error(
+                "specification and database are required unless --write-example is used"
+            )
+        output_path, specifications = generate_database_from_csv(
+            args.specification,
+            args.database,
+            overwrite=args.overwrite,
+        )
+    except (OSError, SpecificationError) as error:
+        parser.exit(2, f"qplot-generate-db: error: {error}\n")
+
+    total_points = sum(specification.point_count for specification in specifications)
+    print(
+        f"Generated {output_path} with {len(specifications)} runs "
+        f"and {total_points} points."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/qplot/windows/_commands.py
+++ b/src/qplot/windows/_commands.py
@@ -194,6 +194,18 @@ COMMANDS: dict[str, CommandSpec] = {
         "Ctrl+Shift+D",
         help_section="General",
     ),
+    "testdata.create_csv": CommandSpec(
+        "testdata.create_csv",
+        "Create Example &CSV...",
+        "Create an example CSV specification for generated test databases",
+        object_name="createTestDatabaseCsvAction",
+    ),
+    "testdata.generate_database": CommandSpec(
+        "testdata.generate_database",
+        "Generate &Database from CSV...",
+        "Generate a QCoDeS test database from a CSV specification",
+        object_name="generateTestDatabaseAction",
+    ),
     "window.main_front_back": CommandSpec(
         "window.main_front_back",
         "Main Window &Front/Back",

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -1,4 +1,7 @@
 import os
+import subprocess
+import sys
+import threading
 from time import perf_counter
 
 from PyQt6 import QtCore, QtGui
@@ -16,6 +19,12 @@ from qplot.datahandling.database import (
 )
 from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.diagnostics import log_event, log_exception
+from qplot.testdata import (
+    GenerationCancelled,
+    generate_database,
+    read_specifications,
+    write_example_csv,
+)
 
 from ._widgets.details_tables import (
     CopyableTableWidget,
@@ -112,6 +121,71 @@ def _database_info_rows_clipboard_text(rows):
     return "\n".join("\t".join(row) for row in rows)
 
 
+def reveal_file_in_file_manager(file_path):
+    """Reveal a generated file in Finder, or open its folder elsewhere."""
+    file_path = os.path.abspath(file_path)
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["open", "-R", file_path],
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+    folder = os.path.dirname(file_path)
+    return QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(folder))
+
+
+class TestDatabaseGenerationSignals(QtCore.QObject):
+    """Signals emitted by background test-database generation."""
+
+    finished = QtCore.pyqtSignal(str, object, object)
+
+
+class TestDatabaseGenerationWorker(QtCore.QRunnable):
+    """Generate a test database without blocking the GUI thread."""
+
+    def __init__(self, specifications, database_path):
+        super().__init__()
+        self.signals = TestDatabaseGenerationSignals()
+        self.specifications = list(specifications)
+        self.database_path = str(database_path)
+        self._cancelled = threading.Event()
+
+    def cancel(self):
+        """Request cooperative cancellation and temporary-file cleanup."""
+        self._cancelled.set()
+
+    def run(self):
+        error = None
+        try:
+            generate_database(
+                self.specifications,
+                self.database_path,
+                overwrite=True,
+                cancelled_callback=self._cancelled.is_set,
+            )
+        except GenerationCancelled:
+            return
+        except Exception as err:
+            error = err
+            log_exception("Test database generation failed", err, __name__)
+
+        try:
+            self.signals.finished.emit(
+                self.database_path,
+                self.specifications,
+                error,
+            )
+        except RuntimeError as err:
+            if "wrapped C/C++ object" not in str(err):
+                raise
+
+
 class DatabaseActionsMixin:
     """
     Database loading, refresh, recent-file, and database-status actions.
@@ -121,6 +195,7 @@ class DatabaseActionsMixin:
     """
 
     _database_refresh_worker: DatabaseRefreshWorker | None
+    _test_database_generation_worker: TestDatabaseGenerationWorker | None
 
     def load_startup_database(self):
         """
@@ -181,6 +256,139 @@ class DatabaseActionsMixin:
                 "The database folder could not be opened.",
                 folder,
             )
+
+
+    @QtCore.pyqtSlot()
+    def create_test_database_csv(self):
+        """Create an example test-data CSV and open its folder."""
+        suggested_path = os.path.join(
+            self.database_open_directory(),
+            "qplot-test-runs.csv",
+        )
+        csv_path = qtw.QFileDialog.getSaveFileName(
+            self,
+            "Create Test Database CSV",
+            suggested_path,
+            "CSV Files (*.csv)",
+        )[0]
+        if not csv_path:
+            self.show_status("Example CSV creation cancelled.", 3000)
+            return False
+        if not csv_path.lower().endswith(".csv"):
+            csv_path += ".csv"
+        csv_path = os.path.abspath(csv_path)
+
+        try:
+            write_example_csv(csv_path, overwrite=True)
+        except Exception as err:
+            log_exception("Example test-data CSV creation failed", err, __name__)
+            self.show_error(
+                "Example CSV Creation Failed",
+                "Could not create the example test-database CSV.",
+                str(err),
+            )
+            return False
+
+        opened = reveal_file_in_file_manager(csv_path)
+        if not opened:
+            self.show_error(
+                "Open CSV Folder Failed",
+                "The example CSV was created, but its folder could not be opened.",
+                csv_path,
+            )
+            return True
+
+        self.show_status(f"Created example CSV and opened its folder: {csv_path}", 5000)
+        return True
+
+
+    @QtCore.pyqtSlot()
+    def generate_test_database_from_csv(self):
+        """Choose a CSV and generate its QCoDeS database in the background."""
+        if getattr(self, "_test_database_generation_active", False):
+            self.show_status("A test database is already being generated.", 5000)
+            return False
+
+        csv_path = qtw.QFileDialog.getOpenFileName(
+            self,
+            "Select Test Database CSV",
+            self.database_open_directory(),
+            "CSV Files (*.csv)",
+        )[0]
+        if not csv_path:
+            self.show_status("Test database generation cancelled.", 3000)
+            return False
+
+        try:
+            specifications = read_specifications(csv_path)
+        except Exception as err:
+            log_exception("Test-data CSV validation failed", err, __name__)
+            self.show_error(
+                "Invalid Test Database CSV",
+                "The selected CSV could not be used to generate a database.",
+                str(err),
+            )
+            return False
+
+        suggested_path = str(os.path.splitext(os.path.abspath(csv_path))[0] + ".db")
+        database_path = qtw.QFileDialog.getSaveFileName(
+            self,
+            "Save Test Database",
+            suggested_path,
+            "QCoDeS Database (*.db)",
+        )[0]
+        if not database_path:
+            self.show_status("Test database generation cancelled.", 3000)
+            return False
+        if not database_path.lower().endswith(".db"):
+            database_path += ".db"
+        database_path = os.path.abspath(database_path)
+
+        self._test_database_generation_active = True
+        action = getattr(self, "generateTestDatabaseAction", None)
+        if action is not None:
+            action.setEnabled(False)
+        worker = TestDatabaseGenerationWorker(specifications, database_path)
+        self._test_database_generation_worker = worker
+        worker.signals.finished.connect(self.test_database_generation_finished)
+        self.show_status(
+            f"Generating test database {os.path.basename(database_path)}...",
+            0,
+        )
+        self.testDatabaseGenerationThreadPool.start(worker)
+        return True
+
+
+    @QtCore.pyqtSlot(str, object, object)
+    def test_database_generation_finished(
+            self,
+            database_path,
+            specifications,
+            error,
+            ):
+        """Apply the result of background test-database generation."""
+        self._test_database_generation_active = False
+        self._test_database_generation_worker = None
+        action = getattr(self, "generateTestDatabaseAction", None)
+        if action is not None:
+            action.setEnabled(True)
+
+        if error is not None:
+            self.show_error(
+                "Test Database Generation Failed",
+                "Could not generate the test database.",
+                str(error),
+            )
+            return
+
+        run_count = len(specifications)
+        point_count = sum(specification.point_count for specification in specifications)
+        run_word = "run" if run_count == 1 else "runs"
+        self.show_status(
+            f"Generated {os.path.basename(database_path)} with {run_count} "
+            f"{run_word} and {point_count} points.",
+            7000,
+        )
 
 
     @QtCore.pyqtSlot()

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -32,7 +32,7 @@ from qplot.datahandling.database import (
 from qplot.diagnostics import log_user_error
 
 from ._commands import create_action
-from ._database_actions import DatabaseActionsMixin
+from ._database_actions import DatabaseActionsMixin, TestDatabaseGenerationWorker
 from ._dataset_handle import DatasetHandle, DatasetKey
 from ._help import add_help_menu
 from ._plot_actions import PlotActionsMixin
@@ -142,6 +142,8 @@ class MainWindow(
         self.databaseExpensiveDetailThreadPool.setMaxThreadCount(1)
         self.databaseRefreshThreadPool = QtCore.QThreadPool(self)
         self.databaseRefreshThreadPool.setMaxThreadCount(1)
+        self.testDatabaseGenerationThreadPool = QtCore.QThreadPool(self)
+        self.testDatabaseGenerationThreadPool.setMaxThreadCount(1)
         self._database_load_generation = 0
         self._database_load_active = False
         self._database_load_state = None
@@ -156,6 +158,8 @@ class MainWindow(
         self._database_refresh_active = False
         self._database_refresh_pending = False
         self._database_refresh_worker: DatabaseRefreshWorker | None = None
+        self._test_database_generation_active = False
+        self._test_database_generation_worker: TestDatabaseGenerationWorker | None = None
         self._next_plot_x = 0
         self._next_plot_y = 0
         self.localLastFile = None
@@ -236,6 +240,21 @@ class MainWindow(
         refreshAction = create_action("window.refresh", self)
         refreshAction.triggered.connect(self.refreshMain)
         fileMenu.addAction(refreshAction)
+
+        fileMenu.addSeparator()
+
+        test_data_menu = cast(qtw.QMenu, fileMenu.addMenu("Generate &Test Data"))
+        create_csv_action = create_action("testdata.create_csv", self)
+        create_csv_action.triggered.connect(self.create_test_database_csv)
+        test_data_menu.addAction(create_csv_action)
+        self.generateTestDatabaseAction = create_action(
+            "testdata.generate_database",
+            self,
+        )
+        self.generateTestDatabaseAction.triggered.connect(
+            self.generate_test_database_from_csv
+        )
+        test_data_menu.addAction(self.generateTestDatabaseAction)
 
         fileMenu.addSeparator()
 
@@ -429,6 +448,9 @@ class MainWindow(
         refresh_worker = getattr(self, "_database_refresh_worker", None)
         if refresh_worker is not None:
             refresh_worker.cancel()
+        generation_worker = getattr(self, "_test_database_generation_worker", None)
+        if generation_worker is not None:
+            generation_worker.cancel()
         self._database_load_generation += 1
         self._database_load_active = False
         self._database_load_state = None
@@ -449,6 +471,8 @@ class MainWindow(
         self._database_refresh_active = False
         self._database_refresh_pending = False
         self._database_refresh_worker = None
+        self._test_database_generation_active = False
+        self._test_database_generation_worker = None
         self.monitor.stop()
         qtw.QApplication.closeAllWindows()
         release_selected = getattr(self, "_release_selected_dataset", None)

--- a/tests/test_package_import.py
+++ b/tests/test_package_import.py
@@ -19,6 +19,7 @@ def test_console_scripts_are_declared():
 
     assert scripts["qplot"] == "qplot.__main__:run"
     assert scripts["qplot-cfg"] == "qplot.configuration.scripts:scripts"
+    assert scripts["qplot-generate-db"] == "qplot.testdata:main"
 
 
 def test_config_schema_is_packaged():

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -1,0 +1,172 @@
+import csv
+
+import numpy as np
+import pytest
+import qcodes as qc
+from qcodes.dataset import initialise_or_create_database_at, load_by_id
+
+from qplot.testdata import (
+    CSV_COLUMNS,
+    SpecificationError,
+    generate_database_from_csv,
+    main,
+    read_specifications,
+    write_example_csv,
+)
+
+
+def write_specification(path, rows):
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CSV_COLUMNS)
+        writer.writerows(rows)
+
+
+def test_example_csv_is_ready_to_generate(tmp_path):
+    csv_path = tmp_path / "example.csv"
+
+    assert write_example_csv(csv_path) == csv_path
+    specifications = read_specifications(csv_path)
+
+    assert csv_path.read_bytes().startswith(b"\xef\xbb\xbf")
+    assert [specification.dimensions for specification in specifications] == [1, 1, 2, 2]
+    assert [specification.point_count for specification in specifications] == [
+        101,
+        501,
+        121 * 81,
+        201 * 101,
+    ]
+    with pytest.raises(SpecificationError, match="already exists"):
+        write_example_csv(csv_path)
+
+
+def test_example_cli_reports_written_path(tmp_path, capsys):
+    csv_path = tmp_path / "example.csv"
+
+    assert main(["--write-example", str(csv_path)]) == 0
+
+    assert csv_path.is_file()
+    assert f"Wrote example CSV: {csv_path}" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("row", "message"),
+    [
+        (
+            ("3", "current", "Current", "nA", "-1", "1", "11", "", "", ""),
+            "dimensions must be 1 or 2",
+        ),
+        (
+            ("1", "V_SD", "Current", "nA", "-1", "1", "11", "", "", ""),
+            "measured_name cannot be V_SD or V_G",
+        ),
+        (
+            ("1", "current", "Current", "nA", "-1", "1", "11", "-2", "2", "5"),
+            "v_g_start, v_g_stop, and v_g_points must be blank for a 1D run",
+        ),
+        (
+            ("2", "current", "Current", "nA", "-1", "1", "11", "", "2", "5"),
+            "v_g_start is required",
+        ),
+    ],
+)
+def test_invalid_rows_report_the_csv_row(tmp_path, row, message):
+    csv_path = tmp_path / "invalid.csv"
+    write_specification(csv_path, [row])
+
+    with pytest.raises(SpecificationError, match=f"CSV row 2: {message}"):
+        read_specifications(csv_path)
+
+
+def test_generate_database_creates_named_sinusoidal_runs(tmp_path):
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_specification(
+        csv_path,
+        [
+            ("1", "current", "Current", "nA", "-2", "2", "5", "", "", ""),
+            (
+                "2",
+                "conductance",
+                "Conductance",
+                "uS",
+                "-0.1",
+                "0.1",
+                "3",
+                "-1",
+                "1",
+                "4",
+            ),
+        ],
+    )
+
+    random_seed = 1234
+    generated_path, specifications = generate_database_from_csv(
+        csv_path,
+        database_path,
+        rng=np.random.default_rng(random_seed),
+    )
+
+    assert generated_path == database_path
+    assert database_path.is_file()
+    assert [specification.point_count for specification in specifications] == [5, 12]
+
+    previous_database_path = qc.config["core"]["db_location"]
+    try:
+        initialise_or_create_database_at(database_path, journal_mode="DELETE")
+        line_run = load_by_id(1)
+        map_run = load_by_id(2)
+
+        assert line_run.name == "run_1"
+        assert map_run.name == "run_2"
+        assert line_run.completed
+        assert map_run.completed
+
+        line_parameters = {parameter.name: parameter for parameter in line_run.get_parameters()}
+        assert set(line_parameters) == {"V_SD", "current"}
+        assert line_parameters["current"].label == "Current"
+        assert line_parameters["current"].unit == "nA"
+        assert line_parameters["current"].depends_on_ == ["V_SD"]
+
+        line_data = line_run.get_parameter_data("current")["current"]
+        np.testing.assert_allclose(line_data["V_SD"], np.linspace(-2.0, 2.0, 5))
+        expected_generator = np.random.default_rng(random_seed)
+        expected_amplitude = expected_generator.uniform(0.5, 1.5)
+        expected_phase = expected_generator.uniform(0.0, 2.0 * np.pi)
+        np.testing.assert_allclose(
+            line_data["current"],
+            expected_amplitude
+            * np.sin(
+                4.0 * np.pi * np.linspace(0.0, 1.0, 5) + expected_phase
+            ),
+            atol=1e-12,
+        )
+
+        map_parameters = {parameter.name: parameter for parameter in map_run.get_parameters()}
+        assert set(map_parameters) == {"V_SD", "V_G", "conductance"}
+        assert map_parameters["conductance"].depends_on_ == ["V_SD", "V_G"]
+        map_data = map_run.get_parameter_data("conductance")["conductance"]
+        assert map_data["conductance"].size == 12
+        assert np.isfinite(map_data["conductance"]).all()
+        assert np.min(map_data["conductance"]) >= -1.5
+        assert np.max(map_data["conductance"]) <= 1.5
+    finally:
+        qc.config["core"]["db_location"] = previous_database_path
+
+
+def test_generate_database_requires_explicit_overwrite(tmp_path):
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_specification(
+        csv_path,
+        [("1", "current", "Current", "nA", "-1", "1", "5", "", "", "")],
+    )
+    generate_database_from_csv(csv_path, database_path)
+
+    with pytest.raises(SpecificationError, match="use --overwrite"):
+        generate_database_from_csv(csv_path, database_path)
+
+    generated_path, _ = generate_database_from_csv(
+        csv_path, database_path, overwrite=True
+    )
+    assert generated_path == database_path

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -967,6 +967,12 @@ class OptionsMenuTestCase(unittest.TestCase):
         def refreshMain(self):
             pass
 
+        def create_test_database_csv(self):
+            pass
+
+        def generate_test_database_from_csv(self):
+            pass
+
         def closeAll(self):
             pass
 
@@ -1006,6 +1012,36 @@ class OptionsMenuTestCase(unittest.TestCase):
             self.assertNotIn("Preview Size", option_texts)
             self.assertNotIn("Confirm Before Closing All Plot Windows", option_texts)
             self.assertNotIn("Confirm Before Quit", option_texts)
+        finally:
+            window.deleteLater()
+
+    def test_file_menu_exposes_test_data_generation_actions(self):
+        window = self.Harness()
+
+        try:
+            window.initMenu()
+            menus = {
+                action.text().replace("&", ""): action.menu()
+                for action in window.menuBar().actions()
+                }
+            file_menu = menus["File"]
+            test_data_menu = next(
+                action.menu()
+                for action in file_menu.actions()
+                if action.text().replace("&", "") == "Generate Test Data"
+                )
+            actions = {
+                action.objectName(): action.text().replace("&", "")
+                for action in test_data_menu.actions()
+                }
+
+            self.assertEqual(
+                actions,
+                {
+                    "createTestDatabaseCsvAction": "Create Example CSV...",
+                    "generateTestDatabaseAction": "Generate Database from CSV...",
+                },
+                )
         finally:
             window.deleteLater()
 

--- a/tests/windows/test_testdata_gui.py
+++ b/tests/windows/test_testdata_gui.py
@@ -1,0 +1,185 @@
+import csv
+import sqlite3
+from unittest.mock import Mock, patch
+
+from PyQt6 import QtGui
+from PyQt6 import QtWidgets as qtw
+
+from qplot.testdata import CSV_COLUMNS
+from qplot.windows._database_actions import (
+    DatabaseActionsMixin,
+    reveal_file_in_file_manager,
+)
+
+
+class ImmediateThreadPool:
+    def start(self, worker):
+        worker.run()
+
+
+class GuiHarness(DatabaseActionsMixin, qtw.QWidget):
+    def __init__(self, directory):
+        super().__init__()
+        self.directory = str(directory)
+        self.status_messages = []
+        self.errors = []
+        self._test_database_generation_active = False
+        self._test_database_generation_worker = None
+        self.testDatabaseGenerationThreadPool = ImmediateThreadPool()
+        self.generateTestDatabaseAction = QtGui.QAction(self)
+
+    def database_open_directory(self):
+        return self.directory
+
+    def show_status(self, message, timeout=5000):
+        self.status_messages.append((message, timeout))
+
+    def show_error(self, title, message, details=None):
+        self.errors.append((title, message, details))
+
+
+def write_small_specification(path):
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CSV_COLUMNS)
+        writer.writerow(("1", "current", "Current", "nA", "-1", "1", "5", "", "", ""))
+
+
+def test_create_example_csv_opens_its_folder(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "example.csv"
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch(
+                "qplot.windows._database_actions.reveal_file_in_file_manager",
+                return_value=True,
+            ) as reveal_file,
+        ):
+            assert harness.create_test_database_csv()
+
+        assert csv_path.is_file()
+        reveal_file.assert_called_once_with(str(csv_path))
+        assert "Created example CSV" in harness.status_messages[-1][0]
+        assert harness.errors == []
+    finally:
+        harness.deleteLater()
+
+
+def test_reveal_file_uses_finder_selection_on_macos(tmp_path):
+    csv_path = tmp_path / "example.csv"
+    csv_path.touch()
+    completed = Mock(returncode=0)
+
+    with (
+        patch("qplot.windows._database_actions.sys.platform", "darwin"),
+        patch(
+            "qplot.windows._database_actions.subprocess.run",
+            return_value=completed,
+        ) as run,
+    ):
+        assert reveal_file_in_file_manager(csv_path)
+
+    run.assert_called_once_with(
+        ["open", "-R", str(csv_path)],
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+
+
+def test_generate_database_from_csv_runs_in_worker_pool(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_small_specification(csv_path)
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+        ):
+            assert harness.generate_test_database_from_csv()
+
+        assert database_path.is_file()
+        connection = sqlite3.connect(database_path)
+        try:
+            assert connection.execute("SELECT name FROM runs").fetchall() == [("run_1",)]
+        finally:
+            connection.close()
+        assert not harness._test_database_generation_active
+        assert harness._test_database_generation_worker is None
+        assert harness.generateTestDatabaseAction.isEnabled()
+        assert "with 1 run and 5 points" in harness.status_messages[-1][0]
+        assert harness.errors == []
+    finally:
+        harness.deleteLater()
+
+
+def test_invalid_csv_is_reported_before_database_destination_prompt(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "invalid.csv"
+    csv_path.write_text("not,a,valid,header\n", encoding="utf-8")
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(qtw.QFileDialog, "getSaveFileName") as save_dialog,
+        ):
+            assert not harness.generate_test_database_from_csv()
+
+        save_dialog.assert_not_called()
+        assert harness.errors[0][0] == "Invalid Test Database CSV"
+        assert "Invalid CSV header" in harness.errors[0][2]
+    finally:
+        harness.deleteLater()
+
+
+def test_generation_cancelled_before_first_run_removes_temporary_database(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_small_specification(csv_path)
+
+    class CancellingThreadPool:
+        def start(self, worker):
+            worker.cancel()
+            worker.run()
+
+    harness.testDatabaseGenerationThreadPool = CancellingThreadPool()
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+        ):
+            assert harness.generate_test_database_from_csv()
+
+        assert not database_path.exists()
+        assert list(tmp_path.glob(".runs-*.db")) == []
+    finally:
+        harness.deleteLater()


### PR DESCRIPTION
## Summary

- prepare qPlot `1.5.0-b4` (package version `1.5.0b4`)
- add a CSV-driven generator for completed 1D and 2D QCoDeS test runs with configurable measured parameters, sweep ranges, and point counts
- generate randomized sinusoidal measurements while keeping the CSV format compact
- add `File → Generate Test Data` actions to create and reveal an example CSV and generate a database in a cancellable background worker
- add the `qplot-generate-db` CLI, validation, atomic output handling, documentation, and changelog coverage

## Why

This beta adds convenient, repeatable test databases covering different 1D and 2D ranges without mock instruments or hand-written scripts. A spreadsheet-friendly specification makes the datasets easy to edit and regenerate from either the GUI or terminal.

## User impact

Users can create an example CSV from qPlot, reveal it in Finder on macOS, edit it in a spreadsheet, and generate a ready-to-load QCoDeS database without blocking the UI. Existing loaded databases and existing destination files remain protected from partial generation.

## Release details

- package version: `1.5.0b4`
- intended GitHub tag: `v1.5.0-b4`
- changelog date: 2026-08-01

## Validation

- `.venv-mac/bin/python -m pytest` — 540 passed
- `.venv-mac/bin/python -m ruff check .` — passed
- `.venv-mac/bin/python -m mypy` — passed
- `.venv-mac/bin/python -m build` — source archive and wheel built
- `.venv-mac/bin/python -m twine check ...` — both artifacts passed
- isolated wheel install — reported `1.5.0b4`
- installed `qplot-generate-db` — created the example CSV and a four-run, 30,704-point QCoDeS database
- qPlot runtime startup smoke test with a generated four-run database