### PR TITLE
Release qPlot 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+## 1.5.0-b6 - 2026-08-03
+
+### Fixed
+
+- Cancel active plot loads and discard queued plot work during shutdown so
+  cooperative database and processing work no longer keeps the command line
+  occupied after qPlot closes.
+- Interrupt active read-only SQLite plot queries where safe, add cancellation
+  checkpoints throughout plot preparation and heatmap processing, and prevent
+  cancelled or partial results from reaching closed plot windows.
+
+### Changed
+
+- Allow qPlot's built-in data operations to cooperate with cancellation while
+  preserving the existing one-argument contract for third-party operations.
+
 ## 1.5.0-b5 - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
-## 1.5.0-b6 - 2026-08-03
+## 1.5.0 - 2026-08-03
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # QCoDeS-Plotter
 
 [![release](https://img.shields.io/github/v/release/lairdgrouplancaster/QCoDeS-Plotter?label=release)](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/releases/latest)
-[![beta](https://img.shields.io/github/v/release/lairdgrouplancaster/QCoDeS-Plotter?include_prereleases&label=beta&color=orange)](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/releases)
 
 QCoDeS-Plotter, or qPlot, is a PyQt-based data viewer for QCoDeS databases. It
 is designed for inspecting completed and running experiments, with live refresh,
@@ -21,8 +20,7 @@ part of the GUI test or support matrix.
 ## Install
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
-The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b6`; it is documented below but is not used for the default install.
+The commands below install the latest full release, `1.5.0`.
 
 Windows:
 
@@ -31,7 +29,7 @@ py -3 --version
 py -3 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install -U pip
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.4.0
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0
 ```
 
 macOS:
@@ -41,14 +39,7 @@ python3 --version
 python3 -m venv .venv-mac
 source .venv-mac/bin/activate
 python -m pip install -U pip
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.4.0
-```
-
-To test the current beta instead, install its explicit tag in the same virtual
-environment:
-
-```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b6
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer
@@ -115,14 +106,12 @@ qplot.run()
 Plot windows may appear before their data has finished loading. Check the
 status bar at the bottom of the plot window before assuming a load has failed.
 
-For the installed `1.4.0` release, see its
-[versioned user guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.4.0/docs/user-guide.md).
-For the current beta, see [docs/user-guide.md](docs/user-guide.md).
+For the installed `1.5.0` release, see its
+[versioned user guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.5.0/docs/user-guide.md).
 
 Likewise, use the
-[1.4.0 troubleshooting guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.4.0/docs/troubleshooting.md)
-for the full release or [docs/troubleshooting.md](docs/troubleshooting.md) for
-the current beta.
+[1.5.0 troubleshooting guide](https://github.com/lairdgrouplancaster/QCoDeS-Plotter/blob/v1.5.0/docs/troubleshooting.md)
+for this release.
 
 For release history, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ part of the GUI test or support matrix.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.4.0`. The current beta
-is `1.5.0-b5`; it is documented below but is not used for the default install.
+is `1.5.0-b6`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -48,7 +48,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b5
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b6
 ```
 
 If the version check reports Python 3.10 or older, install Python 3.11 or newer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,16 @@ read-only database-loading path.
 
 `src/qplot/tools/worker.py` defines the background loader used by plot windows.
 It loads data, reshapes it for the plot type, applies selected operations, and
-emits results back to the GUI thread.
+emits results back to the GUI thread. Plot workers use cooperative cancellation:
+shutdown marks every registered worker as cancelled, interrupts its active
+read-only SQLite connection, clears work that has not started, and keeps the Qt
+event loop alive until running workers unwind. Built-in operations receive a
+cancellation callback and long Python loops check it periodically. Existing
+third-party operation callables remain compatible with the one-argument
+``operation(data_dict)`` contract; a callable that does not cooperate cannot be
+stopped during that individual Python call, so cancellation takes effect as soon
+as it returns. Threads are never terminated forcibly, and cancelled results are
+not applied to plot windows.
 
 `src/qplot/tools/general.py` and `plot_tools.py` contain small data helpers and
 plot operation functions. `src/qplot/tools/operation_registry.py` maps those

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -10,11 +10,10 @@ At runtime, `qplot.__version__` reads the installed package metadata through
 
 ## Current Install Path
 
-Recommended user install. This intentionally targets the latest full release,
-not the current prerelease:
+Recommended user install for the latest full release:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.4.0
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0
 ```
 
 Recommended development install:
@@ -25,15 +24,15 @@ python -m pip install -e ".[dev]"
 
 Both commands expose the `qplot` and `qplot-cfg` entry points.
 
-## Current Beta
+## Current Release
 
-The current beta is `1.5.0-b6`. The package metadata uses the PEP 440 normal
-form `1.5.0b6`; the GitHub release tag should be `v1.5.0-b6`.
+The current release is `1.5.0`. The package metadata uses the PEP 440 form
+`1.5.0`; the GitHub release tag should be `v1.5.0`.
 
-Beta test install:
+Release install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b6
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0
 ```
 
 ## Package Validation
@@ -59,8 +58,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b6`, even if the Git tag includes a separator,
-   such as `v1.5.0-b6`.
+   package form, such as `1.6.0b1`, even if the Git tag includes a separator,
+   such as `v1.6.0-b1`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,13 +27,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.0-b5`. The package metadata uses the PEP 440 normal
-form `1.5.0b5`; the GitHub release tag should be `v1.5.0-b5`.
+The current beta is `1.5.0-b6`. The package metadata uses the PEP 440 normal
+form `1.5.0b6`; the GitHub release tag should be `v1.5.0-b6`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b5
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.0-b6
 ```
 
 ## Package Validation
@@ -59,8 +59,8 @@ or attach them to GitHub releases.
 Before creating a tagged release:
 
 1. Update the version in `pyproject.toml`. For prereleases, use the PEP 440
-   package form, such as `1.5.0b5`, even if the Git tag includes a separator,
-   such as `v1.5.0-b5`.
+   package form, such as `1.5.0b6`, even if the Git tag includes a separator,
+   such as `v1.5.0-b6`.
 2. Move relevant entries from `CHANGELOG.md`'s Unreleased section into the new
    release section.
 3. Run `python -m ruff check .`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b5"
+version = "1.5.0b6"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.0b6"
+version = "1.5.0"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]
@@ -12,7 +12,7 @@ license = "MIT"
 requires-python = ">=3.11"
 keywords = ["qcodes", "pyqt", "pyqtgraph", "data-visualization", "scientific-computing"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: MacOS X",
     "Environment :: Win32 (MS Windows)",
     "Intended Audience :: Science/Research",

--- a/scripts/capture_demo_screenshots.py
+++ b/scripts/capture_demo_screenshots.py
@@ -21,8 +21,13 @@ def configure_environment():
     WORK_DIR.mkdir(parents=True, exist_ok=True)
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     os.environ.setdefault("MPLCONFIGDIR", str(WORK_DIR / "matplotlib"))
-    os.environ["HOME"] = str(WORK_DIR / "home")
-    (WORK_DIR / "home").mkdir(parents=True, exist_ok=True)
+    home_dir = WORK_DIR / "home"
+    os.environ["HOME"] = str(home_dir)
+    if os.name == "nt":
+        # ntpath.expanduser() prefers USERPROFILE over HOME. Keep screenshot
+        # generation isolated from a real qPlot configuration on Windows too.
+        os.environ["USERPROFILE"] = str(home_dir)
+    home_dir.mkdir(parents=True, exist_ok=True)
     (WORK_DIR / "matplotlib").mkdir(parents=True, exist_ok=True)
 
 

--- a/src/qplot/tools/operation_registry.py
+++ b/src/qplot/tools/operation_registry.py
@@ -32,8 +32,16 @@ class OperationCall:
     name: str
     func: Callable
     derivative_axis: str | None = None
+    cooperative: bool = False
 
     def __call__(self, data):
+        return self.func(data)
+
+    def execute(self, data, cancelled_callback):
+        """Run qPlot operations cooperatively while retaining one-arg calls."""
+
+        if self.cooperative:
+            return self.func(data, cancelled_callback=cancelled_callback)
         return self.func(data)
 
 
@@ -46,59 +54,115 @@ class OperationExecutionError(RuntimeError):
 
 
 COMMON_OPERATION_SPECS = (
-    OperationSpec("Limit Maximum", lambda limit, data: pass_filter("low", limit, data), float),
-    OperationSpec("Limit Minimum", lambda limit, data: pass_filter("high", limit, data), float),
+    OperationSpec(
+        "Limit Maximum",
+        lambda limit, data, cancelled_callback=None: pass_filter(
+            "low", limit, data, cancelled_callback=cancelled_callback
+            ),
+        float,
+        ),
+    OperationSpec(
+        "Limit Minimum",
+        lambda limit, data, cancelled_callback=None: pass_filter(
+            "high", limit, data, cancelled_callback=cancelled_callback
+            ),
+        float,
+        ),
     )
 
 PLOT_OPERATION_SPECS = {
     "plot1d": (
         OperationSpec(
             "dy/dx",
-            lambda data: differentiate("x", data),
+            lambda data, cancelled_callback=None: differentiate(
+                "x", data, cancelled_callback=cancelled_callback
+                ),
             None,
             derivative_axis="x",
             ),
         ),
     "plot2d": (
-        OperationSpec("Subtract Row Mean", lambda data: subtract_mean("x", data), None),
-        OperationSpec("Subtract Column Mean", lambda data: subtract_mean("y", data), None),
+        OperationSpec(
+            "Subtract Row Mean",
+            lambda data, cancelled_callback=None: subtract_mean(
+                "x", data, cancelled_callback=cancelled_callback
+                ),
+            None,
+            ),
+        OperationSpec(
+            "Subtract Column Mean",
+            lambda data, cancelled_callback=None: subtract_mean(
+                "y", data, cancelled_callback=cancelled_callback
+                ),
+            None,
+            ),
         OperationSpec(
             "dz/dx",
-            lambda data: differentiate("x", data),
+            lambda data, cancelled_callback=None: differentiate(
+                "x", data, cancelled_callback=cancelled_callback
+                ),
             None,
             derivative_axis="x",
             ),
         OperationSpec(
             "dz/dy",
-            lambda data: differentiate("y", data),
+            lambda data, cancelled_callback=None: differentiate(
+                "y", data, cancelled_callback=cancelled_callback
+                ),
             None,
             derivative_axis="y",
             ),
         OperationSpec(
             "Fill Below",
-            lambda value, data: fill_heatmap("below", data, max_depth=value),
+            lambda value, data, cancelled_callback=None: fill_heatmap(
+                "below",
+                data,
+                max_depth=value,
+                cancelled_callback=cancelled_callback,
+                ),
             int,
             10,
             ),
         OperationSpec(
             "Fill Right",
-            lambda value, data: fill_heatmap("right", data, max_depth=value),
+            lambda value, data, cancelled_callback=None: fill_heatmap(
+                "right",
+                data,
+                max_depth=value,
+                cancelled_callback=cancelled_callback,
+                ),
             int,
             10,
             ),
         ),
     "sweeper": (
-        OperationSpec("Subtract Cut Mean", lambda data: subtract_mean("x", data), None),
-        OperationSpec("Subtract Fixed Mean", lambda data: subtract_mean("y", data), None),
+        OperationSpec(
+            "Subtract Cut Mean",
+            lambda data, cancelled_callback=None: subtract_mean(
+                "x", data, cancelled_callback=cancelled_callback
+                ),
+            None,
+            ),
+        OperationSpec(
+            "Subtract Fixed Mean",
+            lambda data, cancelled_callback=None: subtract_mean(
+                "y", data, cancelled_callback=cancelled_callback
+                ),
+            None,
+            ),
         OperationSpec(
             "Differentiate Cut",
-            lambda data: differentiate("x", data),
+            lambda data, cancelled_callback=None: differentiate(
+                "x", data, cancelled_callback=cancelled_callback
+                ),
             None,
             derivative_axis="x",
             ),
         OperationSpec(
             "Differentiate Fixed",
-            lambda data: differentiate("y", data),
+            lambda data, cancelled_callback=None: differentiate(
+                "y", data, cancelled_callback=cancelled_callback
+                ),
             None,
             derivative_axis="y",
             ),

--- a/src/qplot/tools/plot_tools.py
+++ b/src/qplot/tools/plot_tools.py
@@ -17,9 +17,15 @@ used to find which properties to update the keyed value.
 import numpy as np
 
 
+def _check_cancelled(cancelled_callback):
+    if cancelled_callback is not None and cancelled_callback():
+        raise InterruptedError("Plot operation cancelled.")
+
+
 def subtract_mean(
         axis : str,
-        data_dict : dict
+        data_dict : dict,
+        cancelled_callback=None,
         ):
     """
     Subtracts the mean from the dataGrid based on the axis.
@@ -43,10 +49,12 @@ def subtract_mean(
     """
     dataGrid = data_dict["z"]
     num_axis = 1 if axis == "x" else 0
-    
+
+    _check_cancelled(cancelled_callback)
     mean = np.nanmean(dataGrid, axis=num_axis, keepdims=True)
-    
+    _check_cancelled(cancelled_callback)
     dataGrid = dataGrid - mean
+    _check_cancelled(cancelled_callback)
     
     return {"z" : dataGrid}
     
@@ -54,7 +62,8 @@ def subtract_mean(
 def pass_filter(
         which : str,
         limit : float,
-        data_dict : dict
+        data_dict : dict,
+        cancelled_callback=None,
         ):
     """
     Filters dependant parameter data to set values outside the limit to the 
@@ -94,14 +103,17 @@ def pass_filter(
     else:
         raise KeyError(f'Invalid value for which: {which}. Must be: "high" or "low"')
     
+    _check_cancelled(cancelled_callback)
     new_data = np.clip(data, *limit_arr)
+    _check_cancelled(cancelled_callback)
     
     return {axis : new_data}
 
 
 def differentiate(
         dx : str,
-        data_dict : dict
+        data_dict : dict,
+        cancelled_callback=None,
         ):
     """
     Differentiates the dependant parameter data with respect to the input dx    
@@ -124,6 +136,7 @@ def differentiate(
             {"y": new_data} for 1d
 
     """
+    _check_cancelled(cancelled_callback)
     if dx not in ["x", "y"]:
         raise KeyError(f'Invalid value for dx: {dx}, must be "x" or "y".')
     
@@ -145,7 +158,9 @@ def differentiate(
     if np.any(np.diff(coordinates) == 0):
         raise ValueError("Differentiation axis coordinates must not repeat.")
 
+    _check_cancelled(cancelled_callback)
     new_data = np.gradient(data, coordinates, axis=axis_num)
+    _check_cancelled(cancelled_callback)
     
     return {key : new_data}
 
@@ -153,8 +168,10 @@ def differentiate(
 def fill_heatmap(
         which : str,
         data_dict : dict,
-        max_depth : int = 10
+        max_depth : int = 10,
+        cancelled_callback=None,
         ):
+    _check_cancelled(cancelled_callback)
     data = data_dict["z"].copy()
     if which == "below":
         lines = (data[:, column] for column in range(data.shape[1]))
@@ -167,6 +184,7 @@ def fill_heatmap(
         return {"z": data}
 
     for line in lines:
+        _check_cancelled(cancelled_callback)
         position = 0
         while position < len(line):
             if not np.isnan(line[position]):
@@ -175,13 +193,16 @@ def fill_heatmap(
 
             gap_start = position
             while position < len(line) and np.isnan(line[position]):
+                if position % 1024 == 0:
+                    _check_cancelled(cancelled_callback)
                 position += 1
 
             gap_length = position - gap_start
             bounded = gap_start > 0 and position < len(line)
             if bounded and gap_length <= max_depth:
                 line[gap_start:position] = line[gap_start - 1]
-        
+
+    _check_cancelled(cancelled_callback)
     return {"z" : data}
         
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -1,4 +1,5 @@
 import math
+import threading
 from copy import copy
 from typing import TYPE_CHECKING, Any
 
@@ -21,7 +22,7 @@ from qplot.datahandling.readonly import (
     sqlite_read_only_connection,
 )
 from qplot.diagnostics import log_exception
-from qplot.tools.operation_registry import OperationExecutionError
+from qplot.tools.operation_registry import OperationCall, OperationExecutionError
 
 from . import data2matrix
 from .heatmap_geometry import canonicalize_heatmap_data
@@ -34,6 +35,11 @@ MAX_SQL_HEATMAP_SOURCE_ROWS = 250_000
 MAX_SQL_HEATMAP_GRID_SIDE = 800
 MAX_SQL_HEATMAP_GRID_CELLS = 250_000
 SQL_HEATMAP_SAMPLES_PER_CELL = 4
+CANCELLATION_CHUNK_SIZE = 65_536
+
+
+class PlotWorkCancelled(InterruptedError):
+    """Internal control flow used to unwind cancelled plot work safely."""
 
 
 def _sqlite_identifier(name):
@@ -86,6 +92,9 @@ class loader(QtCore.QRunnable):
         super().__init__()
         self.running = True
         self.emitter = _emitter() # For signals
+        self._cancelled = threading.Event()
+        self._sql_connection_lock = threading.Lock()
+        self._sql_connection = None
         
         # Required working data
         self.cache = cache
@@ -112,8 +121,78 @@ class loader(QtCore.QRunnable):
             ) = None
         
     
+    def _ensure_cancel_state(self) -> None:
+        """Initialise cancellation state for legacy/tests using ``__new__``."""
+
+        if not hasattr(self, "_cancelled"):
+            self._cancelled = threading.Event()
+        if not hasattr(self, "_sql_connection_lock"):
+            self._sql_connection_lock = threading.Lock()
+            self._sql_connection = None
+
+
+    def cancel(self) -> None:
+        """Request cooperative cancellation and interrupt an active SQL read."""
+
+        self._ensure_cancel_state()
+        self._cancelled.set()
+        with self._sql_connection_lock:
+            connection = self._sql_connection
+        if connection is not None:
+            try:
+                connection.interrupt()
+            except Exception:
+                # The worker may be closing the connection at the same time.
+                pass
+
+
+    def is_cancelled(self) -> bool:
+        self._ensure_cancel_state()
+        return self._cancelled.is_set()
+
+
+    def _check_cancelled(self) -> None:
+        if self.is_cancelled():
+            raise PlotWorkCancelled("Plot load cancelled.")
+
+
+    def _set_sql_connection(self, connection) -> None:
+        self._ensure_cancel_state()
+        with self._sql_connection_lock:
+            self._sql_connection = connection
+        if connection is not None and self._cancelled.is_set():
+            try:
+                connection.interrupt()
+            except Exception:
+                pass
+
+
+    def _close_sql_connection(self, connection) -> None:
+        try:
+            connection.close()
+        finally:
+            self._set_sql_connection(None)
+
+
+    def _emit_finished(self, finished: bool) -> None:
+        """Emit completion unless Qt already deleted the receiver at shutdown."""
+
+        try:
+            self.emitter.finished.emit(finished)
+        except RuntimeError as err:
+            message = str(err)
+            if not ("wrapped C/C++ object" in message and "has been deleted" in message):
+                raise
+
+
+    def _finish_cancelled(self) -> None:
+        self.running = False
+        self._emit_finished(False)
+
+
     def run(self):
         try:
+            self._check_cancelled()
             ensure_supported_plot_dimensions(
                 getattr(self.param, "name", "Measurement"),
                 getattr(self.param, "depends_on_", ()),
@@ -131,16 +210,20 @@ class loader(QtCore.QRunnable):
                     completion_conn = qcodes_read_only_connection(
                         cache_database_path(cache)
                         )
+                    self._set_sql_connection(completion_conn)
                     try:
+                        self._check_cancelled()
                         complete = load_param_data_from_db_prep(
                             cache,
                             self.param,
                             connection=completion_conn,
                             )
                     finally:
-                        completion_conn.close()
+                        self._close_sql_connection(completion_conn)
+                    self._check_cancelled()
                     self.read_data = not complete
 
+            self._check_cancelled()
             use_sql_heatmap = (
                 self.read_data
                 and not cache_live
@@ -156,7 +239,9 @@ class loader(QtCore.QRunnable):
                         snapshot_cache_parameter_state(cache, self.param.name)
                         )
                     conn = qcodes_read_only_connection(cache_database_path(cache))
+                    self._set_sql_connection(conn)
                     try:
+                        self._check_cancelled()
                         (
                             self.updated_read_status,
                             self.updated_write_status,
@@ -171,13 +256,15 @@ class loader(QtCore.QRunnable):
                             existing_data,
                         )
                     finally:
-                        conn.close()
+                        self._close_sql_connection(conn)
 
+                    self._check_cancelled()
                     data = self.cache_data[self.param.name]
 
                 else:
                     data = cache_parameter_data(cache, self.param.name)
 
+                self._check_cancelled()
                 depvarData = data[self.param.name]
 
                 # for shaped 2d plots
@@ -222,13 +309,20 @@ class loader(QtCore.QRunnable):
                 if len(self.param.depends_on_) != 1:
                     self.dataGrid = dataGrid
 
+        except PlotWorkCancelled:
+            self._finish_cancelled()
+            return
         except Exception as err: # Raise error in main thread
+            if self.is_cancelled():
+                self._finish_cancelled()
+                return
             log_exception("Plot worker failed", err, __name__)
             self.emitter.errorOccurred.emit(err)
-            self.emitter.finished.emit(False) # False: Failed
+            self._emit_finished(False) # False: Failed
             return
 
         try:
+            self._check_cancelled()
             # Operations are an ordered, atomic pipeline. Large heatmaps are
             # reduced for display only after this pipeline has completed.
             results = self.do_operations()
@@ -241,25 +335,37 @@ class loader(QtCore.QRunnable):
                     self.dataGrid = results[2]
                 self._apply_operation_metadata()
 
+            self._check_cancelled()
             self._aggregate_operated_heatmap_if_needed()
+            self._check_cancelled()
             self._canonicalize_heatmap()
+            self._check_cancelled()
+        except PlotWorkCancelled:
+            self._finish_cancelled()
+            return
         except Exception as err:
+            if self.is_cancelled():
+                self._finish_cancelled()
+                return
             log_exception("Plot processing failed", err, __name__)
             self.emitter.errorOccurred.emit(err)
-            self.emitter.finished.emit(False)
+            self._emit_finished(False)
             return
 
         # Callback
-        self.emitter.finished.emit(True)
+        self._emit_finished(True)
 
 
     def _canonicalize_heatmap(self) -> None:
         """Keep worker indices consistent with increasing heatmap axes."""
 
+        self._check_cancelled()
         if not hasattr(self, "dataGrid"):
             return
         x_data = np.asarray(self.axis_data.get("x", []))
+        self._check_cancelled()
         y_data = np.asarray(self.axis_data.get("y", []))
+        self._check_cancelled()
         data_grid = np.asarray(self.dataGrid)
         if x_data.size == 0 or y_data.size == 0 or data_grid.size == 0:
             return
@@ -269,6 +375,7 @@ class loader(QtCore.QRunnable):
             y_data,
             data_grid,
             )
+        self._check_cancelled()
         self.axis_data["x"] = x_data
         self.axis_data["y"] = y_data
         self.dataGrid = data_grid
@@ -314,10 +421,12 @@ class loader(QtCore.QRunnable):
             return setpoint_count
 
         conn = sqlite_read_only_connection(cache_database_path(self.cache))
+        self._set_sql_connection(conn)
         try:
+            self._check_cancelled()
             setpoint_count = self._selected_parameter_row_count(conn)
         finally:
-            conn.close()
+            self._close_sql_connection(conn)
 
         if setpoint_count is not None:
             self.total_point_count_estimate = setpoint_count
@@ -349,8 +458,11 @@ class loader(QtCore.QRunnable):
 
     def _load_large_heatmap_from_sql(self):
         conn = sqlite_read_only_connection(cache_database_path(self.cache))
+        self._set_sql_connection(conn)
         try:
+            self._check_cancelled()
             rowid_min, rowid_max = self._rowid_span(conn)
+            self._check_cancelled()
             self.heatmap_source_grid_shape = (
                 self._heatmap_source_grid_shape_from_metadata()
                 )
@@ -360,8 +472,9 @@ class loader(QtCore.QRunnable):
                 rowid_max,
                 )
         finally:
-            conn.close()
+            self._close_sql_connection(conn)
 
+        self._check_cancelled()
         x_axis, y_axis, data_grid = self._heatmap_grid_from_arrays(
             x_data,
             y_data,
@@ -387,6 +500,7 @@ class loader(QtCore.QRunnable):
 
 
     def _rowid_span(self, conn):
+        self._check_cancelled()
         table = _sqlite_identifier(self.table_name)
         row = conn.execute(f"SELECT MIN(rowid), MAX(rowid) FROM {table}").fetchone()
         if row is None or row[0] is None or row[1] is None:
@@ -396,6 +510,7 @@ class loader(QtCore.QRunnable):
 
 
     def _read_heatmap_arrays(self, conn, rowid_min, rowid_max):
+        self._check_cancelled()
         if rowid_min is None or rowid_max is None:
             self._heatmap_source_info = {
                 "row_count": 0,
@@ -500,6 +615,7 @@ class loader(QtCore.QRunnable):
 
 
     def _heatmap_spatial_summary(self, conn, where_sql, parameters):
+        self._check_cancelled()
         table = _sqlite_identifier(self.table_name)
         x_column = _sqlite_identifier(self.axes_dict["x"])
         y_column = _sqlite_identifier(self.axes_dict["y"])
@@ -600,7 +716,9 @@ class loader(QtCore.QRunnable):
         y_indices = []
         z_values = []
         aggregated_source_rows = 0
-        for x_index, y_index, z_value, bin_rows in cursor:
+        for row_number, (x_index, y_index, z_value, bin_rows) in enumerate(cursor):
+            if row_number % 1024 == 0:
+                self._check_cancelled()
             if z_value is None:
                 continue
             x_indices.append(int(x_index))
@@ -658,6 +776,7 @@ class loader(QtCore.QRunnable):
 
 
     def _selected_parameter_row_count(self, conn):
+        self._check_cancelled()
         table = _sqlite_identifier(self.table_name)
         z_column = _sqlite_identifier(self.param.name)
         row = conn.execute(
@@ -722,7 +841,9 @@ class loader(QtCore.QRunnable):
         y_values = []
         z_values = []
 
-        for x_value, y_value, z_value in cursor:
+        for row_number, (x_value, y_value, z_value) in enumerate(cursor):
+            if row_number % 1024 == 0:
+                self._check_cancelled()
             x_values.append(x_value)
             y_values.append(y_value)
             z_values.append(z_value)
@@ -731,10 +852,15 @@ class loader(QtCore.QRunnable):
 
 
     def _arrays_from_values(self, x_values, y_values, z_values):
+        self._check_cancelled()
         x_data = np.asarray(x_values, dtype=float)
+        self._check_cancelled()
         y_data = np.asarray(y_values, dtype=float)
+        self._check_cancelled()
         z_data = np.asarray(z_values, dtype=float)
+        self._check_cancelled()
         finite = np.isfinite(x_data) & np.isfinite(y_data) & np.isfinite(z_data)
+        self._check_cancelled()
 
         return x_data[finite], y_data[finite], z_data[finite]
 
@@ -747,6 +873,7 @@ class loader(QtCore.QRunnable):
             *,
             max_cells=MAX_SQL_HEATMAP_GRID_CELLS,
             ):
+        self._check_cancelled()
         max_cells = max(1, int(max_cells))
         if z_data.size == 0:
             self._heatmap_grid_info = {
@@ -767,7 +894,9 @@ class loader(QtCore.QRunnable):
                 )
 
         unique_x = np.unique(x_data)
+        self._check_cancelled()
         unique_y = np.unique(y_data)
+        self._check_cancelled()
         exact_cells = unique_x.size * unique_y.size
         source_grid_shape = getattr(self, "heatmap_source_grid_shape", None)
         if source_grid_shape is None:
@@ -857,6 +986,7 @@ class loader(QtCore.QRunnable):
             source_grid_rows,
             source_grid_columns,
             ):
+        self._check_cancelled()
         x_axis, y_axis = self._spatial_heatmap_axes
         x_indices, y_indices = self._spatial_heatmap_indices
         data_grid = np.full(
@@ -865,6 +995,7 @@ class loader(QtCore.QRunnable):
             dtype=float,
             )
         data_grid[y_indices, x_indices] = z_data
+        self._check_cancelled()
         empty_bins_filled = bool(np.any(~np.isfinite(data_grid)))
         if empty_bins_filled:
             data_grid = self._fill_empty_heatmap_bins(data_grid)
@@ -989,13 +1120,20 @@ class loader(QtCore.QRunnable):
 
 
     def _unique_heatmap_grid(self, x_data, y_data, z_data, unique_x, unique_y):
+        self._check_cancelled()
         x_index = np.searchsorted(unique_x, x_data)
+        self._check_cancelled()
         y_index = np.searchsorted(unique_y, y_data)
         grid_sum = np.zeros((unique_y.size, unique_x.size), dtype=float)
         grid_count = np.zeros((unique_y.size, unique_x.size), dtype=np.int32)
-        np.add.at(grid_sum, (y_index, x_index), z_data)
-        np.add.at(grid_count, (y_index, x_index), 1)
+        for start in range(0, z_data.size, CANCELLATION_CHUNK_SIZE):
+            self._check_cancelled()
+            stop = start + CANCELLATION_CHUNK_SIZE
+            indices = (y_index[start:stop], x_index[start:stop])
+            np.add.at(grid_sum, indices, z_data[start:stop])
+            np.add.at(grid_count, indices, 1)
 
+        self._check_cancelled()
         data_grid = np.full(grid_sum.shape, np.nan, dtype=float)
         np.divide(
             grid_sum,
@@ -1018,6 +1156,7 @@ class loader(QtCore.QRunnable):
             max_cells=None,
             fill_empty=False,
             ):
+        self._check_cancelled()
         x_bins, y_bins = self._bounded_grid_shape(
             unique_x.size,
             unique_y.size,
@@ -1033,12 +1172,18 @@ class loader(QtCore.QRunnable):
             y_bins,
             self._grid_axis_bounds("y"),
             )
+        self._check_cancelled()
 
         grid_sum = np.zeros((y_centres.size, x_centres.size), dtype=float)
         grid_count = np.zeros((y_centres.size, x_centres.size), dtype=np.int32)
-        np.add.at(grid_sum, (y_index, x_index), z_data)
-        np.add.at(grid_count, (y_index, x_index), 1)
+        for start in range(0, z_data.size, CANCELLATION_CHUNK_SIZE):
+            self._check_cancelled()
+            stop = start + CANCELLATION_CHUNK_SIZE
+            indices = (y_index[start:stop], x_index[start:stop])
+            np.add.at(grid_sum, indices, z_data[start:stop])
+            np.add.at(grid_count, indices, 1)
 
+        self._check_cancelled()
         data_grid = np.full(grid_sum.shape, np.nan, dtype=float)
         np.divide(
             grid_sum,
@@ -1054,8 +1199,8 @@ class loader(QtCore.QRunnable):
         return x_centres, y_centres, data_grid
 
 
-    @staticmethod
-    def _fill_empty_heatmap_bins(data_grid):
+    def _fill_empty_heatmap_bins(self, data_grid):
+        self._check_cancelled()
         if data_grid.size == 0 or np.all(np.isfinite(data_grid)):
             return data_grid
         if not np.any(np.isfinite(data_grid)):
@@ -1066,6 +1211,7 @@ class loader(QtCore.QRunnable):
         column_positions = np.arange(filled.shape[1], dtype=float)
 
         for column in range(filled.shape[1]):
+            self._check_cancelled()
             values = filled[:, column]
             finite = np.isfinite(values)
             if np.any(finite) and not np.all(finite):
@@ -1076,6 +1222,7 @@ class loader(QtCore.QRunnable):
                     )
 
         for row in range(filled.shape[0]):
+            self._check_cancelled()
             values = filled[row, :]
             finite = np.isfinite(values)
             if np.any(finite) and not np.all(finite):
@@ -1129,6 +1276,7 @@ class loader(QtCore.QRunnable):
 
 
     def _scaled_axis_indices(self, values, bin_count, bounds=None):
+        self._check_cancelled()
         if bounds is None:
             lower = float(np.nanmin(values))
             upper = float(np.nanmax(values))
@@ -1145,7 +1293,9 @@ class loader(QtCore.QRunnable):
                 )
 
         scaled = (values - lower) / (upper - lower)
+        self._check_cancelled()
         indices = np.floor(scaled * bin_count).astype(np.int64)
+        self._check_cancelled()
         indices = np.clip(indices, 0, bin_count - 1)
         step = (upper - lower) / bin_count
         centres = lower + (np.arange(bin_count, dtype=float) + 0.5) * step
@@ -1154,32 +1304,38 @@ class loader(QtCore.QRunnable):
 
 
     def for_1d(self, data, valid_rows):
+        self._check_cancelled()
         axis_data = {}
         axis_param = {}
         dict_labels = list(data.keys())
         
         x_name =  self.axes_dict["x"]
         axis_data["x"] = data[x_name][valid_rows]
+        self._check_cancelled()
         axis_param["x"] = self.param_dict[x_name]
         
         # get other value
         index = 1 if dict_labels[0] == x_name else 0
         axis_data["y"] = data[dict_labels[index]][valid_rows]
+        self._check_cancelled()
         axis_param["y"] = self.param_dict[dict_labels[index]]
         
         return axis_data, axis_param
         
     
     def for_shaped_2d(self, data, depvarData):
+        self._check_cancelled()
         axis_data = {}
         axis_param = {}
         axis_dimension = {}
         valid = {}
         shaped_axes_are_rectilinear = True
         depvarData = np.asarray(depvarData, dtype=float)
+        self._check_cancelled()
         
         # Find correct data for each axis
         for axis in ["x", "y"]:
+            self._check_cancelled()
             name = self.axes_dict[axis]
             param = self.param_dict[name]
 
@@ -1238,11 +1394,14 @@ class loader(QtCore.QRunnable):
 
 
     def _shaped_axis_values(self, param_data, dimension):
+        self._check_cancelled()
         moved = np.moveaxis(param_data, dimension, 0)
         rows = moved.reshape(moved.shape[0], -1)
         values = np.full(rows.shape[0], np.nan, dtype=float)
 
         for index, row in enumerate(rows):
+            if index % 1024 == 0:
+                self._check_cancelled()
             finite = np.flatnonzero(np.isfinite(row))
             if finite.size:
                 values[index] = row[finite[0]]
@@ -1251,6 +1410,7 @@ class loader(QtCore.QRunnable):
 
 
     def _shaped_axis_residual(self, param_data, dimension):
+        self._check_cancelled()
         values = self._shaped_axis_values(param_data, dimension)
         shape = [1] * param_data.ndim
         shape[dimension] = values.size
@@ -1263,6 +1423,7 @@ class loader(QtCore.QRunnable):
 
 
     def _shaped_axis_is_rectilinear(self, param_data, dimension):
+        self._check_cancelled()
         values = self._shaped_axis_values(param_data, dimension)
         shape = [1] * param_data.ndim
         shape[dimension] = values.size
@@ -1291,6 +1452,7 @@ class loader(QtCore.QRunnable):
 
 
     def _shaped_data_grid(self, data, depvarData, axis_dimension, valid):
+        self._check_cancelled()
         x_dimension = axis_dimension["x"]
         y_dimension = axis_dimension["y"]
 
@@ -1309,9 +1471,11 @@ class loader(QtCore.QRunnable):
     
     
     def for_unshaped_2d(self, data, valid_rows, depvarData):
+        self._check_cancelled()
         axis_data = {}
         axis_param = {}
         for axis in ["x", "y"]:
+            self._check_cancelled()
             # Get specific parameter
             name = self.axes_dict[axis]
             param = self.param_dict[name]
@@ -1325,6 +1489,7 @@ class loader(QtCore.QRunnable):
                 axis_data["x"], 
                 depvarData[valid_rows]
             )
+        self._check_cancelled()
         
         # remove duplicates
         axis_data["y"] = dataGrid.index.to_numpy(float)
@@ -1352,19 +1517,36 @@ class loader(QtCore.QRunnable):
         operations = self.operations
         if len(operations) == 0:
             return None
-        
+
+        self._check_cancelled()
         data_dict = {
             "x" : self.axis_data["x"].copy(),
-            "y" : self.axis_data["y"].copy(),
-            "z" : self.dataGrid.copy() if hasattr(self, "dataGrid") else None # Only give dataGrid if it exists
+            "y" : None,
+            "z" : None,
             }
-        
+        self._check_cancelled()
+        data_dict["y"] = self.axis_data["y"].copy()
+        self._check_cancelled()
+        if hasattr(self, "dataGrid"):
+            data_dict["z"] = self.dataGrid.copy()
+        self._check_cancelled()
+
         for operation in operations:
+            self._check_cancelled()
             try:
-                results = operation(data_dict)
+                if isinstance(operation, OperationCall):
+                    results = operation.execute(data_dict, self.is_cancelled)
+                else:
+                    # Backwards compatibility: arbitrary operations continue
+                    # to receive exactly one data dictionary argument. Such a
+                    # call can only be cancelled after it returns.
+                    results = operation(data_dict)
+                self._check_cancelled()
                 for key in results.keys():
                     data_dict[key] = results[key]
             except Exception as err:
+                if self.is_cancelled():
+                    raise PlotWorkCancelled("Plot load cancelled.") from err
                 name = getattr(operation, "name", None)
                 description = f' "{name}"' if name else ""
                 raise OperationExecutionError(
@@ -1411,14 +1593,17 @@ class loader(QtCore.QRunnable):
     def _aggregate_operated_heatmap_if_needed(self):
         """Reduce an operated raw heatmap to the configured display limit."""
 
+        self._check_cancelled()
         if not self.operations or not hasattr(self, "dataGrid"):
             return
 
         data_grid = np.asarray(self.dataGrid, dtype=float)
+        self._check_cancelled()
         if data_grid.size <= self.max_full_heatmap_points:
             return
 
         x_axis = np.asarray(self.axis_data["x"], dtype=float)
+        self._check_cancelled()
         y_axis = np.asarray(self.axis_data["y"], dtype=float)
         if data_grid.shape != (y_axis.size, x_axis.size):
             raise ValueError(
@@ -1432,9 +1617,12 @@ class loader(QtCore.QRunnable):
             "y": (float(np.nanmin(y_axis)), float(np.nanmax(y_axis))),
             }
         x_data = np.tile(x_axis, y_axis.size)
+        self._check_cancelled()
         y_data = np.repeat(y_axis, x_axis.size)
+        self._check_cancelled()
         z_data = data_grid.reshape(-1)
         finite = np.isfinite(x_data) & np.isfinite(y_data) & np.isfinite(z_data)
+        self._check_cancelled()
         x_data = x_data[finite]
         y_data = y_data[finite]
         z_data = z_data[finite]

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -1220,6 +1220,11 @@ class plotWidget(
         """
         if self.__dict__.get("_merged_trace_users", 0) <= 0:
             self.monitor.stop()
+            self._refresh_pending = False
+            worker = self.__dict__.get("worker")
+            cancel = getattr(worker, "cancel", None)
+            if callable(cancel):
+                cancel()
         self.visible = False
         self._closed = True
         self.closed.emit(self)

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -162,6 +162,14 @@ class PlotRefreshMixin(_PlotRefreshBase):
         worker.emitter.finished.connect(
             lambda finished, worker=worker: self.refreshPlot(finished, worker=worker)
             )
+        worker_registry = getattr(self.threadPool, "_qplot_workers", None)
+        if worker_registry is not None:
+            worker_registry.add(worker)
+            worker.emitter.finished.connect(
+                lambda _finished, worker=worker, registry=worker_registry: (
+                    registry.discard(worker)
+                    )
+                )
         # Error event handling
         worker.emitter.errorOccurred.connect(
             lambda err, worker=worker: self.err_raiser(err, worker=worker)
@@ -321,12 +329,20 @@ class PlotRefreshMixin(_PlotRefreshBase):
             return False
         worker = current_worker
 
+        was_cancelled = bool(
+            getattr(worker, "is_cancelled", lambda: False)()
+            )
+
         if not self._can_process_refresh():
             worker.running = False
             self.end_wait.emit()
             return False
 
         try:
+            if was_cancelled:
+                worker.running = False
+                return False
+
             if not finished:  # error in worker
                 worker.running = False
                 self.show_plot_state(
@@ -431,6 +447,13 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
     @QtCore.pyqtSlot(Exception)
     def err_raiser(self, err: Exception, worker: Any | None = None) -> None:
+        if (
+                worker is not None
+                and getattr(worker, "is_cancelled", lambda: False)()
+                ):
+            worker.running = False
+            return
+
         if not self._can_process_refresh():
             if worker is not None:
                 worker.running = False

--- a/src/qplot/windows/_widgets/operations.py
+++ b/src/qplot/windows/_widgets/operations.py
@@ -281,12 +281,17 @@ class operations_options_base(qtw.QWidget):
                 item.label,
                 func,
                 getattr(item, "derivative_axis", None),
+                cooperative=True,
                 ))
         return operations
  
     
 def func_with_input(func: OperationFunc, value: object) -> OperationFunc:
-    return lambda data: func(value, data)
+    return lambda data, cancelled_callback=None: func(
+        value,
+        data,
+        cancelled_callback=cancelled_callback,
+        )
  
 
 class draggableListWidget(qtw.QListWidget):

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -135,7 +135,7 @@ class MainWindow(
         self.threadPool = QtCore.QThreadPool()
         self.threadPool.setMaxThreadCount(self.config.get("runtime_settings.max_threads"))
         self._plot_workers: set[object] = set()
-        setattr(self.threadPool, "_qplot_workers", self._plot_workers)
+        self.threadPool._qplot_workers = self._plot_workers  # type: ignore[attr-defined]
         self.databaseLoadThreadPool = QtCore.QThreadPool(self)
         self.databaseLoadThreadPool.setMaxThreadCount(1)
         self.databaseDetailThreadPool = QtCore.QThreadPool(self)

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -134,6 +134,8 @@ class MainWindow(
         self.monitor = QtCore.QTimer()
         self.threadPool = QtCore.QThreadPool()
         self.threadPool.setMaxThreadCount(self.config.get("runtime_settings.max_threads"))
+        self._plot_workers: set[object] = set()
+        setattr(self.threadPool, "_qplot_workers", self._plot_workers)
         self.databaseLoadThreadPool = QtCore.QThreadPool(self)
         self.databaseLoadThreadPool.setMaxThreadCount(1)
         self.databaseDetailThreadPool = QtCore.QThreadPool(self)
@@ -500,6 +502,7 @@ class MainWindow(
         generation_worker = getattr(self, "_test_database_generation_worker", None)
         if generation_worker is not None:
             generation_worker.cancel()
+        MainWindow._cancel_plot_work(self)
         self._database_load_generation += 1
         self._database_load_active = False
         self._database_load_state = None
@@ -542,6 +545,26 @@ class MainWindow(
         self._shutdown_ready = True
         event.accept()
         qtw.QApplication.closeAllWindows()
+
+
+    def _cancel_plot_work(self):
+        """Cancel running plot loads and remove work that has not started."""
+
+        workers = set(getattr(self, "_plot_workers", ()))
+        for window in list(getattr(self, "windows", ())):
+            worker = getattr(window, "worker", None)
+            if worker is not None:
+                workers.add(worker)
+
+        for worker in workers:
+            cancel = getattr(worker, "cancel", None)
+            if callable(cancel):
+                cancel()
+
+        pool = getattr(self, "threadPool", None)
+        clear = getattr(pool, "clear", None)
+        if callable(clear):
+            clear()
 
 
     def _shutdown_background_work_active(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,9 @@
 import sqlite3
 import tempfile
+import threading
 import unittest
+from time import perf_counter
+from unittest.mock import patch
 
 import numpy as np
 
@@ -15,12 +18,150 @@ from qplot.tools.plot_tools import (
     pass_filter,
     subtract_mean,
 )
-from qplot.tools.worker import OperationExecutionError, loader
+from qplot.tools.worker import OperationExecutionError, PlotWorkCancelled, loader
 from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
 from qplot.windows._plotWin import plotWidget
 
 
 class ToolFunctionTestCase(unittest.TestCase):
+    def test_cancel_interrupts_plot_worker_while_loading_database(self):
+        started = threading.Event()
+
+        class Connection:
+            def __init__(self):
+                self.interrupted = threading.Event()
+
+            def interrupt(self):
+                self.interrupted.set()
+
+            def close(self):
+                pass
+
+        class Cache:
+            pass
+
+        class Param:
+            name = "signal"
+            depends_on_ = ("x",)
+
+        connection = Connection()
+
+        def blocking_prep(*_args, **_kwargs):
+            started.set()
+            connection.interrupted.wait(2.0)
+            raise sqlite3.OperationalError("interrupted")
+
+        with (
+                patch.object(worker_module, "cache_table_name", return_value="results"),
+                patch.object(worker_module, "cache_database_path", return_value="plot.db"),
+                patch.object(worker_module, "cache_is_live", return_value=False),
+                patch.object(
+                    worker_module,
+                    "qcodes_read_only_connection",
+                    return_value=connection,
+                    ),
+                patch.object(
+                    worker_module,
+                    "load_param_data_from_db_prep",
+                    side_effect=blocking_prep,
+                    ),
+                ):
+            worker = loader(
+                Cache(),
+                Param(),
+                {"x": object(), "signal": object()},
+                {"x": "x"},
+                )
+            thread = threading.Thread(target=worker.run)
+            thread.start()
+            self.assertTrue(started.wait(1.0))
+
+            cancel_started = perf_counter()
+            worker.cancel()
+            thread.join(1.0)
+
+        self.assertFalse(thread.is_alive())
+        self.assertLess(perf_counter() - cancel_started, 1.0)
+        self.assertTrue(connection.interrupted.is_set())
+        self.assertTrue(worker.is_cancelled())
+
+    def test_cancellation_between_pipeline_operations_skips_remaining_work(self):
+        calls = []
+        worker = loader.__new__(loader)
+        worker.axis_data = {
+            "x": np.array([1.0, 2.0]),
+            "y": np.array([3.0, 4.0]),
+            }
+
+        def cancelling_operation(data):
+            calls.append("first")
+            worker.cancel()
+            return {"y": data["y"] * 2}
+
+        def skipped_operation(data):
+            calls.append("second")
+            return data
+
+        worker.operations = [cancelling_operation, skipped_operation]
+
+        with self.assertRaises(PlotWorkCancelled):
+            loader.do_operations(worker)
+
+        self.assertEqual(calls, ["first"])
+        np.testing.assert_array_equal(worker.axis_data["y"], [3.0, 4.0])
+
+    def test_arbitrary_operation_callable_keeps_one_argument_contract(self):
+        class ThirdPartyOperation:
+            def __call__(self, data):
+                return {"y": data["y"] + 1}
+
+            def execute(self):
+                raise AssertionError("Unrelated execute method must not be used")
+
+        worker = loader.__new__(loader)
+        worker.axis_data = {
+            "x": np.array([1.0, 2.0]),
+            "y": np.array([3.0, 4.0]),
+            }
+        worker.operations = [ThirdPartyOperation()]
+
+        result = loader.do_operations(worker)
+
+        np.testing.assert_array_equal(result[1], [4.0, 5.0])
+
+    def test_cooperative_fill_operation_returns_promptly_after_cancel(self):
+        cancellation = threading.Event()
+        checkpoint_reached = threading.Event()
+        data = np.full((1200, 1200), np.nan)
+        data[:, (0, -1)] = 1.0
+        errors = []
+
+        def cancelled():
+            checkpoint_reached.set()
+            return cancellation.is_set()
+
+        def run_operation():
+            try:
+                fill_heatmap(
+                    "below",
+                    {"z": data},
+                    max_depth=1200,
+                    cancelled_callback=cancelled,
+                    )
+            except InterruptedError:
+                errors.append("cancelled")
+
+        thread = threading.Thread(target=run_operation)
+        thread.start()
+        self.assertTrue(checkpoint_reached.wait(1.0))
+        cancel_started = perf_counter()
+        cancellation.set()
+        thread.join(1.0)
+
+        self.assertFalse(thread.is_alive())
+        self.assertLess(perf_counter() - cancel_started, 1.0)
+        self.assertEqual(errors, ["cancelled"])
+
     def test_try_as_num_handles_int_float_scientific_and_string(self):
         self.assertEqual(try_as_num("4"), 4)
         self.assertEqual(try_as_num("4.5"), 4.5)

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -1647,6 +1647,39 @@ class CloseAllPlotsTestCase(unittest.TestCase):
             main_window.MainWindow._shutdown_background_work_active(harness)
         )
 
+    def test_shutdown_cancels_all_plot_workers_and_discards_queued_work(self):
+        class Worker:
+            def __init__(self):
+                self.cancelled = False
+
+            def cancel(self):
+                self.cancelled = True
+
+        class Pool:
+            def __init__(self):
+                self.cleared = False
+
+            def clear(self):
+                self.cleared = True
+
+        active_worker = Worker()
+        queued_worker = Worker()
+        harness = type(
+            "Harness",
+            (),
+            {
+                "_plot_workers": {active_worker, queued_worker},
+                "windows": [type("Window", (), {"worker": active_worker})()],
+                "threadPool": Pool(),
+            },
+            )()
+
+        main_window.MainWindow._cancel_plot_work(harness)
+
+        self.assertTrue(active_worker.cancelled)
+        self.assertTrue(queued_worker.cancelled)
+        self.assertTrue(harness.threadPool.cleared)
+
     def test_deferred_shutdown_finishes_after_workers_return(self):
         old_close_all_windows = qtw.QApplication.closeAllWindows
         closed = []

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -521,6 +521,50 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         self.assertIs(handle.delete_timer, delete_timer)
         self.assertEqual(delete_timer.stopped, 0)
 
+    def test_cancelled_worker_cannot_update_a_closed_plot(self):
+        window = self._window()
+        worker = window.worker
+        worker.read_data = False
+        worker.axis_data = {"x": ["cancelled x"], "y": ["cancelled y"]}
+        worker.axis_param = {"x": object(), "y": object()}
+        worker.is_cancelled = lambda: True
+        window.axis_data = {"x": ["old x"], "y": ["old y"]}
+        window._closed = True
+        window._merged_trace_users = 0
+
+        result = plotWidget.refreshPlot(window, True, worker=worker)
+
+        self.assertFalse(result)
+        self.assertEqual(window.axis_data, {"x": ["old x"], "y": ["old y"]})
+        self.assertEqual(window.plot_states, [])
+
+    def test_plot_close_cancels_current_worker_and_drops_pending_refresh(self):
+        class Monitor:
+            stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        class Worker:
+            cancelled = False
+
+            def cancel(self):
+                self.cancelled = True
+
+        window = plotWidget.__new__(plotWidget)
+        qtw.QMainWindow.__init__(window)
+        window.monitor = Monitor()
+        window.worker = Worker()
+        window._merged_trace_users = 0
+        window._refresh_pending = True
+
+        plotWidget.closeEvent(window, object())
+
+        self.assertTrue(window.worker.cancelled)
+        self.assertFalse(window._refresh_pending)
+        self.assertTrue(window._closed)
+
+
     def test_closed_hidden_source_can_refresh_while_a_trace_retains_it(self):
         window = self._window()
         dataset_key = DatasetKey("database.db", "guid")


### PR DESCRIPTION
## Summary

Prepare the stable qPlot 1.5.0 release with safe cooperative cancellation for plot work during application shutdown.

## What changed

- add a thread-safe cancellation event to plot loader workers
- interrupt active read-only SQLite plot queries where safe
- cancel all registered active plot workers and clear queued plot work during shutdown
- preserve deferred shutdown so Qt objects remain alive while active workers unwind
- add cancellation checkpoints around database loading, array preparation and copying, pipeline operations, heatmap aggregation, and canonicalization
- make qPlot-owned long-running operations cooperative without changing the existing one-argument operation callable contract
- prevent cancelled or partial results from updating closed plot windows
- document the cancellation model and its compatibility limitation
- isolate screenshot generation from the real qPlot user configuration on Windows
- promote the package, changelog, documentation, install commands, and maturity classifier to stable `1.5.0` / `v1.5.0`

## Root cause

Plot windows closed immediately, but plot loader workers had no cancellation mechanism. MainWindow correctly kept the Qt event loop alive until its thread pools became idle, so an active or queued plot operation could continue running and keep the launching command line occupied long after the UI disappeared.

## Compatibility limitation

An arbitrary third-party operation that does not cooperate cannot be interrupted while its current Python function call is executing. Cancellation is observed as soon as that call returns. qPlot never forcibly terminates Python or Qt threads.

## Validation

- `python -m ruff check .`
- `python -m mypy` — 62 source files, no issues
- `python -m pytest` — 582 passed
- built the exact committed source snapshot as `qplot-1.5.0.tar.gz` and `qplot-1.5.0-py3-none-any.whl`
- `python -m twine check` — both exact-commit artifacts passed
- installed the exact-commit wheel with dependencies into a fresh virtual environment
- `qplot-cfg -version` — `1.5.0`
- `python -c "import qplot; print(qplot.__version__)"` — `1.5.0`
- launched the cleanly installed wheel for a GUI smoke check
