### PR TITLE
Fix cloud loading and heatmap correctness

### DIFF
--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -7,6 +7,7 @@ load workers, and diagnostic report generation outside the GUI class.
 
 import os
 import queue
+import stat
 import subprocess
 import sys
 import threading
@@ -36,6 +37,11 @@ CLOUD_PLACEHOLDER_XATTR_MARKERS = (
     "com.apple.fileprovider",
     "com.apple.fileutil.PlaceholderData",
     "com.microsoft.OneDrive",
+    )
+WINDOWS_CLOUD_PLACEHOLDER_ATTRIBUTES = (
+    getattr(stat, "FILE_ATTRIBUTE_OFFLINE", 0x00001000)
+    | getattr(stat, "FILE_ATTRIBUTE_RECALL_ON_OPEN", 0x00040000)
+    | getattr(stat, "FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS", 0x00400000)
     )
 
 
@@ -155,7 +161,15 @@ def database_is_likely_cloud_placeholder(database_path):
         return False
 
     logical_size = getattr(info, "st_size", 0)
-    allocated_size = getattr(info, "st_blocks", 0) * 512
+    file_attributes = getattr(info, "st_file_attributes", None)
+    if file_attributes is not None:
+        return bool(file_attributes & WINDOWS_CLOUD_PLACEHOLDER_ATTRIBUTES)
+
+    blocks = getattr(info, "st_blocks", None)
+    if blocks is None:
+        return False
+
+    allocated_size = blocks * 512
     return logical_size > 0 and allocated_size == 0
 
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -672,66 +672,91 @@ class loader(QtCore.QRunnable):
             return self._arrays_from_values([], [], [])
 
         x_bins, y_bins = self._bounded_grid_shape(x_count, y_count)
-        x_centres, x_lower_edge, x_scale = self._spatial_axis_bins(
-            float(x_min),
-            float(x_max),
-            x_count,
-            x_bins,
-            )
-        y_centres, y_lower_edge, y_scale = self._spatial_axis_bins(
-            float(y_min),
-            float(y_max),
-            y_count,
-            y_bins,
-            )
-        if x_centres.size == 0 or y_centres.size == 0:
-            self.sampled_heatmap_source = False
-            self.aggregated_heatmap_source = False
-            return self._arrays_from_values([], [], [])
-
         table = _sqlite_identifier(self.table_name)
         x_column = _sqlite_identifier(self.axes_dict["x"])
         y_column = _sqlite_identifier(self.axes_dict["y"])
         z_column = _sqlite_identifier(self.param.name)
-        x_bin_sql = f"MIN(CAST(({x_column} - ?) * ? AS INTEGER), ?)"
-        y_bin_sql = f"MIN(CAST(({y_column} - ?) * ? AS INTEGER), ?)"
+
+        x_exact = x_bins >= x_count
+        y_exact = y_bins >= y_count
+        query_parameters: list[float | int] = []
+        if x_exact:
+            x_centres = np.array([], dtype=float)
+            x_group_sql = x_column
+        else:
+            x_centres, x_lower_edge, x_scale = self._spatial_axis_bins(
+                float(x_min),
+                float(x_max),
+                x_count,
+                x_bins,
+                )
+            x_group_sql = f"MIN(CAST(({x_column} - ?) * ? AS INTEGER), ?)"
+            query_parameters.extend((x_lower_edge, x_scale, x_bins - 1))
+
+        if y_exact:
+            y_centres = np.array([], dtype=float)
+            y_group_sql = y_column
+        else:
+            y_centres, y_lower_edge, y_scale = self._spatial_axis_bins(
+                float(y_min),
+                float(y_max),
+                y_count,
+                y_bins,
+                )
+            y_group_sql = f"MIN(CAST(({y_column} - ?) * ? AS INTEGER), ?)"
+            query_parameters.extend((y_lower_edge, y_scale, y_bins - 1))
+
+        if (
+                (not x_exact and x_centres.size == 0)
+                or (not y_exact and y_centres.size == 0)
+                ):
+            self.sampled_heatmap_source = False
+            self.aggregated_heatmap_source = False
+            return self._arrays_from_values([], [], [])
+
         cursor = conn.execute(
             (
-                "SELECT x_bin, y_bin, AVG(z_value), COUNT(*) FROM ("
-                f"SELECT {x_bin_sql} AS x_bin, {y_bin_sql} AS y_bin, "
+                "SELECT x_group, y_group, AVG(z_value), COUNT(*) FROM ("
+                f"SELECT {x_group_sql} AS x_group, {y_group_sql} AS y_group, "
                 f"{z_column} AS z_value FROM {table} WHERE {where_sql}"
-                ") GROUP BY x_bin, y_bin ORDER BY y_bin, x_bin"
+                ") GROUP BY x_group, y_group ORDER BY y_group, x_group"
                 ),
-            (
-                x_lower_edge,
-                x_scale,
-                x_bins - 1,
-                y_lower_edge,
-                y_scale,
-                y_bins - 1,
-                *parameters,
-                ),
+            (*query_parameters, *parameters),
             )
