### PR TITLE
Preserve QCoDeS source databases during read-only viewing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,13 @@ diagnostic report generation.
 
 `src/qplot/datahandling/readonly.py` centralises enforced read-only database
 access. Use these helpers for QCoDeS and direct SQLite connections so qPlot does
-not initialise, upgrade, or write to loaded QCoDeS databases.
+not initialise, upgrade, or write to loaded QCoDeS databases. The access policy
+has two paths: databases without a WAL use direct `mode=ro&immutable=1` access;
+databases with a WAL use a consistency-checked database-plus-WAL copy under the
+system temporary directory. Direct SQLite reads, QCoDeS `AtomicConnection`
+reads, dataset loading, refresh workers, metadata inspection, and the
+subprocess access probe all go through this policy. Never open an input database
+with SQLite or QCoDeS directly from viewer code.
 
 `src/qplot/datahandling/LoadFromDB.py` adapts QCoDeS database loading for
 threaded refreshes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,6 +124,13 @@ If the database is being written by a running experiment, try again after a
 short wait. For persistent failures, use the `Database Information` button in
 the main window if the file can be opened far enough for diagnostics.
 
+For a live WAL database, qPlot reads a private database-and-WAL snapshot so it
+does not alter the source SQLite sidecars. A writer that commits continuously
+can prevent qPlot from obtaining a consistent copy. In that case qPlot reports
+that the WAL changed during the read-only snapshot; wait for a pause between
+commits and refresh. qPlot deliberately does not show an older immutable view
+when an uncheckpointed WAL is present.
+
 ## A OneDrive Database Waits for Sync
 
 On macOS, OneDrive and other cloud providers can leave a `.db` file as an

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -17,9 +17,23 @@ You can also open a database directly from the command line:
 qplot path/to/database.db
 ```
 
-qPlot opens QCoDeS databases read-only. It can view runs that are still being
-written by another process, but it does not initialise, upgrade, or modify the
-loaded database file.
+qPlot opens QCoDeS databases without changing the database file or any SQLite
+`-wal`, `-shm`, or `-journal` files beside it. A checkpointed database with no
+WAL is opened directly with SQLite's immutable read-only mode, so it can also
+be viewed when both the file and its directory are read-only.
+
+When a WAL exists, qPlot never applies immutable mode to the source because
+that would hide committed rows which have not yet been checkpointed. Instead,
+it copies the database and WAL to a private system-temporary directory, checks
+that the source did not change while they were copied, and opens that snapshot.
+Every refresh makes a new snapshot, so committed rows added by a running
+QCoDeS measurement become visible. The source `-shm` is not opened by qPlot,
+and snapshot files are removed when their connection closes.
+
+If a busy writer changes the files throughout every snapshot attempt, qPlot
+reports a read-only snapshot error and leaves the source untouched. It does not
+fall back to an immutable view that could silently show stale data. Refresh
+again after the writer has a sufficiently long pause between commits.
 
 ### Opening Databases from the File Manager
 

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -78,15 +78,14 @@ def database_access_error(database_path, timeout=DATABASE_ACCESS_TIMEOUT_SECONDS
 
     """
     probe = (
-        "from pathlib import Path\n"
-        "import sqlite3, sys\n"
-        "uri = f'{Path(sys.argv[1]).resolve().as_uri()}?mode=ro'\n"
-        "conn = sqlite3.connect(uri, timeout=1, uri=True)\n"
+        "import sys\n"
+        "from qplot.datahandling.readonly import probe_read_only_database\n"
         "try:\n"
-        "    conn.execute('PRAGMA user_version').fetchone()\n"
-        "finally:\n"
-        "    conn.close()\n"
-    )
+        "    probe_read_only_database(sys.argv[1])\n"
+        "except Exception as err:\n"
+        "    print(err, file=sys.stderr)\n"
+        "    raise SystemExit(1)\n"
+        )
 
     try:
         result = subprocess.run(

--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -1,4 +1,7 @@
+import shutil
 import sqlite3
+import tempfile
+import weakref
 from pathlib import Path
 
 import qcodes
@@ -6,6 +9,28 @@ from qcodes.dataset import load_by_guid, load_by_id
 from qcodes.dataset.sqlite.database import connect, get_DB_debug, get_DB_location
 
 SQLITE_READ_ONLY_CACHE_KIB = 16 * 1024
+WAL_SNAPSHOT_ATTEMPTS = 5
+
+
+class ReadOnlyDatabaseAccessError(RuntimeError):
+    """Raised when qPlot cannot take a non-mutating view of a database."""
+
+
+class _ManagedSQLiteConnection(sqlite3.Connection):
+    """SQLite connection that owns a temporary WAL snapshot, when needed."""
+
+    _qplot_snapshot: tempfile.TemporaryDirectory | None = None
+
+    def attach_snapshot(self, snapshot):
+        self._qplot_snapshot = snapshot
+
+    def close(self):
+        try:
+            super().close()
+        finally:
+            if self._qplot_snapshot is not None:
+                self._qplot_snapshot.cleanup()
+                self._qplot_snapshot = None
 
 
 def set_qcodes_database_location(database_path):
@@ -29,15 +54,39 @@ def configure_read_only_sqlite_connection(conn):
 
 
 def qcodes_read_only_connection(database_path):
-    """Open an exact-path QCoDeS connection with SQLite read-only enforcement.
+    """Open a source-preserving, AtomicConnection-compatible database view.
 
-    QCoDeS builds a SQLite URI by placing its database argument between
-    ``file:`` and ``?mode=ro``. Supplying only the escaped path portion keeps
-    URI-reserved filename characters from becoming URI syntax while retaining
-    QCoDeS' AtomicConnection setup, converters, and schema checks.
+    A checkpointed database with no WAL is opened directly as immutable. If a
+    WAL exists, qPlot instead opens a consistent private copy under the system
+    temporary directory. This keeps live WAL rows visible without letting
+    SQLite create or update source ``-wal`` or ``-shm`` files.
     """
-    return configure_read_only_sqlite_connection(
-        connect(_sqlite_uri_path(database_path), get_DB_debug(), read_only=True)
+    source_path = _resolved_database_path(database_path)
+    for _attempt in range(2):
+        target_path, immutable, snapshot = _prepare_read_target(source_path)
+        try:
+            conn = connect(
+                _qcodes_uri_path(target_path, immutable=immutable),
+                get_DB_debug(),
+                read_only=True,
+                )
+        except Exception:
+            if snapshot is not None:
+                snapshot.cleanup()
+            raise
+
+        if immutable and _wal_path(source_path).exists():
+            conn.close()
+            continue
+
+        conn.path_to_dbfile = str(source_path)
+        if snapshot is not None:
+            _attach_snapshot_cleanup(conn, snapshot)
+        return configure_read_only_sqlite_connection(conn)
+
+    raise ReadOnlyDatabaseAccessError(
+        "The database became live while qPlot was opening it. Refresh to retry; "
+        "qPlot did not open the source in a mode that could change it."
         )
 
 
@@ -63,23 +112,169 @@ def load_by_id_read_only(run_id):
         raise
 
 
+def _resolved_database_path(database_path):
+    return Path(database_path).resolve()
+
+
 def _sqlite_uri_path(database_path):
     """Return an absolute, URI-escaped SQLite path without the ``file:`` prefix."""
-    return Path(database_path).resolve().as_uri().removeprefix("file:")
+    return _resolved_database_path(database_path).as_uri().removeprefix("file:")
 
 
-def sqlite_read_only_uri(database_path):
-    """Build a SQLite URI that opens an existing database read-only."""
-    return f"file:{_sqlite_uri_path(database_path)}?mode=ro"
+def sqlite_read_only_uri(database_path, *, immutable=False):
+    """Build an exact-path SQLite URI with enforced read-only access."""
+    uri = f"file:{_sqlite_uri_path(database_path)}?mode=ro"
+    if immutable:
+        uri += "&immutable=1"
+    return uri
 
 
 def sqlite_read_only_connection(database_path, timeout=10, **kwargs):
-    """Open a direct sqlite3 connection with SQLite read-only enforcement."""
-    return configure_read_only_sqlite_connection(
-        sqlite3.connect(
-            sqlite_read_only_uri(database_path),
-            timeout=timeout,
-            uri=True,
-            **kwargs,
+    """Open a direct source-preserving SQLite connection.
+
+    Static databases are opened immutable in place. WAL databases are opened
+    from a consistency-checked temporary snapshot so SQLite never touches the
+    source sidecars and every new connection sees a fresh committed WAL view.
+    """
+    source_path = _resolved_database_path(database_path)
+    kwargs.setdefault("factory", _ManagedSQLiteConnection)
+
+    for _attempt in range(2):
+        target_path, immutable, snapshot = _prepare_read_target(source_path)
+        try:
+            conn = sqlite3.connect(
+                sqlite_read_only_uri(target_path, immutable=immutable),
+                timeout=timeout,
+                uri=True,
+                **kwargs,
+                )
+        except Exception:
+            if snapshot is not None:
+                snapshot.cleanup()
+            raise
+
+        if immutable and _wal_path(source_path).exists():
+            conn.close()
+            continue
+
+        if snapshot is not None:
+            attach_snapshot = getattr(conn, "attach_snapshot", None)
+            if not callable(attach_snapshot):
+                conn.close()
+                snapshot.cleanup()
+                raise TypeError(
+                    "A custom SQLite connection factory used for a live WAL "
+                    "database must provide attach_snapshot()."
+                    )
+            attach_snapshot(snapshot)
+        return configure_read_only_sqlite_connection(conn)
+
+    raise ReadOnlyDatabaseAccessError(
+        "The database became live while qPlot was opening it. Refresh to retry; "
+        "qPlot did not open the source in a mode that could change it."
         )
-    )
+
+
+def probe_read_only_database(database_path):
+    """Exercise the same non-mutating open policy used by all viewer reads."""
+    conn = sqlite_read_only_connection(database_path, timeout=1)
+    try:
+        conn.execute("PRAGMA user_version").fetchone()
+    finally:
+        conn.close()
+
+
+def _qcodes_uri_path(database_path, *, immutable):
+    """Build the URI path expected by QCoDeS' URI-constructing helper.
+
+    QCoDeS adds ``file:`` and a final ``?mode=ro`` itself. For immutable
+    access, the dummy final parameter absorbs that second question mark while
+    retaining the earlier, valid ``mode=ro`` and ``immutable=1`` options.
+    """
+    path = _sqlite_uri_path(database_path)
+    if immutable:
+        return f"{path}?mode=ro&immutable=1&qplot="
+    return path
+
+
+def _wal_path(database_path):
+    return Path(f"{database_path}-wal")
+
+
+def _file_signature(path):
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return None
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+        )
+
+
+def _source_signature(database_path):
+    return (
+        _file_signature(database_path),
+        _file_signature(_wal_path(database_path)),
+        )
+
+
+def _prepare_read_target(database_path):
+    """Select immutable static access or make a stable private WAL snapshot."""
+    if not database_path.is_file():
+        raise FileNotFoundError(database_path)
+
+    wal_path = _wal_path(database_path)
+    if not wal_path.exists():
+        return database_path, True, None
+
+    for _attempt in range(WAL_SNAPSHOT_ATTEMPTS):
+        before = _source_signature(database_path)
+        if before[0] is None:
+            raise FileNotFoundError(database_path)
+        if before[1] is None:
+            return database_path, True, None
+
+        snapshot = tempfile.TemporaryDirectory(prefix="qplot-readonly-")
+        snapshot_path = Path(snapshot.name) / "database.db"
+        try:
+            shutil.copyfile(database_path, snapshot_path)
+            shutil.copyfile(wal_path, _wal_path(snapshot_path))
+        except FileNotFoundError:
+            snapshot.cleanup()
+            continue
+        except OSError as err:
+            snapshot.cleanup()
+            raise ReadOnlyDatabaseAccessError(
+                f"Could not copy a read-only view of {database_path}: {err}"
+                ) from err
+
+        if _source_signature(database_path) == before:
+            return snapshot_path, False, snapshot
+        snapshot.cleanup()
+
+    raise ReadOnlyDatabaseAccessError(
+        "The database WAL changed continuously while qPlot tried to make a "
+        "non-mutating snapshot. Refresh to retry; the source database and its "
+        "SQLite sidecars were not opened for writing."
+        )
+
+
+def _attach_snapshot_cleanup(conn, snapshot):
+    """Make an AtomicConnection clean up its private snapshot on close or GC."""
+    connection_ref = weakref.ref(conn)
+    finalizer = weakref.finalize(conn, snapshot.cleanup)
+
+    def close_snapshot():
+        connection = connection_ref()
+        try:
+            if connection is not None:
+                sqlite3.Connection.close(connection)
+        finally:
+            finalizer()
+
+    conn.close = close_snapshot
+    conn._qplot_snapshot_finalizer = finalizer

--- a/tests/datahandling/test_readonly.py
+++ b/tests/datahandling/test_readonly.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import sqlite3
+from pathlib import Path
 
 import pytest
 import qcodes
@@ -13,7 +14,9 @@ from qcodes.dataset.sqlite.connection import AtomicConnection
 from qcodes.parameters import ManualParameter
 
 from qplot._repair import repair
+from qplot.datahandling.database import database_access_error, database_info_rows
 from qplot.datahandling.readonly import (
+    ReadOnlyDatabaseAccessError,
     load_by_guid_read_only,
     load_by_id_read_only,
     qcodes_read_only_connection,
@@ -32,6 +35,13 @@ def _directory_state(directory):
     return state
 
 
+def _run_without_source_changes(directory, operation):
+    before = _directory_state(directory)
+    result = operation()
+    assert _directory_state(directory) == before
+    return result
+
+
 def _create_qcodes_run(database_path):
     initialise_or_create_database_at(database_path, journal_mode="DELETE")
     experiment = load_or_create_experiment("read_only", sample_name="reserved path")
@@ -47,6 +57,25 @@ def _create_qcodes_run(database_path):
     run_id = dataset.run_id
     dataset.conn.close()
     return run_id, guid
+
+
+def _create_default_wal_run(database_path):
+    initialise_or_create_database_at(database_path)
+    experiment = load_or_create_experiment("read_only_wal", sample_name="wal")
+    setpoint = ManualParameter("wal_setpoint")
+    signal = ManualParameter("wal_signal")
+    measurement = Measurement(exp=experiment, name="wal_run")
+    measurement.register_parameter(setpoint)
+    measurement.register_parameter(signal, setpoints=(setpoint,))
+    with measurement.run() as datasaver:
+        datasaver.add_result((setpoint, 1.0), (signal, 2.0))
+        dataset = datasaver.dataset
+    run_id = dataset.run_id
+    guid = dataset.guid
+    table_name = dataset.table_name
+    dataset.conn.close()
+    experiment.conn.close()
+    return run_id, guid, table_name
 
 
 def test_sqlite_read_only_connection_rejects_writes(tmp_path):
@@ -150,3 +179,218 @@ def test_qcodes_reads_reserved_paths_without_changing_any_file(
         assert _directory_state(tmp_path) == original_state
     finally:
         qcodes.config.core.db_location = original_database_path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission test")
+def test_completed_default_wal_database_opens_from_read_only_directory(
+    tmp_path,
+):
+    database_path = tmp_path / "completed.db"
+    original_database_path = qcodes.config.core.db_location
+    original_directory_mode = tmp_path.stat().st_mode
+    try:
+        run_id, guid, _table_name = _create_default_wal_run(database_path)
+        set_qcodes_database_location(database_path)
+
+        assert database_path.read_bytes()[18:20] == b"\x02\x02"
+        assert sorted(path.name for path in tmp_path.iterdir()) == ["completed.db"]
+
+        database_path.chmod(0o444)
+        tmp_path.chmod(0o555)
+        expected_state = _directory_state(tmp_path)
+
+        def direct_sqlite_read():
+            conn = sqlite_read_only_connection(database_path)
+            try:
+                return conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+            finally:
+                conn.close()
+
+        assert _run_without_source_changes(tmp_path, direct_sqlite_read) == 1
+
+        def qcodes_sqlite_read():
+            conn = qcodes_read_only_connection(database_path)
+            try:
+                assert isinstance(conn, AtomicConnection)
+                assert conn.path_to_dbfile == str(database_path.resolve())
+                return conn.execute("SELECT guid FROM runs").fetchone()[0]
+            finally:
+                conn.close()
+
+        assert _run_without_source_changes(tmp_path, qcodes_sqlite_read) == guid
+
+        runs = _run_without_source_changes(
+            tmp_path,
+            lambda: get_runs_via_sql(database_path),
+            )
+        assert list(runs) == [run_id]
+
+        def load_dataset():
+            dataset = load_by_guid_read_only(guid, database_path)
+            try:
+                return dataset.run_id
+            finally:
+                dataset.conn.close()
+
+        assert _run_without_source_changes(tmp_path, load_dataset) == run_id
+        assert _run_without_source_changes(tmp_path, repair) is None
+        assert _run_without_source_changes(
+            tmp_path,
+            lambda: database_access_error(database_path),
+            ) is None
+        info_rows = _run_without_source_changes(
+            tmp_path,
+            lambda: database_info_rows(database_path),
+            )
+        assert any(label == "Runs" and value == "1" for label, value in info_rows)
+
+        assert _directory_state(tmp_path) == expected_state
+        assert sorted(path.name for path in tmp_path.iterdir()) == ["completed.db"]
+    finally:
+        tmp_path.chmod(original_directory_mode)
+        database_path.chmod(0o644)
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_live_wal_refreshes_see_new_rows_without_source_changes(tmp_path):
+    database_path = tmp_path / "live.db"
+    original_database_path = qcodes.config.core.db_location
+    try:
+        initialise_or_create_database_at(database_path)
+        experiment = load_or_create_experiment("live_wal", sample_name="wal")
+        setpoint = ManualParameter("live_setpoint")
+        signal = ManualParameter("live_signal")
+        measurement = Measurement(exp=experiment, name="live_wal_run")
+        measurement.register_parameter(setpoint)
+        measurement.register_parameter(signal, setpoints=(setpoint,))
+
+        with measurement.run() as datasaver:
+            dataset = datasaver.dataset
+            table_name = dataset.table_name
+            guid = dataset.guid
+            datasaver.add_result((setpoint, 1.0), (signal, 2.0))
+            datasaver.flush_data_to_database(block=True)
+
+            assert (tmp_path / "live.db-wal").stat().st_size > 0
+            assert (tmp_path / "live.db-shm").stat().st_size > 0
+
+            immutable = sqlite3.connect(
+                f"{database_path.resolve().as_uri()}?mode=ro&immutable=1",
+                uri=True,
+                )
+            try:
+                try:
+                    immutable_count = immutable.execute(
+                        f'SELECT COUNT(*) FROM "{table_name}"'
+                        ).fetchone()[0]
+                except sqlite3.OperationalError as err:
+                    assert "no such table" in str(err)
+                    immutable_count = 0
+            finally:
+                immutable.close()
+            assert immutable_count < 1
+
+            def direct_row_count():
+                conn = sqlite_read_only_connection(database_path)
+                try:
+                    return conn.execute(
+                        f'SELECT COUNT(*) FROM "{table_name}"'
+                        ).fetchone()[0]
+                finally:
+                    conn.close()
+
+            def qcodes_row_count():
+                conn = qcodes_read_only_connection(database_path)
+                try:
+                    return conn.execute(
+                        f'SELECT COUNT(*) FROM "{table_name}"'
+                        ).fetchone()[0]
+                finally:
+                    conn.close()
+
+            def snapshot_is_temporary(opener):
+                conn = opener(database_path)
+                snapshot_path = Path(
+                    conn.execute("PRAGMA database_list").fetchone()[2]
+                    )
+                try:
+                    assert snapshot_path != database_path.resolve()
+                    assert snapshot_path.is_file()
+                    return snapshot_path.parent
+                finally:
+                    conn.close()
+
+            for opener in (
+                sqlite_read_only_connection,
+                qcodes_read_only_connection,
+            ):
+                snapshot_directory = _run_without_source_changes(
+                    tmp_path,
+                    lambda opener=opener: snapshot_is_temporary(opener),
+                    )
+                assert not snapshot_directory.exists()
+
+            assert _run_without_source_changes(tmp_path, direct_row_count) == 1
+            assert _run_without_source_changes(tmp_path, qcodes_row_count) == 1
+            assert _run_without_source_changes(
+                tmp_path,
+                lambda: database_access_error(database_path),
+                ) is None
+
+            datasaver.add_result((setpoint, 2.0), (signal, 3.0))
+            datasaver.flush_data_to_database(block=True)
+
+            assert _run_without_source_changes(tmp_path, direct_row_count) == 2
+            assert _run_without_source_changes(tmp_path, qcodes_row_count) == 2
+
+            def dataset_row_count():
+                loaded = load_by_guid_read_only(guid, database_path)
+                try:
+                    data = loaded.get_parameter_data("live_signal")
+                    return len(data["live_signal"]["live_signal"])
+                finally:
+                    loaded.conn.close()
+
+            assert _run_without_source_changes(tmp_path, dataset_row_count) == 2
+
+        dataset.conn.close()
+        experiment.conn.close()
+    finally:
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_unstable_live_wal_fails_instead_of_using_immutable_data(
+    tmp_path,
+    monkeypatch,
+):
+    from qplot.datahandling import readonly
+
+    database_path = tmp_path / "unstable.db"
+    writer = sqlite3.connect(database_path)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE live_rows (value INTEGER)")
+        writer.execute("INSERT INTO live_rows VALUES (1)")
+        writer.commit()
+        original_state = _directory_state(tmp_path)
+
+        real_signature = readonly._source_signature
+        signature_call = 0
+
+        def changing_signature(path):
+            nonlocal signature_call
+            signature_call += 1
+            database_signature, wal_signature = real_signature(path)
+            assert wal_signature is not None
+            return database_signature, (*wal_signature[:-1], signature_call)
+
+        monkeypatch.setattr(readonly, "_source_signature", changing_signature)
+        monkeypatch.setattr(readonly, "WAL_SNAPSHOT_ATTEMPTS", 2)
+
+        with pytest.raises(ReadOnlyDatabaseAccessError, match="changed continuously"):
+            sqlite_read_only_connection(database_path)
+
+        assert _directory_state(tmp_path) == original_state
+    finally:
+        writer.close()


### PR DESCRIPTION
## Summary

- centralize all viewer SQLite, QCoDeS `AtomicConnection`, dataset-loading, and subprocess-probe opens behind one source-preserving policy
- open checkpointed databases with no WAL directly using exact-path `mode=ro&immutable=1`
- read databases with a WAL through consistency-checked database-plus-WAL snapshots in the system temporary directory, never opening the source `-shm`
- preserve URI-reserved database filenames through the existing exact-path URI fix
- document live-WAL behavior and add artifact-integrity, POSIX read-only, live-refresh, cleanup, and no-stale-fallback regressions

## Root cause

SQLite `mode=ro` still creates missing WAL/SHM sidecars and can change bytes in an existing SHM file. Adding `immutable=1` prevents that mutation, but SQLite then ignores uncheckpointed WAL rows and makes live plots silently stale.

The new static/live policy uses immutable access only when no WAL exists. A live WAL is copied with the database into a private snapshot whose source file identities, sizes, and timestamps are checked before and after copying. Each refresh takes a fresh snapshot. If the files remain in motion through every bounded attempt, qPlot reports a clear error instead of opening the source write-capably or falling back to stale immutable data.

## Validation

- `python -m ruff check .`
- configured `python -m mypy`
- targeted database-facing suite: 190 passed
- full test suite: 602 passed
- actual `python -m qplot` offscreen startup reached the GUI event loop successfully