### PR TITLE
Prepare qPlot 1.5.0 beta 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+## 1.5.0-b5 - 2026-08-02
+
 ### Added
 
 - Include ten cumulative CSV instruction files targeting databases from about
   10 MB to 30 GB, with CLI and File-menu actions for exporting the collection.
+- Add **File > Close Database** and **Quit qPlot** commands. Quit uses the
+  platform-standard shortcut, including Command-Q on macOS and Ctrl-Q on
+  Windows and Linux.
 
 ### Changed
 
@@ -19,6 +24,21 @@ installation commands and release validation, see `docs/distribution.md`.
 - Write generated QCoDeS results in bounded array chunks instead of one point
   at a time, substantially reducing large test-database generation time while
   retaining cancellation between chunks.
+- Cancel database work, close plot and preview connections, and wait for
+  background workers before qPlot exits.
+
+### Fixed
+
+- Prevent shutdown tracebacks when an interrupted SQLite worker completes
+  after its Qt signal object has already been deleted.
+- Detect a database file replaced at the same path and discard cached metadata,
+  plots, previews, and connections belonging to the old file.
+- Clear stale run selection and details when loading a selected run fails.
+- Validate generated result columns and stored row counts, and publish generated
+  databases atomically without overwriting a concurrently created file.
+- Reject merging 2D cuts whose fixed-axis values are incompatible.
+- Keep preview scheduling bounded and prevent stale workers from overwriting
+  newer preview state.
 
 ## 1.5.0-b4 - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ part of the GUI test or support matrix.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b4`; it is documented below but is not used for the default install.
+is `1.5.0-b5`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -48,7 +48,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b4
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b5
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,13 +27,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.0-b4`. The package metadata uses the PEP 440 normal
-form `1.5.0b4`; the GitHub release tag should be `v1.5.0-b4`.
+The current beta is `1.5.0-b5`. The package metadata uses the PEP 440 normal
+form `1.5.0b5`; the GitHub release tag should be `v1.5.0-b5`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b4
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b5
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b4`, even if the Git tag includes a separator,
-   such as `v1.5.0-b4`.
+   package form, such as `1.5.0b5`, even if the Git tag includes a separator,
+   such as `v1.5.0-b5`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -104,6 +104,8 @@ Common actions:
 * `File -> Refresh` checks the current database for new runs.
 * `File -> Open Database Folder` opens the folder containing the loaded
   database.
+* `File -> Close Database` closes its plot windows, cancels background database
+  work, and releases the current database.
 * `File -> Generate Test Data -> Create Example CSV...` writes a spreadsheet
   template, reveals it in Finder on macOS, or opens its containing folder in
   the platform file manager.
@@ -124,6 +126,8 @@ Common actions:
 * `Help -> Keyboard Shortcuts` shows the shortcut reference inside qPlot.
 * `Help -> Copy Diagnostic Log Path` copies the log file location for support
   or troubleshooting.
+* `File -> Quit qPlot` closes the database and exits. Its shortcut is `Cmd+Q`
+  on macOS and `Ctrl+Q` on Windows and Linux.
 * The refresh interval controls how often qPlot checks for new runs. Set it to
   `0.0 s` to disable automatic checks.
 * `Auto-plot` opens newly detected runs automatically. When enabled while a run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b4"
+version = "1.5.0b5"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -429,13 +429,38 @@ class DatabaseDetailSignals(QtCore.QObject):
     finished = QtCore.pyqtSignal(int, str, object)
 
 
+class _InterruptibleSqlWorker:
+    """Allows the GUI thread to interrupt an active read-only SQLite query."""
+
+    def _init_sql_interrupt(self):
+        self._sql_connection_lock = threading.Lock()
+        self._sql_connection = None
+
+
+    def _interrupt_sql(self):
+        with self._sql_connection_lock:
+            connection = self._sql_connection
+        if connection is not None:
+            try:
+                connection.interrupt()
+            except Exception:
+                pass
+
+
+    def _set_sql_connection(self, connection):
+        with self._sql_connection_lock:
+            self._sql_connection = connection
+        if connection is not None and self._cancelled.is_set():
+            self._interrupt_sql()
+
+
 class DatabaseRefreshSignals(QtCore.QObject):
     """Signals emitted by a coalesced main-window refresh worker."""
 
     finished = QtCore.pyqtSignal(int, str, object, object, object)
 
 
-class DatabaseRefreshWorker(QtCore.QRunnable):
+class DatabaseRefreshWorker(_InterruptibleSqlWorker, QtCore.QRunnable):
     """Fetch new runs and live-run status without blocking the GUI thread."""
 
     def __init__(self, generation, database_path, last_run_id, watched_runs):
@@ -446,10 +471,12 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
         self.last_run_id = int(last_run_id or 0)
         self.watched_runs = list(watched_runs or [])
         self._cancelled = threading.Event()
+        self._init_sql_interrupt()
 
 
     def cancel(self):
         self._cancelled.set()
+        self._interrupt_sql()
 
 
     def run(self):
@@ -463,6 +490,7 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
                 self.last_run_id,
                 database_path=self.database_path,
                 cancelled_callback=self._cancelled.is_set,
+                connection_callback=self._set_sql_connection,
                 ) or {}
             for guid in self.watched_runs:
                 if self._cancelled.is_set():
@@ -472,6 +500,7 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
                     database_path=self.database_path,
                     include_storage_bytes=False,
                     cancelled_callback=self._cancelled.is_set,
+                    connection_callback=self._set_sql_connection,
                     )
                 if status:
                     statuses[guid] = status
@@ -500,7 +529,7 @@ class DatabaseRefreshWorker(QtCore.QRunnable):
                 raise
 
 
-class DatabaseLoadWorker(QtCore.QRunnable):
+class DatabaseLoadWorker(_InterruptibleSqlWorker, QtCore.QRunnable):
     """
     Loads database metadata away from the GUI thread.
 
@@ -522,6 +551,7 @@ class DatabaseLoadWorker(QtCore.QRunnable):
         self.database_path = database_path
         self.cloud_sync_timeout = cloud_sync_timeout
         self._cancelled = threading.Event()
+        self._init_sql_interrupt()
 
 
     def cancel(self):
@@ -530,6 +560,7 @@ class DatabaseLoadWorker(QtCore.QRunnable):
 
         """
         self._cancelled.set()
+        self._interrupt_sql()
 
 
     def run(self):
@@ -568,12 +599,15 @@ class DatabaseLoadWorker(QtCore.QRunnable):
             runs = get_runs_basic_via_sql(
                 self.database_path,
                 cancelled_callback=self._is_cancelled,
+                connection_callback=self._set_sql_connection,
                 ) or {}
             if self._is_cancelled():
                 return
         except InterruptedError:
             return
         except Exception as err:
+            if self._is_cancelled():
+                return
             log_exception("Database load worker failed", err, __name__)
             self._emit_finished({}, err)
             return
@@ -615,7 +649,7 @@ class DatabaseLoadWorker(QtCore.QRunnable):
             )
 
 