-        x_indices = []
-        y_indices = []
+        x_groups = []
+        y_groups = []
         z_values = []
         aggregated_source_rows = 0
-        for row_number, (x_index, y_index, z_value, bin_rows) in enumerate(cursor):
+        for row_number, (x_group, y_group, z_value, bin_rows) in enumerate(cursor):
             if row_number % 1024 == 0:
                 self._check_cancelled()
             if z_value is None:
                 continue
-            x_indices.append(int(x_index))
-            y_indices.append(int(y_index))
+            x_groups.append(x_group)
+            y_groups.append(y_group)
             z_values.append(z_value)
             aggregated_source_rows += int(bin_rows)
 
-        x_index_data = np.asarray(x_indices, dtype=np.int64)
-        y_index_data = np.asarray(y_indices, dtype=np.int64)
+        x_group_data = np.asarray(x_groups, dtype=float)
+        y_group_data = np.asarray(y_groups, dtype=float)
         z_data = np.asarray(z_values, dtype=float)
-        finite = np.isfinite(z_data)
-        x_index_data = x_index_data[finite]
-        y_index_data = y_index_data[finite]
+        finite = (
+            np.isfinite(x_group_data)
+            & np.isfinite(y_group_data)
+            & np.isfinite(z_data)
+            )
+
+        if x_exact:
+            x_centres = np.unique(x_group_data[np.isfinite(x_group_data)])
+            x_index_data = np.searchsorted(x_centres, x_group_data[finite])
+        else:
+            x_index_data = x_group_data[finite].astype(np.int64)
+        if y_exact:
+            y_centres = np.unique(y_group_data[np.isfinite(y_group_data)])
+            y_index_data = np.searchsorted(y_centres, y_group_data[finite])
+        else:
+            y_index_data = y_group_data[finite].astype(np.int64)
+
         z_data = z_data[finite]
         self._spatial_heatmap_axes = (x_centres, y_centres)
         self._spatial_heatmap_indices = (x_index_data, y_index_data)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -157,6 +157,10 @@ class plotWidget(
     make_ds = QtCore.pyqtSignal([object])
     previewTraceDropRequested = QtCore.pyqtSignal(object, object, str)
     trace_updated = QtCore.pyqtSignal()
+
+    def _view_range_changed_programmatically(self) -> None:
+        """Allow plot types to react to qPlot-driven range changes."""
+
     
     _label_width = 95 #About the size of 3 s.f. scientific
     def __init__(self, 

--- a/src/qplot/windows/_plot_axis_scaling.py
+++ b/src/qplot/windows/_plot_axis_scaling.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         vbMenu: Any
 
         def _context_menu_action(self, text: str) -> Any | None: ...
+        def _view_range_changed_programmatically(self) -> None: ...
 else:
     class _PlotAxisScalingBase:
         pass
@@ -296,6 +297,7 @@ class PlotAxisScalingMixin(_PlotAxisScalingBase):
             self.vb.setXRange(*values, padding=0)
         else:
             self.vb.setYRange(*values, padding=0)
+        self._view_range_changed_programmatically()
 
     def _axis_scale_auto_clicked(self, axis: _AxisName) -> None:
         ui = self._axis_scale_controls[axis]

--- a/src/qplot/windows/_plot_marquee.py
+++ b/src/qplot/windows/_plot_marquee.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         vb: Any
 
         def formatNum(self, value: float) -> str: ...
+        def _view_range_changed_programmatically(self) -> None: ...
 else:
     class _PlotMarqueeBase:
         pass
@@ -266,6 +267,7 @@ class PlotMarqueeMixin(_PlotMarqueeBase):
             self.vb.setXRange(rect.left(), rect.right(), padding=0)
         if "y" in axes:
             self.vb.setYRange(rect.top(), rect.bottom(), padding=0)
+        self._view_range_changed_programmatically()
         return True
 
     def _marquee_stats_text(self) -> str | None:

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -99,6 +99,10 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         self.plot.autoBtn.clicked.connect(
             lambda _button: self._zoom_large_heatmap_to_all()
             )
+
+
+    def _view_range_changed_programmatically(self) -> None:
+        self._schedule_visible_heatmap_reload()
       
 
     def initRefresh(self, refresh: Any) -> None:
@@ -189,6 +193,11 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
             plot_worker.running = False
             return
 
+        full_sql_refresh = bool(
+            getattr(plot_worker, "loaded_from_sql_heatmap", False)
+            and getattr(plot_worker, "heatmap_axis_ranges", None) is None
+            )
+
         try:
             self._update_large_heatmap_state(plot_worker)
             if not self._has_plottable_heatmap_data():
@@ -246,11 +255,20 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         finally:
             # Allow new workers after empty live loads or display errors.
             plot_worker.running = False
+            if full_sql_refresh:
+                self._schedule_visible_heatmap_reload()
 
 
     def _update_large_heatmap_state(self, worker: Any) -> None:
         self._update_heatmap_downsample_state(worker)
         if not getattr(worker, "loaded_from_sql_heatmap", False):
+            self._large_heatmap_sql_mode = False
+            self._heatmap_full_axis_ranges = None
+            self._heatmap_full_view_ranges = None
+            self._heatmap_last_view_ranges = None
+            timer = self.__dict__.get("_heatmap_view_reload_timer")
+            if timer is not None:
+                timer.stop()
             return
 
         self._large_heatmap_sql_mode = True
@@ -264,8 +282,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 )
             self._heatmap_full_view_ranges = self._axis_view_ranges_from_data()
 
-        if worker_ranges is not None:
-            self._heatmap_last_view_ranges = self._normalise_axis_ranges(worker_ranges)
+        self._heatmap_last_view_ranges = self._normalise_axis_ranges(worker_ranges)
 
 
     def _init_heatmap_downsample_warning_button(self) -> None:
@@ -928,14 +945,12 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 )
             return False
 
-        self._heatmap_last_view_ranges = None
-        self.load_data(
+        return self.load_data(
             force_sql_heatmap=True,
             heatmap_axis_ranges=None,
             heatmap_full_axis_ranges=full_axis_ranges,
             status_message=f"Loading full heatmap for {self.param.name}...",
             )
-        return True
 
 
     def _schedule_visible_heatmap_reload(self, *_args: Any) -> None:
@@ -963,7 +978,6 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
         if self._axis_ranges_match(ranges, self._heatmap_last_view_ranges):
             return
 
-        self._heatmap_last_view_ranges = ranges
         self.load_data(
             force_sql_heatmap=True,
             heatmap_axis_ranges=ranges,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -371,6 +371,90 @@ class ToolFunctionTestCase(unittest.TestCase):
                 worker.dataGrid.size,
                 )
 
+    def test_large_heatmap_sql_aggregation_preserves_nonuniform_exact_axes(self):
+        rows = [
+            (x, 0.0, z)
+            for _repeat in range(3)
+            for x, z in ((0.0, 0.0), (1.0, 10.0), (100.0, 100.0))
+            ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            database_path = f"{tmpdir}/nonuniform.db"
+            self._create_heatmap_table_from_rows(database_path, rows)
+            worker = self._sql_heatmap_worker(database_path)
+            worker.cache.rundescriber.shapes = None
+
+            old_database_path = worker_module.cache_database_path
+            old_set_complete = worker_module.set_parameter_complete
+            old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
+            old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
+            try:
+                worker_module.cache_database_path = lambda _cache: database_path
+                worker_module.set_parameter_complete = (
+                    lambda param, complete=False: setattr(param, "_complete", complete)
+                    )
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 2
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 3
+
+                loader._load_large_heatmap_from_sql(worker)
+                loader._canonicalize_heatmap(worker)
+            finally:
+                worker_module.cache_database_path = old_database_path
+                worker_module.set_parameter_complete = old_set_complete
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
+
+        np.testing.assert_array_equal(worker.axis_data["x"], [0.0, 1.0, 100.0])
+        np.testing.assert_array_equal(worker.axis_data["y"], [0.0])
+        np.testing.assert_array_equal(worker.dataGrid, [[0.0, 10.0, 100.0]])
+        self.assertTrue(worker.heatmap_downsample_info["source_aggregated"])
+        self.assertFalse(worker.heatmap_downsample_info["grid_binned"])
+
+    def test_large_heatmap_sql_aggregation_can_mix_exact_and_binned_axes(self):
+        rows = [
+            (x, float(y), x + y)
+            for _repeat in range(2)
+            for y in range(4)
+            for x in (0.0, 100.0)
+            ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            database_path = f"{tmpdir}/mixed-axes.db"
+            self._create_heatmap_table_from_rows(database_path, rows)
+            worker = self._sql_heatmap_worker(database_path)
+            worker.cache.rundescriber.shapes = None
+
+            old_database_path = worker_module.cache_database_path
+            old_set_complete = worker_module.set_parameter_complete
+            old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
+            old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
+            old_grid_side = worker_module.MAX_SQL_HEATMAP_GRID_SIDE
+            try:
+                worker_module.cache_database_path = lambda _cache: database_path
+                worker_module.set_parameter_complete = (
+                    lambda param, complete=False: setattr(param, "_complete", complete)
+                    )
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 2
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 4
+                worker_module.MAX_SQL_HEATMAP_GRID_SIDE = 2
+
+                loader._load_large_heatmap_from_sql(worker)
+                loader._canonicalize_heatmap(worker)
+            finally:
+                worker_module.cache_database_path = old_database_path
+                worker_module.set_parameter_complete = old_set_complete
+                worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
+                worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
+                worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
+
+        np.testing.assert_array_equal(worker.axis_data["x"], [0.0, 100.0])
+        np.testing.assert_array_equal(worker.axis_data["y"], [0.5, 2.5])
+        np.testing.assert_array_equal(
+            worker.dataGrid,
+            [[0.5, 100.5], [2.5, 102.5]],
+            )
+        self.assertTrue(worker.heatmap_downsample_info["grid_binned"])
+
     def test_large_heatmap_sql_output_is_independent_of_insertion_order(self):
         rows = [
             (float(x), float(y), float(x + y * 100))

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -3207,6 +3207,73 @@ class AutoPlotToggleTestCase(unittest.TestCase):
 
 
 class CloudDatabasePrefetchTestCase(unittest.TestCase):
+    @patch.object(database_module, "database_cloud_storage_label", return_value="OneDrive")
+    @patch.object(database_module.os, "stat")
+    def test_local_windows_cloud_file_is_not_treated_as_placeholder(
+            self,
+            stat_file,
+            _cloud_label,
+            ):
+        stat_file.return_value = type(
+            "FileInfo",
+            (),
+            {"st_size": 4096, "st_file_attributes": 0x20},
+            )()
+
+        self.assertFalse(
+            database_module.database_is_likely_cloud_placeholder("OneDrive/local.db")
+            )
+
+    @patch.object(database_module, "database_cloud_storage_label", return_value="OneDrive")
+    @patch.object(database_module.os, "stat")
+    def test_offline_windows_cloud_file_is_treated_as_placeholder(
+            self,
+            stat_file,
+            _cloud_label,
+            ):
+        stat_file.return_value = type(
+            "FileInfo",
+            (),
+            {
+                "st_size": 4096,
+                "st_file_attributes": database_module.WINDOWS_CLOUD_PLACEHOLDER_ATTRIBUTES,
+                },
+            )()
+
+        self.assertTrue(
+            database_module.database_is_likely_cloud_placeholder("OneDrive/offline.db")
+            )
+
+    @patch.object(database_module, "database_cloud_storage_label", return_value="OneDrive")
+    @patch.object(database_module.os, "stat")
+    def test_cloud_file_without_allocation_metadata_is_not_assumed_placeholder(
+            self,
+            stat_file,
+            _cloud_label,
+            ):
+        stat_file.return_value = type("FileInfo", (), {"st_size": 4096})()
+
+        self.assertFalse(
+            database_module.database_is_likely_cloud_placeholder("OneDrive/unknown.db")
+            )
+
+    @patch.object(database_module, "database_cloud_storage_label", return_value="OneDrive")
+    @patch.object(database_module.os, "stat")
+    def test_sparse_cloud_file_uses_posix_allocation_metadata(
+            self,
+            stat_file,
+            _cloud_label,
+            ):
+        stat_file.return_value = type(
+            "FileInfo",
+            (),
+            {"st_size": 4096, "st_blocks": 0},
+            )()
+
+        self.assertTrue(
+            database_module.database_is_likely_cloud_placeholder("OneDrive/sparse.db")
+            )
+
     def test_prefetch_subprocess_retries_transient_timeout_errors(self):
         class Handle:
             def __init__(self):

--- a/tests/windows/test_plot1d.py
+++ b/tests/windows/test_plot1d.py
@@ -1657,10 +1657,13 @@ class SnapToTraceTestCase(unittest.TestCase):
         window = plotWidget.__new__(plotWidget)
         window.vb = ViewBox()
         window.marquee = QtCore.QRectF(1.0, 2.0, 3.0, 4.0)
+        range_changes = []
+        window._view_range_changed_programmatically = lambda: range_changes.append(True)
 
         self.assertTrue(window.zoom_marquee("xy"))
         self.assertEqual(window.vb.x_range, (1.0, 4.0, 0))
         self.assertEqual(window.vb.y_range, (2.0, 6.0, 0))
+        self.assertEqual(range_changes, [True])
 
     def test_escape_clears_marquee(self):
         window = qtw.QMainWindow()

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -398,6 +398,89 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
             (-0.5, 29.5),
             )
 
+    def test_full_sql_refresh_invalidates_previously_loaded_visible_range(self):
+        class Worker:
+            loaded_from_sql_heatmap = True
+            heatmap_axis_ranges = None
+            heatmap_source_axis_ranges = {
+                "x": (0.0, 39.0),
+                "y": (0.0, 29.0),
+                }
+
+        window = plot2d.__new__(plot2d)
+        window.axis_data = {
+            "x": np.array([4.5, 14.5, 24.5, 34.5]),
+            "y": np.array([3.25, 10.75, 18.25, 25.75]),
+            }
+        window._heatmap_full_axis_ranges = {
+            "x": (0.0, 39.0),
+            "y": (0.0, 29.0),
+            }
+        window._heatmap_full_view_ranges = None
+        window._heatmap_last_view_ranges = {
+            "x": (10.0, 20.0),
+            "y": (5.0, 10.0),
+            }
+        window._update_heatmap_downsample_state = lambda _worker: None
+
+        window._update_large_heatmap_state(Worker())
+
+        self.assertIsNone(window._heatmap_last_view_ranges)
+
+    def test_full_resolution_refresh_clears_large_heatmap_sql_state(self):
+        class Timer:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        window = plot2d.__new__(plot2d)
+        window._large_heatmap_sql_mode = True
+        window._heatmap_full_axis_ranges = {"x": (0.0, 1.0), "y": (0.0, 1.0)}
+        window._heatmap_full_view_ranges = dict(window._heatmap_full_axis_ranges)
+        window._heatmap_last_view_ranges = dict(window._heatmap_full_axis_ranges)
+        window._heatmap_view_reload_timer = Timer()
+        window._update_heatmap_downsample_state = lambda _worker: None
+
+        window._update_large_heatmap_state(
+            type("Worker", (), {"loaded_from_sql_heatmap": False})()
+            )
+
+        self.assertFalse(window._large_heatmap_sql_mode)
+        self.assertIsNone(window._heatmap_full_axis_ranges)
+        self.assertIsNone(window._heatmap_full_view_ranges)
+        self.assertIsNone(window._heatmap_last_view_ranges)
+        self.assertTrue(window._heatmap_view_reload_timer.stopped)
+
+    def test_full_sql_refresh_schedules_visible_detail_after_worker_release(self):
+        worker = type(
+            "Worker",
+            (),
+            {
+                "loaded_from_sql_heatmap": True,
+                "heatmap_axis_ranges": None,
+                "running": True,
+                },
+            )()
+        window = plot2d.__new__(plot2d)
+        window.param = type("Param", (), {"name": "signal"})()
+        window._update_large_heatmap_state = lambda _worker: None
+        window._has_plottable_heatmap_data = lambda: False
+        window._invalidate_heatmap_geometry = lambda: None
+        window.show_status = lambda *_args: None
+        window.show_plot_state = lambda *_args, **_kwargs: None
+        scheduled_after_release = []
+        window._schedule_visible_heatmap_reload = lambda: (
+            scheduled_after_release.append(not worker.running)
+            )
+
+        with patch.object(plotWidget, "refreshPlot", return_value=True):
+            plot2d.refreshPlot(window, True, worker=worker)
+
+        self.assertFalse(worker.running)
+        self.assertEqual(scheduled_after_release, [True])
+
     def test_zoom_to_all_reloads_full_large_heatmap(self):
         class ViewBox:
             def __init__(self):
@@ -445,7 +528,10 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
                 "padding": 0,
                 }],
             )