-class _PrioritizedRunWorker(QtCore.QRunnable):
+class _PrioritizedRunWorker(_InterruptibleSqlWorker, QtCore.QRunnable):
     """
     Base for background workers that need selected/visible run prioritisation.
 
@@ -632,6 +666,7 @@ class _PrioritizedRunWorker(QtCore.QRunnable):
             for index, run_id in enumerate(self.run_ids)
             }
         self._cancelled = threading.Event()
+        self._init_sql_interrupt()
         self._priority_lock = threading.Lock()
         self._priority_epoch = 0
         self._priority_scores = {}
@@ -639,6 +674,7 @@ class _PrioritizedRunWorker(QtCore.QRunnable):
 
     def cancel(self):
         self._cancelled.set()
+        self._interrupt_sql()
 
 
     def prioritize_run_ids(self, run_ids):
@@ -778,6 +814,7 @@ class DatabaseDetailWorker(_PrioritizedRunWorker):
                         include_storage_estimate=True,
                         include_read_setpoint_count=False,
                         cancelled_callback=self._is_cancelled,
+                        connection_callback=self._set_sql_connection,
                         ):
                     if self._is_cancelled():
                         return
@@ -835,6 +872,7 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                         batch,
                         batch_size=self.batch_size,
                         cancelled_callback=self._is_cancelled,
+                        connection_callback=self._set_sql_connection,
                         ):
                     if self._is_cancelled():
                         return
@@ -866,6 +904,7 @@ class DatabaseExpensiveDetailWorker(_PrioritizedRunWorker):
                         batch,
                         batch_size=storage_batch_size,
                         cancelled_callback=self._is_cancelled,
+                        connection_callback=self._set_sql_connection,
                         ):
                     if self._is_cancelled():
                         return

--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -17,10 +17,16 @@ def _install_cancel_progress_handler(conn, cancelled_callback):
         set_progress_handler(lambda: int(bool(cancelled_callback())), 1000)
 
 
+def _notify_connection(connection_callback, connection):
+    if connection_callback is not None:
+        connection_callback(connection)
+
+
 def get_runs_via_sql(
         database_path=None,
         include_details=True,
         cancelled_callback=None,
+        connection_callback=None,
         ):
     """
     Read from the currently initialised QCoDeS database and fetches all data to
@@ -36,6 +42,7 @@ def get_runs_via_sql(
     """
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         return _fetch_run_rows(
@@ -44,10 +51,17 @@ def get_runs_via_sql(
             include_details=include_details,
             )
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
-def get_runs_basic_via_sql(database_path=None, cancelled_callback=None):
+def get_runs_basic_via_sql(
+        database_path=None,
+        cancelled_callback=None,
+        connection_callback=None,
+        ):
     """
     Read the run list without scanning result tables.
 
@@ -61,6 +75,7 @@ def get_runs_basic_via_sql(database_path=None, cancelled_callback=None):
         database_path=database_path,
         include_details=False,
         cancelled_callback=cancelled_callback,
+        connection_callback=connection_callback,
         )
 
 
@@ -73,6 +88,7 @@ def iter_run_detail_batches_via_sql(
         include_storage_estimate=False,
         include_read_setpoint_count=True,
         cancelled_callback=None,
+        connection_callback=None,
         ):
     """
     Yield detailed run metadata in small batches.
@@ -88,6 +104,7 @@ def iter_run_detail_batches_via_sql(
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         for offset in range(0, len(run_ids), batch_size):
@@ -108,7 +125,10 @@ def iter_run_detail_batches_via_sql(
                 )
             yield rows or {}
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
 def iter_run_shape_batches_via_sql(
@@ -116,6 +136,7 @@ def iter_run_shape_batches_via_sql(
         run_ids,
         batch_size=1,
         cancelled_callback=None,
+        connection_callback=None,
         ):
     """
     Yield setpoint-shape metadata for runs that need result-table inference.
@@ -131,6 +152,7 @@ def iter_run_shape_batches_via_sql(
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         for offset in range(0, len(run_ids), batch_size):
@@ -160,7 +182,10 @@ def iter_run_shape_batches_via_sql(
             if rows:
                 yield rows
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
 def iter_run_storage_batches_via_sql(
@@ -168,6 +193,7 @@ def iter_run_storage_batches_via_sql(
         run_ids,
         batch_size=25,
         cancelled_callback=None,
+        connection_callback=None,
         ):
     """
     Yield per-run storage sizes after the cheap detail pass has completed.
@@ -184,6 +210,7 @@ def iter_run_storage_batches_via_sql(
     batch_size = max(1, int(batch_size or 1))
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         run_tables = _run_storage_tables(cursor, run_ids)
@@ -217,10 +244,18 @@ def iter_run_storage_batches_via_sql(
             if rows:
                 yield rows
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
-def find_new_runs(last_run_id, database_path=None, cancelled_callback=None):
+def find_new_runs(
+        last_run_id,
+        database_path=None,
+        cancelled_callback=None,
+        connection_callback=None,
+        ):
     """
     Fetch all runs created after the last seen run ID.
 
@@ -242,11 +277,15 @@ def find_new_runs(last_run_id, database_path=None, cancelled_callback=None):
     conn = qcodes_read_only_connection(database_path or get_DB_location())
 
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         return _fetch_run_rows(cursor, "WHERE runs.run_id > ?", (last_run_id, ))
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
 def _fetch_run_rows(
@@ -948,6 +987,7 @@ def get_run_status(
         database_path=None,
         include_storage_bytes=True,
         cancelled_callback=None,
+        connection_callback=None,
         ):
     """
     Returns completion and result count information for one run.
@@ -955,6 +995,7 @@ def get_run_status(
     """
     conn = qcodes_read_only_connection(database_path or get_DB_location())
     try:
+        _notify_connection(connection_callback, conn)
         _install_cancel_progress_handler(conn, cancelled_callback)
         cursor = conn.cursor()
         optional_columns = _existing_run_columns(cursor, ["measurement_exception"])
@@ -1029,7 +1070,10 @@ def get_run_status(
 
         return status
     finally:
-        conn.close()
+        try:
+            _notify_connection(connection_callback, None)
+        finally:
+            conn.close()
 
 
 def has_finished(guid) -> float | None:

--- a/src/qplot/testdata.py
+++ b/src/qplot/testdata.py
@@ -7,6 +7,7 @@ import csv
 import math
 import os
 import re
+import sqlite3
 import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -103,6 +104,23 @@ class GenerationCancelled(RuntimeError):
     """Raised internally when test-database generation is cancelled."""
 
 
+def _result_column_name_is_usable(name):
+    """Return whether SQLite accepts ``name`` as QCoDeS will emit it."""
+    connection = sqlite3.connect(":memory:")
+    try:
+        # Parameter names have already passed _PARAMETER_NAME_PATTERN, so this
+        # parser probe cannot introduce additional SQL tokens. Keeping the
+        # identifier unquoted deliberately mirrors QCoDeS result-table SQL.
+        connection.execute(
+            f"CREATE TABLE qplot_results (id INTEGER PRIMARY KEY, {name} numeric)"
+        )
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        connection.close()
+    return True
+
+
 @dataclass(frozen=True)
 class RunSpecification:
     """Validated settings for one generated QCoDeS run."""
@@ -180,6 +198,11 @@ def _parse_row(row, line_number):
         raise _row_error(
             line_number,
             "measured_name cannot be V_SD or V_G because those names are swept",
+        )
+    if not _result_column_name_is_usable(measured_name):
+        raise _row_error(
+            line_number,
+            "measured_name cannot be used as a QCoDeS result column",
         )
 
     measured_label = _required(row, "measured_label", line_number)
@@ -416,7 +439,13 @@ def _write_run(
                     (v_sd, v_sd_values[result_slice]),
                     (measured, measured_values[result_slice]),
                 )
-        return
+        points_written = int(datasaver.points_written)
+        if points_written != specification.point_count:
+            raise RuntimeError(
+                f"run_{run_number} persisted {points_written} of "
+                f"{specification.point_count} expected result rows"
+            )
+        return points_written
 
     assert specification.v_g_start is not None
     assert specification.v_g_stop is not None
@@ -446,6 +475,35 @@ def _write_run(
                     (v_g, v_g_values[result_slice]),
                     (measured, measured_values[result_slice]),
                 )
+    points_written = int(datasaver.points_written)
+    if points_written != specification.point_count:
+        raise RuntimeError(
+            f"run_{run_number} persisted {points_written} of "
+            f"{specification.point_count} expected result rows"
+        )
+    return points_written
+
+
+def _publish_database(temporary_path, database_path, overwrite):
+    """Publish a generated database atomically with optional no-clobber."""
+    if overwrite:
+        os.replace(temporary_path, database_path)
+        return
+
+    try:
+        # Both paths are in the same directory. Creating the destination hard
+        # link is atomic and fails if another process won the destination race.
+        os.link(temporary_path, database_path)
+    except FileExistsError as error:
+        raise SpecificationError(
+            f"{database_path} already exists; use --overwrite to replace it"
+        ) from error
+    except OSError as error:
+        raise OSError(
+            "Could not atomically publish the generated database without "
+            "overwriting an existing file"
+        ) from error
+    temporary_path.unlink()
 
 
 def generate_database(
@@ -502,13 +560,18 @@ def generate_database(
                     f"{specification.dimensions}D, {specification.point_count} points)."
                 )
                 try:
-                    _write_run(
+                    points_written = _write_run(
                         experiment,
                         run_number,
                         specification,
                         random_generator,
                         cancelled_callback=cancelled_callback,
                     )
+                    if points_written != specification.point_count:
+                        raise RuntimeError(
+                            f"run_{run_number} persisted {points_written} of "
+                            f"{specification.point_count} expected result rows"
+                        )
                 except GenerationCancelled:
                     _timestamped_message(
                         f"Run stopped (cancelled): run_{run_number} "
@@ -529,7 +592,7 @@ def generate_database(
             _raise_if_cancelled(cancelled_callback)
         finally:
             connection.close()
-        os.replace(temporary_path, database_path)
+        _publish_database(temporary_path, database_path, overwrite)
     except GenerationCancelled:
         temporary_path.unlink(missing_ok=True)
         _timestamped_message(

--- a/src/qplot/windows/_commands.py
+++ b/src/qplot/windows/_commands.py
@@ -101,6 +101,12 @@ COMMANDS: dict[str, CommandSpec] = {
         "Ctrl+L",
         help_section="General",
     ),
+    "database.close": CommandSpec(
+        "database.close",
+        "&Close Database",
+        "Close the current database and its plot windows",
+        object_name="closeDatabaseAction",
+    ),
     "window.refresh": CommandSpec(
         "window.refresh",
         "&Refresh",
@@ -119,7 +125,7 @@ COMMANDS: dict[str, CommandSpec] = {
     "app.quit": CommandSpec(
         "app.quit",
         "&Quit qPlot",
-        "Quit qPlot",
+        "Close the database and quit qPlot",
         _standard_shortcuts(QKeySequence.StandardKey.Quit, ["Ctrl+Q"]),
         help_section="General",
         help_shortcut="Ctrl+Q / Cmd+Q",

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -27,11 +27,27 @@ from qplot.testdata import (
     write_example_csv,
 )
 
+from ._dataset_handle import canonical_database_path
 from ._widgets.details_tables import (
     CopyableTableWidget,
     copy_to_clipboard,
     format_value,
 )
+
+
+def _database_file_identity(database_path):
+    """Return a stable identity that changes when a database is replaced."""
+    try:
+        stat_result = os.stat(database_path)
+    except OSError:
+        return None
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
 
 
 class DatabaseInfoDialog(qtw.QDialog):
@@ -431,6 +447,14 @@ class DatabaseActionsMixin:
             f"{run_word} and {point_count} points.",
             7000,
         )
+        file_textbox = getattr(self, "fileTextbox", None)
+        current_database = file_textbox.text() if file_textbox is not None else ""
+        if (
+                current_database
+                and canonical_database_path(current_database)
+                == canonical_database_path(database_path)
+                ):
+            self.load_file(database_path, force=True)
 
 
     @QtCore.pyqtSlot()
@@ -465,6 +489,7 @@ class DatabaseActionsMixin:
         self._database_load_active = False
         self._database_load_state = None
         self._database_load_worker = None
+        self._loaded_database_identity = None
         if hasattr(self, "_set_database_load_controls_enabled"):
             self._set_database_load_controls_enabled(True)
         if hasattr(self, "_hide_database_load_panel"):
@@ -500,6 +525,9 @@ class DatabaseActionsMixin:
         self.RunList.scrollToTop()
 
         self.infoBox.clear()
+        clear_database_cache = getattr(self.infoBox, "clear_database_cache", None)
+        if callable(clear_database_cache):
+            clear_database_cache()
         self.infoBox.preview.set_database_runs("", {})
         self.infoBox.scrollToTop()
         self._sync_empty_state()
@@ -855,7 +883,7 @@ class DatabaseActionsMixin:
             self.recentDatabaseMenu.addAction(action)
 
 
-    def load_file(self, abspath, load_started_at=None):
+    def load_file(self, abspath, load_started_at=None, *, force=False):
         """
         Updates the database for RunList display and loading datasets.
 
@@ -870,7 +898,23 @@ class DatabaseActionsMixin:
 
         DatabaseActionsMixin._cancel_database_refresh(self)
 
-        if abspath == get_DB_location() and self.fileTextbox.text() == abspath:
+        qcodes_database = get_DB_location()
+        displayed_database = self.fileTextbox.text()
+        same_loaded_database = bool(
+            qcodes_database
+            and displayed_database
+            and canonical_database_path(abspath)
+            == canonical_database_path(qcodes_database)
+            == canonical_database_path(displayed_database)
+        )
+        current_identity = _database_file_identity(abspath)
+        loaded_identity = getattr(self, "_loaded_database_identity", None)
+        if (
+                same_loaded_database
+                and not force
+                and loaded_identity is not None
+                and current_identity == loaded_identity
+                ):
             if not self.infoBox.preview.has_database(abspath):
                 self.infoBox.preview.set_database_runs(
                     abspath,
@@ -889,6 +933,7 @@ class DatabaseActionsMixin:
         self._database_load_state = {
             "abspath": abspath,
             "load_started_at": load_started_at,
+            "reload_same_path": force or same_loaded_database,
         }
 
         self._set_database_load_controls_enabled(False)
@@ -929,6 +974,9 @@ class DatabaseActionsMixin:
         self.RunList.scrollToTop()
 
         self.infoBox.clear()
+        clear_database_cache = getattr(self.infoBox, "clear_database_cache", None)
+        if callable(clear_database_cache):
+            clear_database_cache()
         self.infoBox.scrollToTop()
 
         if self.fileTextbox.text() and self.fileTextbox.text() != self.localLastFile:
@@ -1046,7 +1094,16 @@ class DatabaseActionsMixin:
             return
 
         self._cancel_database_detail_load()
+        if state.get("reload_same_path"):
+            invalidate_runtime_state = getattr(
+                self,
+                "_invalidate_database_runtime_state",
+                None,
+            )
+            if callable(invalidate_runtime_state):
+                invalidate_runtime_state(abspath)
         set_qcodes_database_location(abspath)
+        self._loaded_database_identity = _database_file_identity(abspath)
         runs = runs or {}
         run_id_signals_blocked = self.run_idBox.blockSignals(True)
         run_list_signals_blocked = self.RunList.blockSignals(True)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -1124,7 +1124,11 @@ class plotWidget(
 
         for window in app.topLevelWidgets():
             if window.__class__.__name__ == "MainWindow":
-                window.close()
+                quit_application = getattr(window, "quit_application", None)
+                if callable(quit_application):
+                    quit_application()
+                else:
+                    window.close()
                 return
 
         app.closeAllWindows()

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -12,7 +12,12 @@ from qplot.datahandling.dimensions import (
 from qplot.datahandling.readonly import load_by_guid_read_only, load_by_id_read_only
 from qplot.diagnostics import log_exception
 
-from ._dataset_handle import DatasetHandle, DatasetKey, close_dataset_connection
+from ._dataset_handle import (
+    DatasetHandle,
+    DatasetKey,
+    canonical_database_path,
+    close_dataset_connection,
+)
 from ._subplots.subplot1d import _subplot_axis_order
 from .plot1d import plot1d
 from .plot2d import plot2d
@@ -92,6 +97,35 @@ class PlotActionsMixin:
             )
 
 
+    def _clear_selected_run_state(self):
+        """Clear run actions and UI after a selected dataset cannot be loaded."""
+        self._release_selected_dataset()
+        self.selected_run_id = None
+
+        run_id_box = getattr(self, "run_idBox", None)
+        if run_id_box is not None:
+            signals_blocked = run_id_box.blockSignals(True)
+            try:
+                run_id_box.setText("")
+            finally:
+                run_id_box.blockSignals(signals_blocked)
+
+        run_list = getattr(self, "RunList", None)
+        if run_list is not None:
+            signals_blocked = run_list.blockSignals(True)
+            try:
+                run_list.clearSelection()
+                set_current_item = getattr(run_list, "setCurrentItem", None)
+                if callable(set_current_item):
+                    set_current_item(None)
+            finally:
+                run_list.blockSignals(signals_blocked)
+
+        info_box = getattr(self, "infoBox", None)
+        if info_box is not None:
+            info_box.clear()
+
+
     def _evict_dataset_handle(self, dataset_key):
         handle = self.dataset_holder.pop(dataset_key, None)
         if handle is None:
@@ -115,6 +149,34 @@ class PlotActionsMixin:
                 handle.close()
             except Exception as err:
                 log_exception("Plot dataset cleanup failed", err, __name__)
+
+
+    def _invalidate_database_runtime_state(self, database_path):
+        """Close datasets and plot windows backed by a replaced database."""
+        canonical_path = canonical_database_path(database_path)
+        selected_key = getattr(self, "_selected_dataset_key", None)
+        if (
+                selected_key is not None
+                and selected_key.database_path == canonical_path
+                ):
+            self._release_selected_dataset()
+            self.selected_run_id = None
+
+        for win in list(getattr(self, "windows", [])):
+            dataset_key = getattr(win, "_dataset_key", None)
+            if (
+                    dataset_key is None
+                    or dataset_key.database_path != canonical_path
+                    ):
+                continue
+            try:
+                win.close()
+            except Exception as err:
+                log_exception("Replaced database plot cleanup failed", err, __name__)
+
+        for dataset_key in list(self.dataset_holder):
+            if dataset_key.database_path == canonical_path:
+                self._evict_dataset_handle(dataset_key)
 
     @QtCore.pyqtSlot(object)
     def onClose(self, win):
@@ -287,6 +349,7 @@ class PlotActionsMixin:
                 self._replace_selected_dataset(dataset, dataset_key)
         except Exception as err:
             log_exception("Selected run load failed", err, __name__)
+            self._clear_selected_run_state()
             self.show_error("Run Load Failed", f"Could not load run with GUID {guid}.", str(err))
             return
 

--- a/src/qplot/windows/_subplots/subplot1d.py
+++ b/src/qplot/windows/_subplots/subplot1d.py
@@ -11,13 +11,12 @@ def _subplot_axis_order(
         ) -> tuple[str, str] | None:
     """Map source data axes onto a host plot, or reject incompatible axes."""
 
-    del source_is_cut
     shared_x = parent_options.get("x")
     if not shared_x:
         return None
     if shared_x == source_options.get("x"):
         return "x", "y"
-    if shared_x == source_options.get("y"):
+    if not source_is_cut and shared_x == source_options.get("y"):
         return "y", "x"
     return None
 

--- a/src/qplot/windows/_widgets/preview.py
+++ b/src/qplot/windows/_widgets/preview.py
@@ -913,14 +913,52 @@ class PreviewWorker(QtCore.QRunnable):
         self.metadata = metadata
         self.preview_size = preview_size
         self._cancelled = threading.Event()
+        self._connection_lock = threading.Lock()
+        self._connection = None
 
 
     def cancel(self):
         self._cancelled.set()
+        with self._connection_lock:
+            connection = self._connection
+        if connection is not None:
+            try:
+                connection.interrupt()
+            except Exception:
+                # The worker may have closed the connection between the lock
+                # release and this cross-thread cancellation request.
+                pass
 
 
     def is_cancelled(self):
         return self._cancelled.is_set()
+
+
+    def _set_connection(self, connection):
+        with self._connection_lock:
+            self._connection = connection
+        if connection is not None and self._cancelled.is_set():
+            try:
+                connection.interrupt()
+            except Exception:
+                pass
+
+
+    def _emit_finished(self, previews, error):
+        try:
+            self.signals.finished.emit(
+                self.generation,
+                self.guid,
+                previews,
+                error,
+            )
+        except RuntimeError as err:
+            message = str(err)
+            if not (
+                    "wrapped C/C++ object" in message
+                    and "has been deleted" in message
+                    ):
+                raise
 
 
     def run(self):
@@ -933,16 +971,17 @@ class PreviewWorker(QtCore.QRunnable):
                     self.metadata,
                     size=self.preview_size,
                     is_cancelled=self._cancelled.is_set,
+                    connection_callback=self._set_connection,
                 )
             if self._cancelled.is_set():
                 previews = []
-            self.signals.finished.emit(self.generation, self.guid, previews, None)
+            self._emit_finished(previews, None)
         except Exception as error:
             if self._cancelled.is_set():
-                self.signals.finished.emit(self.generation, self.guid, [], None)
+                self._emit_finished([], None)
                 return
             log_exception("Preview generation failed", error, __name__)
-            self.signals.finished.emit(self.generation, self.guid, [], error)
+            self._emit_finished([], error)
 
 
 class PreviewSignals(QtCore.QObject):
@@ -954,6 +993,7 @@ def generate_run_previews(
         metadata,
         size=PREVIEW_SIZE,
         is_cancelled=None,
+        connection_callback=None,
         ):
     if is_cancelled is not None and is_cancelled():
         return []
@@ -968,6 +1008,8 @@ def generate_run_previews(
 
     previews = []
     conn = sqlite_read_only_connection(database_path, timeout=10)
+    if connection_callback is not None:
+        connection_callback(conn)
     cursor = None
     try:
         if is_cancelled is not None:
@@ -1009,6 +1051,8 @@ def generate_run_previews(
     finally:
         if cursor is not None:
             cursor.close()
+        if connection_callback is not None:
+            connection_callback(None)
         conn.close()
 
     return previews

--- a/src/qplot/windows/_widgets/treeWidgets.py
+++ b/src/qplot/windows/_widgets/treeWidgets.py
@@ -1121,6 +1121,11 @@ class moreInfo(qtw.QTabWidget):
         self.raw.clear()
 
 
+    def clear_database_cache(self):
+        """Discard summaries tied to the previously loaded database file."""
+        self._setpoint_summary_cache.clear()
+
+
     def scrollToTop(self):
         self.overview.scrollToTop()
         self.parameters.scrollToTop()

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -161,6 +161,11 @@ class MainWindow(
         self._database_refresh_worker: DatabaseRefreshWorker | None = None
         self._test_database_generation_active = False
         self._test_database_generation_worker: TestDatabaseGenerationWorker | None = None
+        self._shutdown_started = False
+        self._shutdown_ready = False
+        self._shutdown_timer = QtCore.QTimer(self)
+        self._shutdown_timer.setInterval(25)
+        self._shutdown_timer.timeout.connect(self._finish_deferred_shutdown)
         self._next_plot_x = 0
         self._next_plot_y = 0
         self.localLastFile = None
@@ -236,6 +241,10 @@ class MainWindow(
             )
         open_folder_action.triggered.connect(self.open_database_location)
         fileMenu.addAction(open_folder_action)
+
+        self.closeDatabaseAction = create_action("database.close", self)
+        self.closeDatabaseAction.triggered.connect(self.close_current_database)
+        fileMenu.addAction(self.closeDatabaseAction)
         
         # Force update check on database
         refreshAction = create_action("window.refresh", self)
@@ -284,7 +293,7 @@ class MainWindow(
         fileMenu.addAction(closeAction)
 
         quitAction = create_action("app.quit", self)
-        quitAction.triggered.connect(self.close)
+        quitAction.triggered.connect(self.quit_application)
         fileMenu.addAction(quitAction)
 
         add_standard_window_controls(self)
@@ -415,6 +424,32 @@ class MainWindow(
 ###############################################################################
 #Open/Close events
 
+    @QtCore.pyqtSlot()
+    def close_current_database(self):
+        """
+        Closes plot windows before releasing the current database.
+
+        """
+        if not self.fileTextbox.text():
+            self.show_status("No database is loaded.", 3000)
+            return
+
+        if not self.close_plot_windows(confirm=True, status=False):
+            self.show_status("Database close cancelled.", 3000)
+            return
+
+        self.close_database()
+
+
+    @QtCore.pyqtSlot()
+    def quit_application(self):
+        """
+        Routes the Quit command through the main window's shutdown handler.
+
+        """
+        self.close()
+
+
     @QtCore.pyqtSlot(bool)
     def closeEvent(self, event):
         """
@@ -423,6 +458,13 @@ class MainWindow(
         Also handles some closing admin        
 
         """
+        if getattr(self, "_shutdown_ready", False):
+            event.accept()
+            return
+        if getattr(self, "_shutdown_started", False):
+            event.ignore()
+            return
+
         # Confirm exit
         if self.config.get(CONFIRM_QUIT_KEY):
             reply = ask_confirmation_with_dont_ask_again(
@@ -431,9 +473,7 @@ class MainWindow(
                 "Are you sure you want to exit?",
                 CONFIRM_QUIT_KEY,
                 )
-            if reply == qtw.QMessageBox.StandardButton.Yes:
-                event.accept()
-            else:
+            if reply != qtw.QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
 
@@ -483,13 +523,66 @@ class MainWindow(
         self._test_database_generation_active = False
         self._test_database_generation_worker = None
         self.monitor.stop()
+        self.close_plot_windows(confirm=False, status=False)
+        self.close_database(status=False)
+
+        if MainWindow._shutdown_background_work_active(self):
+            self._shutdown_started = True
+            event.ignore()
+            hide = getattr(self, "hide", None)
+            if callable(hide):
+                hide()
+            shutdown_timer = getattr(self, "_shutdown_timer", None)
+            if shutdown_timer is not None:
+                shutdown_timer.start()
+            else:
+                QtCore.QTimer.singleShot(25, self._finish_deferred_shutdown)
+            return
+
+        self._shutdown_ready = True
+        event.accept()
         qtw.QApplication.closeAllWindows()
-        release_selected = getattr(self, "_release_selected_dataset", None)
-        if callable(release_selected):
-            release_selected()
-        close_handles = getattr(self, "_close_all_dataset_handles", None)
-        if callable(close_handles):
-            close_handles()
+
+
+    def _shutdown_background_work_active(self):
+        """
+        Reports whether a qPlot worker still needs the Qt event loop.
+
+        """
+        pool_names = (
+            "threadPool",
+            "databaseLoadThreadPool",
+            "databaseDetailThreadPool",
+            "databaseExpensiveDetailThreadPool",
+            "databaseRefreshThreadPool",
+            "testDatabaseGenerationThreadPool",
+        )
+        for pool_name in pool_names:
+            pool = getattr(self, pool_name, None)
+            if pool is not None and pool.activeThreadCount() > 0:
+                return True
+
+        preview = getattr(getattr(self, "infoBox", None), "preview", None)
+        return bool(getattr(preview, "_workers", {}))
+
+
+    @QtCore.pyqtSlot()
+    def _finish_deferred_shutdown(self):
+        """
+        Finishes Quit after cancelled background workers have returned.
+
+        """
+        if not getattr(self, "_shutdown_started", False):
+            return
+        if MainWindow._shutdown_background_work_active(self):
+            return
+
+        shutdown_timer = getattr(self, "_shutdown_timer", None)
+        if shutdown_timer is not None:
+            shutdown_timer.stop()
+        self._shutdown_started = False
+        self._shutdown_ready = True
+        qtw.QApplication.closeAllWindows()
     
    
     @QtCore.pyqtSlot()

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -148,6 +148,7 @@ class MainWindow(
         self._database_load_active = False
         self._database_load_state = None
         self._database_load_worker = None
+        self._loaded_database_identity = None
         self._database_detail_generation = 0
         self._database_detail_active = False
         self._database_detail_worker = None

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -7,6 +7,7 @@ import qcodes as qc
 from qcodes.dataset import initialise_or_create_database_at, load_by_id
 from qcodes.dataset.measurements import DataSaver
 
+from qplot import testdata as testdata_module
 from qplot.testdata import (
     CSV_COLUMNS,
     INSTRUCTION_FILE_NAMES,
@@ -129,6 +130,14 @@ def test_instruction_collection_cli_exports_all_files(tmp_path, capsys):
         (
             ("1", "V_SD", "Current", "nA", "-1", "1", "11", "", "", ""),
             "measured_name cannot be V_SD or V_G",
+        ),
+        (
+            ("1", "id", "Current", "nA", "-1", "1", "11", "", "", ""),
+            "measured_name cannot be used as a QCoDeS result column",
+        ),
+        (
+            ("1", "select", "Current", "nA", "-1", "1", "11", "", "", ""),
+            "measured_name cannot be used as a QCoDeS result column",
         ),
         (
             ("1", "current", "Current", "nA", "-1", "1", "11", "-2", "2", "5"),
@@ -390,6 +399,26 @@ def test_generation_failure_reports_timestamped_stop_and_removes_temporary_datab
     assert "Test database generation stopped (failed)" in output
 
 
+def test_generation_rejects_silently_missing_result_rows(
+    tmp_path,
+    monkeypatch,
+):
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_specification(
+        csv_path,
+        [("1", "current", "Current", "nA", "-1", "1", "5", "", "", "")],
+    )
+
+    monkeypatch.setattr(DataSaver, "add_result", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="persisted 0 of 5 expected result rows"):
+        generate_database_from_csv(csv_path, database_path)
+
+    assert not database_path.exists()
+    assert list(tmp_path.glob(".runs-*.db")) == []
+
+
 def test_generate_database_requires_explicit_overwrite(tmp_path):
     csv_path = tmp_path / "runs.csv"
     database_path = tmp_path / "runs.db"
@@ -406,3 +435,29 @@ def test_generate_database_requires_explicit_overwrite(tmp_path):
         csv_path, database_path, overwrite=True
     )
     assert generated_path == database_path
+
+
+def test_no_overwrite_publish_does_not_clobber_concurrently_created_file(
+    tmp_path,
+    monkeypatch,
+):
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_specification(
+        csv_path,
+        [("1", "current", "Current", "nA", "-1", "1", "5", "", "", "")],
+    )
+    original_write_run = testdata_module._write_run
+
+    def write_run_after_competitor_arrives(*args, **kwargs):
+        points_written = original_write_run(*args, **kwargs)
+        database_path.write_bytes(b"concurrent owner")
+        return points_written
+
+    monkeypatch.setattr(testdata_module, "_write_run", write_run_after_competitor_arrives)
+
+    with pytest.raises(SpecificationError, match="already exists"):
+        generate_database_from_csv(csv_path, database_path)
+
+    assert database_path.read_bytes() == b"concurrent owner"
+    assert list(tmp_path.glob(".runs-*.db")) == []

--- a/tests/widgets/test_run_details.py
+++ b/tests/widgets/test_run_details.py
@@ -779,6 +779,81 @@ class RunDetailsTabsTestCase(unittest.TestCase):
         self.assertEqual(preview.queue, {})
         self.assertEqual(preview.active, set())
 
+    def test_cancelled_preview_worker_ignores_deleted_signal_during_shutdown(self):
+        worker = preview_module.PreviewWorker(
+            1,
+            "previews.db",
+            "run-guid",
+            {},
+            100,
+        )
+
+        class DeletedFinishedSignal:
+            def emit(self, *args):
+                raise RuntimeError(
+                    "wrapped C/C++ object of type PreviewSignals has been deleted"
+                )
+
+        worker.signals = type(
+            "DeletedSignals",
+            (),
+            {"finished": DeletedFinishedSignal()},
+        )()
+
+        def interrupt_preview(*args, **kwargs):
+            worker.cancel()
+            raise sqlite3.OperationalError("interrupted")
+
+        with patch.object(
+                preview_module,
+                "generate_run_previews",
+                side_effect=interrupt_preview,
+                ):
+            worker.run()
+
+    def test_preview_worker_cancel_interrupts_its_active_sql_connection(self):
+        worker = preview_module.PreviewWorker(
+            1,
+            "previews.db",
+            "run-guid",
+            {},
+            100,
+        )
+
+        class Connection:
+            interrupts = 0
+
+            def interrupt(self):
+                self.interrupts += 1
+
+        connection = Connection()
+        worker._set_connection(connection)
+        worker.cancel()
+
+        self.assertTrue(worker.is_cancelled())
+        self.assertEqual(connection.interrupts, 1)
+
+    def test_cancelled_preview_worker_interrupts_a_new_sql_connection(self):
+        worker = preview_module.PreviewWorker(
+            1,
+            "previews.db",
+            "run-guid",
+            {},
+            100,
+        )
+        worker.cancel()
+
+        class Connection:
+            interrupts = 0
+
+            def interrupt(self):
+                self.interrupts += 1
+
+        connection = Connection()
+        worker._set_connection(connection)
+
+        self.assertEqual(connection.interrupts, 1)
+
     def test_deleting_preview_does_not_wait_for_python_worker(self):
         script = textwrap.dedent("""
             import threading

--- a/tests/windows/test_commands.py
+++ b/tests/windows/test_commands.py
@@ -1,6 +1,6 @@
 import unittest
 
-from PyQt6 import QtCore
+from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot.windows._commands import (
@@ -32,6 +32,22 @@ class CommandRegistryTestCase(unittest.TestCase):
             )
         finally:
             window.deleteLater()
+
+    def test_database_close_and_platform_quit_commands_are_registered(self):
+        close_action = command_spec("database.close")
+        quit_action = command_spec("app.quit")
+
+        self.assertEqual(close_action.text, "&Close Database")
+        self.assertEqual(close_action.object_name, "closeDatabaseAction")
+        self.assertEqual(quit_action.help_shortcut, "Ctrl+Q / Cmd+Q")
+        self.assertTrue(
+            any(
+                shortcut in quit_action.resolved_shortcuts()
+                for shortcut in QtGui.QKeySequence.keyBindings(
+                    QtGui.QKeySequence.StandardKey.Quit
+                )
+            )
+        )
 
     def test_dynamic_measurement_command_uses_expected_number(self):
         spec = plot_measurement_command_spec(2)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -15,6 +15,7 @@ from qplot.datahandling import database as database_module
 from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.windows import _database_actions as database_actions
 from qplot.windows import main as main_window
+from qplot.windows._commands import command_spec
 from qplot.windows._dataset_handle import DatasetHandle, DatasetKey, TraceKey
 from qplot.windows._plot_actions import PlotActionsMixin
 from qplot.windows._plotWin import plotWidget
@@ -1079,6 +1080,8 @@ class OptionsMenuTestCase(unittest.TestCase):
             super().__init__()
             self.config = OptionsMenuTestCase.FakeConfig()
             self.preview_size = 200
+            self.close_database_commands = 0
+            self.quit_commands = 0
 
         def refresh_recent_database_menu(self):
             pass
@@ -1088,6 +1091,9 @@ class OptionsMenuTestCase(unittest.TestCase):
 
         def open_database_location(self):
             pass
+
+        def close_current_database(self):
+            self.close_database_commands += 1
 
         def refreshMain(self):
             pass
@@ -1103,6 +1109,9 @@ class OptionsMenuTestCase(unittest.TestCase):
 
         def closeAll(self):
             pass
+
+        def quit_application(self):
+            self.quit_commands += 1
 
         def restore_default_settings(self):
             pass
@@ -1174,8 +1183,96 @@ class OptionsMenuTestCase(unittest.TestCase):
         finally:
             window.deleteLater()
 
+    def test_file_menu_exposes_close_database_and_quit_commands(self):
+        window = self.Harness()
+
+        try:
+            window.initMenu()
+            file_menu = next(
+                action.menu()
+                for action in window.menuBar().actions()
+                if action.text().replace("&", "") == "File"
+            )
+            actions = {
+                action.text().replace("&", ""): action
+                for action in file_menu.actions()
+                if not action.isSeparator()
+            }
+
+            actions["Close Database"].trigger()
+            actions["Quit qPlot"].trigger()
+
+            self.assertEqual(window.close_database_commands, 1)
+            self.assertEqual(window.quit_commands, 1)
+            self.assertEqual(
+                actions["Quit qPlot"].shortcuts(),
+                command_spec("app.quit").resolved_shortcuts(),
+            )
+        finally:
+            window.deleteLater()
+
 
 class CloseAllPlotsTestCase(unittest.TestCase):
+    def test_close_current_database_closes_plots_before_database(self):
+        calls = []
+
+        class Field:
+            def text(self):
+                return "test.db"
+
+        class Harness:
+            close_current_database = main_window.MainWindow.close_current_database
+
+            def __init__(self):
+                self.fileTextbox = Field()
+
+            def close_plot_windows(self, confirm=True, status=True):
+                calls.append(("plots", confirm, status))
+                return True
+
+            def close_database(self, status=True):
+                calls.append(("database", status))
+
+            def show_status(self, message, timeout=5000):
+                calls.append(("status", message, timeout))
+
+        Harness().close_current_database()
+
+        self.assertEqual(calls, [("plots", True, False), ("database", True)])
+
+    def test_close_current_database_can_be_cancelled_with_plots_open(self):
+        calls = []
+
+        class Field:
+            def text(self):
+                return "test.db"
+
+        class Harness:
+            close_current_database = main_window.MainWindow.close_current_database
+
+            def __init__(self):
+                self.fileTextbox = Field()
+
+            def close_plot_windows(self, confirm=True, status=True):
+                calls.append(("plots", confirm, status))
+                return False
+
+            def close_database(self, status=True):
+                raise AssertionError("Database should stay open after cancelling")
+
+            def show_status(self, message, timeout=5000):
+                calls.append(("status", message, timeout))
+
+        Harness().close_current_database()
+
+        self.assertEqual(
+            calls,
+            [
+                ("plots", True, False),
+                ("status", "Database close cancelled.", 3000),
+            ],
+        )
+
     def test_close_all_can_be_cancelled_when_warning_enabled(self):
         old_confirmation = main_window.ask_confirmation_with_dont_ask_again
         confirmation_keys = []
@@ -1352,6 +1449,7 @@ class CloseAllPlotsTestCase(unittest.TestCase):
         old_close_all_windows = qtw.QApplication.closeAllWindows
         confirmations = []
         closed_all_windows = []
+        shutdown_order = []
         updates = []
 
         class FakeConfig:
@@ -1410,6 +1508,13 @@ class CloseAllPlotsTestCase(unittest.TestCase):
                 self.monitor = Timer()
                 self.infoBox = type("InfoBox", (), {"preview": Preview()})()
 
+            def close_plot_windows(self, confirm=True, status=True):
+                shutdown_order.append(("plots", confirm, status))
+                return True
+
+            def close_database(self, status=True):
+                shutdown_order.append(("database", status))
+
         def fake_confirmation(window, title, message, config_key, *args):
             confirmations.append((title, message, config_key))
             window.config.update(config_key, False)
@@ -1417,7 +1522,11 @@ class CloseAllPlotsTestCase(unittest.TestCase):
 
         try:
             main_window.ask_confirmation_with_dont_ask_again = fake_confirmation
-            qtw.QApplication.closeAllWindows = lambda: closed_all_windows.append(True)
+            def close_all_windows():
+                shutdown_order.append(("windows",))
+                closed_all_windows.append(True)
+
+            qtw.QApplication.closeAllWindows = close_all_windows
             harness = Harness()
             worker = harness._database_load_worker
             event = Event()
@@ -1442,6 +1551,138 @@ class CloseAllPlotsTestCase(unittest.TestCase):
         self.assertTrue(harness.infoBox.preview.shut_down)
         self.assertTrue(harness.monitor.stopped)
         self.assertEqual(closed_all_windows, [True])
+        self.assertEqual(
+            shutdown_order,
+            [
+                ("plots", False, False),
+                ("database", False),
+                ("windows",),
+            ],
+        )
+
+    def test_cancelled_quit_leaves_database_open(self):
+        old_confirmation = main_window.ask_confirmation_with_dont_ask_again
+
+        class FakeConfig:
+            def get(self, key):
+                return True
+
+        class Event:
+            accepted = False
+            ignored = False
+
+            def accept(self):
+                self.accepted = True
+
+            def ignore(self):
+                self.ignored = True
+
+        class Harness:
+            closeEvent = main_window.MainWindow.closeEvent
+
+            def __init__(self):
+                self.config = FakeConfig()
+
+            def close_plot_windows(self, confirm=True, status=True):
+                raise AssertionError("Plot windows should stay open after cancelling")
+
+            def close_database(self, status=True):
+                raise AssertionError("Database should stay open after cancelling")
+
+        try:
+            main_window.ask_confirmation_with_dont_ask_again = (
+                lambda *args, **kwargs: qtw.QMessageBox.StandardButton.No
+            )
+            event = Event()
+            Harness().closeEvent(event)
+        finally:
+            main_window.ask_confirmation_with_dont_ask_again = old_confirmation
+
+        self.assertFalse(event.accepted)
+        self.assertTrue(event.ignored)
+
+    def test_quit_application_closes_the_main_window(self):
+        calls = []
+
+        class Harness:
+            quit_application = main_window.MainWindow.quit_application
+
+            def close(self):
+                calls.append("close")
+
+        Harness().quit_application()
+
+        self.assertEqual(calls, ["close"])
+
+    def test_shutdown_waits_for_owned_pools_and_preview_workers(self):
+        class Pool:
+            def __init__(self, active):
+                self.active = active
+
+            def activeThreadCount(self):
+                return self.active
+
+        preview = type("Preview", (), {"_workers": {}})()
+        harness = type(
+            "Harness",
+            (),
+            {
+                "threadPool": Pool(1),
+                "infoBox": type("InfoBox", (), {"preview": preview})(),
+            },
+        )()
+
+        self.assertTrue(
+            main_window.MainWindow._shutdown_background_work_active(harness)
+        )
+
+        harness.threadPool.active = 0
+        preview._workers = {("generation", "guid"): object()}
+        self.assertTrue(
+            main_window.MainWindow._shutdown_background_work_active(harness)
+        )
+
+        preview._workers = {}
+        self.assertFalse(
+            main_window.MainWindow._shutdown_background_work_active(harness)
+        )
+
+    def test_deferred_shutdown_finishes_after_workers_return(self):
+        old_close_all_windows = qtw.QApplication.closeAllWindows
+        closed = []
+
+        class Timer:
+            stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        class Harness:
+            _finish_deferred_shutdown = (
+                main_window.MainWindow._finish_deferred_shutdown
+            )
+
+            def __init__(self):
+                self._shutdown_started = True
+                self._shutdown_ready = False
+                self._shutdown_timer = Timer()
+                self.infoBox = type(
+                    "InfoBox",
+                    (),
+                    {"preview": type("Preview", (), {"_workers": {}})()},
+                )()
+
+        try:
+            qtw.QApplication.closeAllWindows = lambda: closed.append(True)
+            harness = Harness()
+            harness._finish_deferred_shutdown()
+        finally:
+            qtw.QApplication.closeAllWindows = old_close_all_windows
+
+        self.assertTrue(harness._shutdown_timer.stopped)
+        self.assertFalse(harness._shutdown_started)
+        self.assertTrue(harness._shutdown_ready)
+        self.assertEqual(closed, [True])
 
     def test_confirmation_options_use_shared_labels_and_config_keys(self):
         updates = []
@@ -3129,17 +3370,20 @@ class DatabaseRefreshWorkerTestCase(unittest.TestCase):
             10,
             database_path="example.db",
             cancelled_callback=ANY,
+            connection_callback=ANY,
             )
         self.assertEqual(seen_status_calls, [
             ("guid-1", {
                 "database_path": "example.db",
                 "include_storage_bytes": False,
                 "cancelled_callback": ANY,
+                "connection_callback": ANY,
                 }),
             ("guid-2", {
                 "database_path": "example.db",
                 "include_storage_bytes": False,
                 "cancelled_callback": ANY,
+                "connection_callback": ANY,
                 }),
             ])
         self.assertEqual(results, [(
@@ -3155,6 +3399,21 @@ class DatabaseRefreshWorkerTestCase(unittest.TestCase):
 
 
 class DatabaseLoadWorkerTestCase(unittest.TestCase):
+    def test_database_worker_cancel_interrupts_active_sql_connection(self):
+        worker = main_window.DatabaseLoadWorker(7, "example.db")
+
+        class Connection:
+            interrupts = 0
+
+            def interrupt(self):
+                self.interrupts += 1
+
+        connection = Connection()
+        worker._set_sql_connection(connection)
+        worker.cancel()
+
+        self.assertEqual(connection.interrupts, 1)
+
     def test_database_load_worker_opens_database_read_only_and_returns_runs(self):
         old_access_error = database_module.database_access_error
         old_get_runs = database_module.get_runs_basic_via_sql
@@ -3164,8 +3423,13 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             calls.append(("access", database_path))
             return None
 
-        def get_runs(database_path, cancelled_callback=None):
+        def get_runs(
+                database_path,
+                cancelled_callback=None,
+                connection_callback=None,
+                ):
             self.assertTrue(callable(cancelled_callback))
+            self.assertTrue(callable(connection_callback))
             calls.append(("basic_runs", database_path))
             return {1: {"guid": "guid-1", "run_timestamp": 123.0}}
 
@@ -3455,8 +3719,10 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 include_storage_estimate=False,
                 include_read_setpoint_count=True,
                 cancelled_callback=None,
+                connection_callback=None,
                 ):
             self.assertTrue(callable(cancelled_callback))
+            self.assertTrue(callable(connection_callback))
             calls.append((
                 database_path,
                 run_ids,
@@ -3523,8 +3789,10 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 run_ids,
                 batch_size=1,
                 cancelled_callback=None,
+                connection_callback=None,
                 ):
             self.assertTrue(callable(cancelled_callback))
+            self.assertTrue(callable(connection_callback))
             calls.append(("shapes", database_path, run_ids, batch_size))
             if 1 in run_ids:
                 yield {1: {"guid": "guid-1", "setpoint_shape": [10], "setpoint_count": 10}}
@@ -3534,8 +3802,10 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                 run_ids,
                 batch_size=25,
                 cancelled_callback=None,
+                connection_callback=None,
                 ):
             self.assertTrue(callable(cancelled_callback))
+            self.assertTrue(callable(connection_callback))
             calls.append(("storage", database_path, run_ids, batch_size))
             if 1 in run_ids:
                 yield {1: {"guid": "guid-1", "storage_bytes": 2000}}

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -180,6 +180,49 @@ class DatasetHandleTestCase(unittest.TestCase):
         self.assertTrue(dataset.conn.closed)
         self.assertEqual(harness.dataset_holder, {})
 
+    def test_replaced_database_invalidation_closes_only_matching_state(self):
+        class Connection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class Window:
+            def __init__(self, dataset_key):
+                self._dataset_key = dataset_key
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        key_a = DatasetKey("database-a.db", "guid-a")
+        key_b = DatasetKey("database-b.db", "guid-b")
+        dataset_a = type("Dataset", (), {"conn": Connection()})()
+        dataset_b = type("Dataset", (), {"conn": Connection()})()
+        window_a = Window(key_a)
+        window_b = Window(key_b)
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        harness.ds = dataset_a
+        harness._selected_dataset_key = key_a
+        harness.selected_run_id = 1
+        harness.dataset_holder = {
+            key_a: DatasetHandle(dataset_a),
+            key_b: DatasetHandle(dataset_b),
+        }
+        harness.windows = [window_a, window_b]
+
+        harness._invalidate_database_runtime_state("database-a.db")
+
+        self.assertIsNone(harness.ds)
+        self.assertIsNone(harness._selected_dataset_key)
+        self.assertIsNone(harness.selected_run_id)
+        self.assertTrue(window_a.closed)
+        self.assertFalse(window_b.closed)
+        self.assertTrue(dataset_a.conn.closed)
+        self.assertFalse(dataset_b.conn.closed)
+        self.assertEqual(harness.dataset_holder, {key_b: harness.dataset_holder[key_b]})
+
     def test_replacing_selected_dataset_closes_only_unheld_previous_dataset(self):
         class Connection:
             closed = False
@@ -583,6 +626,62 @@ class DatabaseAwareDatasetCacheTestCase(unittest.TestCase):
             "shared-guid",
             DatasetKey("database-b.db", "x").database_path,
         )
+
+    def test_failed_selection_clears_previous_dataset_and_selected_row(self):
+        class RunList:
+            def __init__(self):
+                self.signals_blocked = False
+                self.selection_cleared = False
+                self.current_item = object()
+
+            def blockSignals(self, blocked):
+                previous = self.signals_blocked
+                self.signals_blocked = blocked
+                return previous
+
+            def clearSelection(self):
+                self.selection_cleared = True
+
+            def setCurrentItem(self, item):
+                self.current_item = item
+
+        class InfoBox:
+            def __init__(self):
+                self.cleared = False
+
+            def clear(self):
+                self.cleared = True
+
+        harness = type("Harness", (PlotActionsMixin,), {})()
+        old_dataset = self.Dataset("database.db", run_id=7)
+        old_key = DatasetKey("database.db", old_dataset.guid)
+        harness.fileTextbox = self.Field("database.db")
+        harness.run_idBox = self.Field("7")
+        harness.RunList = RunList()
+        harness.infoBox = InfoBox()
+        harness.ds = old_dataset
+        harness._selected_dataset_key = old_key
+        harness.selected_run_id = 7
+        harness.dataset_holder = {old_key: DatasetHandle(old_dataset)}
+        harness._load_dataset = lambda _key: (_ for _ in ()).throw(
+            RuntimeError("broken run")
+        )
+        harness.status_messages = []
+        harness.error_messages = []
+        harness.show_status = lambda *args: harness.status_messages.append(args)
+        harness.show_error = lambda *args: harness.error_messages.append(args)
+
+        harness.updateSelected("new-guid")
+
+        self.assertIsNone(harness.ds)
+        self.assertIsNone(harness._selected_dataset_key)
+        self.assertIsNone(harness.selected_run_id)
+        self.assertEqual(harness.run_idBox.text(), "")
+        self.assertTrue(harness.RunList.selection_cleared)
+        self.assertIsNone(harness.RunList.current_item)
+        self.assertTrue(harness.infoBox.cleared)
+        self.assertEqual(harness.error_messages[0][0], "Run Load Failed")
+        self.assertIn(old_key, harness.dataset_holder)
 
     def test_same_guid_and_parameter_plots_in_different_databases_coexist(self):
         class PlotWindow:
@@ -1768,10 +1867,14 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         def __init__(self):
             self.preview = DatabaseLoadUiTestCase.Preview()
             self.cleared = False
+            self.database_cache_cleared = False
             self.scrolled = False
 
         def clear(self):
             self.cleared = True
+
+        def clear_database_cache(self):
+            self.database_cache_cleared = True
 
         def scrollToTop(self):
             self.scrolled = True
@@ -2135,6 +2238,47 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
                     started_workers,
                     )
                 self.assertIn("Database is already loaded", harness.status_messages[-1][0])
+            finally:
+                set_qcodes_database_location(active_database)
+
+    def test_replaced_same_path_database_starts_full_reload_and_invalidation(self):
+        active_database = get_DB_location()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "database.db"
+            replacement_path = Path(temp_dir) / "replacement.db"
+            database_path.write_bytes(b"first database")
+            replacement_path.write_bytes(b"replacement database with new identity")
+            try:
+                harness = self.Harness()
+                self.assertTrue(harness.load_database_path(str(database_path)))
+                generation = harness._database_load_generation
+                harness.database_load_finished(
+                    generation,
+                    str(database_path),
+                    {},
+                    None,
+                )
+                started_workers = len(harness.databaseLoadThreadPool.started)
+                invalidated = []
+                harness._invalidate_database_runtime_state = invalidated.append
+
+                os.replace(replacement_path, database_path)
+                self.assertTrue(harness.load_database_path(str(database_path)))
+
+                self.assertEqual(
+                    len(harness.databaseLoadThreadPool.started),
+                    started_workers + 1,
+                )
+                self.assertTrue(harness._database_load_state["reload_same_path"])
+                generation = harness._database_load_generation
+                harness.database_load_finished(
+                    generation,
+                    str(database_path),
+                    {},
+                    None,
+                )
+                self.assertEqual(invalidated, [str(database_path)])
+                self.assertTrue(harness.infoBox.database_cache_cleared)
             finally:
                 set_qcodes_database_location(active_database)
 

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -1113,11 +1113,17 @@ class SnapToTraceTestCase(unittest.TestCase):
                 source_is_cut=True,
             )
         )
-        self.assertEqual(
+        self.assertIsNone(
             _subplot_axis_order(
                 {"x": "gate", "y": "current"},
                 {"x": "field", "y": "gate"},
                 source_is_cut=True,
+            )
+        )
+        self.assertEqual(
+            _subplot_axis_order(
+                {"x": "gate", "y": "current"},
+                {"x": "field", "y": "gate"},
             ),
             ("y", "x"),
         )

--- a/tests/windows/test_testdata_gui.py
+++ b/tests/windows/test_testdata_gui.py
@@ -155,6 +155,29 @@ def test_generate_database_from_csv_runs_in_worker_pool(tmp_path):
         harness.deleteLater()
 
 
+def test_generation_completion_force_reloads_replaced_current_database(tmp_path):
+    harness = GuiHarness(tmp_path)
+    database_path = tmp_path / "runs.db"
+    harness.fileTextbox = type(
+        "Field",
+        (),
+        {"text": lambda _self: str(database_path)},
+    )()
+    harness.load_file = Mock(return_value=True)
+    specification = Mock(point_count=5)
+
+    try:
+        harness.test_database_generation_finished(
+            str(database_path),
+            [specification],
+            None,
+        )
+
+        harness.load_file.assert_called_once_with(str(database_path), force=True)
+    finally:
+        harness.deleteLater()
+
+
 def test_invalid_csv_is_reported_before_database_destination_prompt(tmp_path):
     harness = GuiHarness(tmp_path)
     csv_path = tmp_path / "invalid.csv"


### PR DESCRIPTION
## Release target

qPlot **1.5.0 beta 5**

- package version: `1.5.0b5`
- release tag to create after merge: `v1.5.0-b5`
- release date: 2026-08-02

## Highlights

- add ten cumulative test-database CSV specifications from about 10 MB to 30 GB
- batch generated QCoDeS writes and report timestamped progress and elapsed time
- add **File > Close Database**
- add database-aware **Quit qPlot** using Command-Q on macOS and Ctrl-Q on Windows/Linux

## Fixes

- reject fixed-axis 2D cuts when merging into incompatible 1D plots
- validate generated result columns and persisted row counts
- publish generated databases atomically without overwriting a concurrent creator
- clear stale selected-run state after a load failure
- detect database replacement at the same path and discard old caches, handles, previews, and plots
- bound preview scheduling and prevent stale workers from replacing newer preview state
- cancel and interrupt database work, close database handles, and wait for workers before Qt teardown
- prevent the shutdown traceback involving `sqlite3.OperationalError: interrupted` and deleted `PreviewSignals`

## Release preparation

- [x] bump `project.version` to `1.5.0b5`
- [x] move user-facing changes into the `1.5.0-b5` changelog section
- [x] update README and distribution install examples to `v1.5.0-b5`
- [x] validate the source distribution and wheel
- [x] install the wheel in a fresh virtual environment and verify both version entry points
- [ ] create tag `v1.5.0-b5` and the GitHub beta release after merge

## Validation

- `.venv-mac/bin/python -m ruff check .`
- `.venv-mac/bin/python -m mypy` — 62 source files
- `.venv-mac/bin/python -m pytest -q` — 575 passed, 16 subtests passed
- `.venv-mac/bin/python -m build`
- `.venv-mac/bin/python -m twine check ...` — wheel and source distribution passed
- clean-wheel install: `qplot-cfg -version` and `qplot.__version__` both report `1.5.0b5`
- clean-wheel `pip check` — no broken requirements
- qPlot GUI startup smoke check completed