-        self.assertIsNone(window._heatmap_last_view_ranges)
+        self.assertEqual(
+            window._heatmap_last_view_ranges,
+            {"x": (10.0, 20.0), "y": (5.0, 10.0)},
+            )
         self.assertEqual(loads[0]["heatmap_axis_ranges"], None)
         self.assertEqual(
             loads[0]["heatmap_full_axis_ranges"],
@@ -471,9 +557,41 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
 
         window._reload_visible_heatmap_data()
 
-        self.assertIsNone(window._heatmap_last_view_ranges)
+        self.assertEqual(
+            window._heatmap_last_view_ranges,
+            {"x": (10.0, 20.0), "y": (5.0, 10.0)},
+            )
         self.assertEqual(len(loads), 1)
         self.assertIsNone(loads[0]["heatmap_axis_ranges"])
+
+    def test_failed_visible_reload_can_retry_the_same_range(self):
+        requested_ranges = {
+            "x": (2.0, 4.0),
+            "y": (3.0, 7.0),
+            }
+        window = plot2d.__new__(plot2d)
+        window._large_heatmap_sql_mode = True
+        window._heatmap_full_axis_ranges = {
+            "x": (0.0, 10.0),
+            "y": (0.0, 20.0),
+            }
+        window._heatmap_last_view_ranges = None
+        window.worker = type("Worker", (), {"running": False})()
+        window.param = type("Param", (), {"name": "signal"})()
+        window._visible_heatmap_axis_ranges = lambda: requested_ranges
+        loads = []
+
+        def reject_load(**kwargs):
+            loads.append(kwargs)
+            return False
+
+        window.load_data = reject_load
+
+        window._reload_visible_heatmap_data()
+        window._reload_visible_heatmap_data()
+
+        self.assertEqual(len(loads), 2)
+        self.assertIsNone(window._heatmap_last_view_ranges)
         self.assertEqual(
             loads[0]["heatmap_full_axis_ranges"],
             window._heatmap_full_axis_ranges,

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -1628,6 +1628,42 @@ class RunListParentLookupTestCase(unittest.TestCase):
             manual.deleteLater()
             window.vb.deleteLater()
 
+    def test_manual_axis_scale_notifies_programmatic_range_change(self):
+        class ViewBox:
+            def __init__(self):
+                self.x_range = None
+
+            def viewRange(self):
+                return [[0.0, 1.0], [0.0, 1.0]]
+
+            def setXRange(self, low, high, padding=0):
+                self.x_range = (low, high, padding)
+
+        window = plotWidget.__new__(plotWidget)
+        minimum = qtw.QLineEdit("2")
+        maximum = qtw.QLineEdit("4")
+        manual = qtw.QRadioButton()
+        window.vb = ViewBox()
+        window._axis_scale_controls = {
+            "x": type(
+                "AxisControls",
+                (),
+                {"minText": minimum, "maxText": maximum, "manualRadio": manual},
+                )()
+            }
+        range_changes = []
+        window._view_range_changed_programmatically = lambda: range_changes.append(True)
+
+        try:
+            plotWidget._axis_scale_range_text_changed(window, "x")
+
+            self.assertEqual(window.vb.x_range, (2.0, 4.0, 0))
+            self.assertEqual(range_changes, [True])
+        finally:
+            minimum.deleteLater()
+            maximum.deleteLater()
+            manual.deleteLater()
+
     def test_colorbar_scale_action_opens_dialog_without_nested_menu(self):
         class Bar:
             def __init__(self):


### PR DESCRIPTION
## Summary

- detect Windows cloud placeholders from file attributes instead of assuming missing `st_blocks` means offline
- preserve exact nonuniform coordinates during SQL heatmap aggregation when an axis does not need reduction
- keep large-heatmap load state tied to successful workers and reload detail after full refreshes
- make marquee zoom and manual axis limits request visible-range heatmap detail
- clear stale SQL heatmap state after returning to full-resolution loading

## Why

On Windows, local OneDrive databases were always classified as placeholders and fully streamed before SQLite opened them. Large SQL heatmaps could also fabricate uniformly spaced coordinates for irregular sweeps even when every distinct coordinate fit in the output grid. Separately, large-heatmap refresh and programmatic zoom paths could leave coarse data displayed or suppress retries after failed loads.

## Impact

Local cloud-backed databases open without an unnecessary full-file read, irregular sweep coordinates remain scientifically accurate, and zoomed heatmaps consistently reload detailed data across refresh, marquee, and manual-axis workflows.

## Validation

- `python -m pytest`: 593 passed, 16 subtests passed
- `python -m ruff check .`: passed
- `python -m mypy`: passed (62 source files)
- two-million-row heatmap benchmark: 500 x 500 aggregation in 2.052 s
- launched qPlot from the project virtual environment