### PR TITLE
Fix live-run completion race

### DIFF
--- a/src/qplot/datahandling/LoadFromDB.py
+++ b/src/qplot/datahandling/LoadFromDB.py
@@ -23,7 +23,6 @@ from qplot.datahandling.qcodes_cache import (
     cache_lock,
     parameter_is_complete,
     prepare_cache_if_empty,
-    set_cache_dataset_completed,
 )
 
 if TYPE_CHECKING:
@@ -103,19 +102,19 @@ def load_param_data_from_db_prep(
         )
 
     if parameter_is_complete(param): # Altered to be per param
-        return True
+        return True, cache_dataset_completed(cache)
 
     with cache_lock(cache):
         is_completed = completed(
             connection or cache_dataset_connection(cache),
             cache_dataset_run_id(cache),
             )
-        if cache_dataset_completed(cache) != is_completed:
-            set_cache_dataset_completed(cache, is_completed)
         if cache_data(cache) == {}:
             prepare_cache_if_empty(cache)
-    
-    return False
+
+    # The worker must load and process the final rows before publishing this
+    # database completion observation to the viewer dataset.
+    return False, is_completed
 
 
 def load_param_data_from_db(

--- a/src/qplot/datahandling/qcodes_cache.py
+++ b/src/qplot/datahandling/qcodes_cache.py
@@ -70,7 +70,17 @@ def cache_dataset_completed(cache):
 
 
 def set_cache_dataset_completed(cache, completed):
-    cache_dataset(cache).completed = completed
+    """Update qPlot's cached QCoDeS completion state without database writes.
+
+    QCoDeS 0.58's public ``DataSet.completed`` setter calls
+    ``mark_run_complete`` after changing ``_completed``. Viewer datasets are
+    loaded from databases that qPlot must never write, and their connections
+    may belong to another thread, so completion observations from SQLite must
+    only update the viewer-owned in-memory flag.
+    """
+
+    with cache_lock(cache):
+        cache_dataset(cache)._completed = bool(completed)
 
 
 def parameter_is_complete(param):
@@ -105,6 +115,7 @@ def update_cache_parameter_data(
         updated_read_status,
         updated_write_status,
         updated_data,
+        dataset_completed=None,
         ):
     """Commit a parameter refresh unless a newer worker already won the race.
 
@@ -112,7 +123,8 @@ def update_cache_parameter_data(
     data read from SQLite.  ``_write_status`` is instead an in-memory array
     insertion offset.  In particular, QCoDeS reports ``0`` after appending to
     an unshaped parameter tree, so it cannot safely be used to order refresh
-    workers.
+    workers. Database completion is monotonic and is published last so an
+    older in-flight refresh cannot revert a successful final commit.
     """
 
     with cache_lock(cache):
@@ -129,6 +141,10 @@ def update_cache_parameter_data(
         cache_read_status(cache)[parameter_name] = next_read_status
         cache_write_status(cache)[parameter_name] = next_write_status
         cache_data(cache)[parameter_name] = updated_data[parameter_name]
+        if dataset_completed is True:
+            # Completion is terminal for monitoring, so publish it only after
+            # every part of the successful cache commit above.
+            set_cache_dataset_completed(cache, dataset_completed)
         return True
 
 

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -100,6 +100,7 @@ class loader(QtCore.QRunnable):
         self.cache = cache
         self.table_name = cache_table_name(cache)
         self.param = param
+        self.dataset_completed: bool | None = None
         self.display_param = copy(param)
         self.param_dict = param_dict
         
@@ -213,7 +214,10 @@ class loader(QtCore.QRunnable):
                     self._set_sql_connection(completion_conn)
                     try:
                         self._check_cancelled()
-                        complete = load_param_data_from_db_prep(
+                        (
+                            parameter_complete,
+                            self.dataset_completed,
+                        ) = load_param_data_from_db_prep(
                             cache,
                             self.param,
                             connection=completion_conn,
@@ -221,7 +225,7 @@ class loader(QtCore.QRunnable):
                     finally:
                         self._close_sql_connection(completion_conn)
                     self._check_cancelled()
-                    self.read_data = not complete
+                    self.read_data = not parameter_complete
 
             self._check_cancelled()
             use_sql_heatmap = (

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -7,6 +7,7 @@ from PyQt6 import QtWidgets as qtw
 from qplot.datahandling.qcodes_cache import (
     cache_dataset_completed,
     cache_has_no_written_data,
+    set_cache_dataset_completed,
     set_parameter_complete,
     update_cache_parameter_data,
 )
@@ -363,6 +364,11 @@ class PlotRefreshMixin(_PlotRefreshBase):
                     worker.updated_read_status,
                     worker.updated_write_status,
                     worker.cache_data,
+                    dataset_completed=getattr(
+                        worker,
+                        "dataset_completed",
+                        None,
+                        ),
                     )
                 if not cache_updated:
                     self._refresh_pending = True
@@ -429,6 +435,13 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 dataset_length = self.ds.number_of_results
             self.last_ds_len = dataset_length
             self.hide_plot_state()
+            if (
+                    getattr(worker, "loaded_from_sql_heatmap", False)
+                    and getattr(worker, "dataset_completed", None) is True
+                    ):
+                # Direct SQL heatmaps intentionally bypass the QCoDeS cache.
+                # Publish completion only after their final plot data commits.
+                set_cache_dataset_completed(self.ds.cache, True)
             return True
 
         except AttributeError as err:

--- a/tests/datahandling/test_qcodes_cache.py
+++ b/tests/datahandling/test_qcodes_cache.py
@@ -24,7 +24,11 @@ class Dataset:
     path_to_db = "experiment.db"
     conn = object()
     run_id = 7
-    completed = False
+    _completed = False
+
+    @property
+    def completed(self):
+        return self._completed
 
 
 class Cache:
@@ -82,8 +86,21 @@ def test_cache_parameter_snapshot_copies_state_mappings():
     assert data == {"signal": {"signal": [1, 2]}}
 
 
-def test_dataset_completion_helper_sets_private_flag():
+def test_dataset_completion_helper_sets_private_flag_without_property_setter():
+    class SetterRejectingDataset(Dataset):
+        def __init__(self):
+            self._completed = False
+
+        @property
+        def completed(self):
+            return self._completed
+
+        @completed.setter
+        def completed(self, _value):
+            raise AssertionError("QCoDeS completion setter must not be called")
+
     cache = Cache()
+    cache._dataset = SetterRejectingDataset()
 
     set_cache_dataset_completed(cache, True)
 
@@ -108,6 +125,40 @@ def test_cache_update_writes_single_parameter_state():
     assert committed
 
 
+def test_cache_update_publishes_completion_after_parameter_state():
+    cache = Cache()
+
+    committed = update_cache_parameter_data(
+        cache,
+        "signal",
+        {"signal": 4},
+        {"signal": 4},
+        {"signal": {"signal": [3, 4]}},
+        dataset_completed=True,
+    )
+
+    assert committed
+    assert cache_dataset_completed(cache)
+    assert cache._data["signal"] == {"signal": [3, 4]}
+
+
+def test_cache_update_does_not_revert_published_completion():
+    cache = Cache()
+    set_cache_dataset_completed(cache, True)
+
+    committed = update_cache_parameter_data(
+        cache,
+        "signal",
+        {"signal": 4},
+        {"signal": 4},
+        {"signal": {"signal": [3, 4]}},
+        dataset_completed=False,
+    )
+
+    assert committed
+    assert cache_dataset_completed(cache)
+
+
 def test_cache_update_rejects_result_older_than_current_parameter_state():
     cache = Cache()
     cache._read_status["signal"] = 8
@@ -119,12 +170,14 @@ def test_cache_update_rejects_result_older_than_current_parameter_state():
         {"signal": 4},
         {"signal": 4},
         {"signal": {"signal": [3, 4]}},
+        dataset_completed=True,
     )
 
     assert not committed
     assert cache._read_status["signal"] == 8
     assert cache._write_status["signal"] == 8
     assert cache._data["signal"] == {"signal": [1, 2]}
+    assert not cache_dataset_completed(cache)
 
 
 def test_cache_update_accepts_newer_read_with_reset_unshaped_write_status():
@@ -200,10 +253,13 @@ def test_load_param_data_from_db_prep_defers_parameter_completion_until_commit(m
 
     monkeypatch.setattr(load_from_db, "completed", lambda conn, run_id: True)
 
-    result = load_from_db.load_param_data_from_db_prep(cache, param)
+    parameter_complete, dataset_completed = (
+        load_from_db.load_param_data_from_db_prep(cache, param)
+        )
 
-    assert result is False
-    assert cache._dataset.completed
+    assert parameter_complete is False
+    assert dataset_completed is True
+    assert not cache._dataset.completed
     assert not param._complete
     assert cache.prepare_called
 
@@ -218,7 +274,7 @@ def test_load_param_data_from_db_prep_skips_completed_param(monkeypatch):
 
     monkeypatch.setattr(load_from_db, "completed", fail_if_called)
 
-    assert load_from_db.load_param_data_from_db_prep(cache, param) is True
+    assert load_from_db.load_param_data_from_db_prep(cache, param) == (True, False)
     assert not cache.prepare_called
 
 

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -1,7 +1,11 @@
+import hashlib
+import threading
 import time
 from pathlib import Path
+from time import perf_counter
 
 import numpy as np
+import qcodes
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 from qcodes.dataset import (
@@ -12,8 +16,17 @@ from qcodes.dataset import (
 )
 from qcodes.parameters import ManualParameter
 
+import qplot.tools.worker as worker_module
 from qplot.configuration.config import config
+from qplot.datahandling.qcodes_cache import cache_parameter_data
+from qplot.datahandling.readonly import (
+    load_by_id_read_only,
+    set_qcodes_database_location,
+)
+from qplot.tools.worker import loader
 from qplot.windows import main as main_window
+from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
+from qplot.windows._plotWin import plotWidget
 
 
 def configure_temp_qplot(monkeypatch, tmp_path):
@@ -89,6 +102,35 @@ def close_main_window(window):
     window.deleteLater()
     qtw.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
     qtw.QApplication.processEvents()
+
+
+def database_artifact_state(database_path):
+    """Record content and metadata for the database and SQLite sidecars."""
+
+    state = {}
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        path = Path(f"{database_path}{suffix}")
+        if not path.exists():
+            state[suffix] = None
+            continue
+        stat = path.stat()
+        state[suffix] = (
+            stat.st_size,
+            stat.st_mtime_ns,
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+            )
+    return state
+
+
+def run_plot_worker_on_thread(worker):
+    errors = []
+    worker.emitter.errorOccurred.connect(errors.append)
+    thread = threading.Thread(target=worker.run)
+    thread.start()
+    thread.join(10)
+    qtw.QApplication.processEvents()
+    assert not thread.is_alive()
+    return errors
 
 
 def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
@@ -170,3 +212,207 @@ def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
         assert vertical_cut.sweep_id in heatmap_window.sweep_lines
     finally:
         close_main_window(window)
+
+
+def test_threaded_live_run_completion_commits_final_rows_before_stopping_monitor(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = Path(tmp_path) / "threaded-live-run.db"
+    original_database_path = qcodes.config.core.db_location
+    initial_row_written = threading.Event()
+    finish_writer = threading.Event()
+    writer_state = {}
+    writer_errors = []
+    viewer_dataset = None
+
+    def write_measurement():
+        try:
+            initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+            experiment = load_or_create_experiment(
+                "threaded_live_run",
+                sample_name="completion_race",
+                )
+            gate = ManualParameter("gate")
+            signal = ManualParameter("signal")
+            measurement = Measurement(exp=experiment, name="completion_race")
+            measurement.register_parameter(gate)
+            measurement.register_parameter(signal, setpoints=(gate,))
+            with measurement.run(write_in_background=False) as datasaver:
+                datasaver.add_result((gate, 0.0), (signal, 10.0))
+                datasaver.flush_data_to_database(block=True)
+                writer_state["run_id"] = datasaver.dataset.run_id
+                initial_row_written.set()
+                if not finish_writer.wait(10):
+                    raise TimeoutError("Test did not release the measurement writer")
+                datasaver.add_result((gate, 1.0), (signal, 11.0))
+                datasaver.add_result((gate, 2.0), (signal, 12.0))
+            datasaver.dataset.conn.close()
+        except BaseException as error:
+            writer_errors.append(error)
+            initial_row_written.set()
+
+    writer_thread = threading.Thread(target=write_measurement)
+    writer_thread.start()
+
+    try:
+        assert initial_row_written.wait(10)
+        assert writer_errors == []
+
+        set_qcodes_database_location(database_path)
+        viewer_dataset = load_by_id_read_only(writer_state["run_id"])
+        assert viewer_dataset.running
+        assert viewer_dataset.number_of_results == 1
+
+        parameter = dependent_parameter(viewer_dataset, 1)
+        parameter._complete = False
+        parameters = {
+            candidate.name: candidate
+            for candidate in viewer_dataset.get_parameters()
+            }
+        parameters[parameter.name] = parameter
+        axes = {"x": parameter.depends_on_[0]}
+
+        finish_writer.set()
+        writer_thread.join(10)
+        assert not writer_thread.is_alive()
+        assert writer_errors == []
+        assert viewer_dataset.running
+        # The source-preserving viewer connection is intentionally pinned to
+        # the WAL snapshot from when the run was opened. Plot workers must use
+        # fresh read-only snapshots to discover the committed final rows.
+        assert viewer_dataset.number_of_results == 1
+
+        writer_complete_artifacts = database_artifact_state(database_path)
+        assert set(writer_complete_artifacts) == {"", "-wal", "-shm", "-journal"}
+        assert writer_complete_artifacts[""] is not None
+
+        original_load = worker_module.load_param_data_from_db
+
+        def fail_final_load(*_args, **_kwargs):
+            raise RuntimeError("injected final-load failure")
+
+        monkeypatch.setattr(
+            worker_module,
+            "load_param_data_from_db",
+            fail_final_load,
+            )
+        failed_worker = loader(
+            viewer_dataset.cache,
+            parameter,
+            parameters,
+            axes,
+            )
+        failed_errors = run_plot_worker_on_thread(failed_worker)
+
+        assert len(failed_errors) == 1
+        assert "injected final-load failure" in str(failed_errors[0])
+        assert failed_worker.dataset_completed is True
+        assert viewer_dataset.running
+        assert not viewer_dataset.completed
+        assert not parameter._complete
+
+        class Monitor:
+            def __init__(self):
+                self.active = True
+                self.stop_count = 0
+
+            def stop(self):
+                self.active = False
+                self.stop_count += 1
+
+        class SpinBox:
+            def value(self):
+                return 0.1
+
+        class EndWait:
+            def __init__(self):
+                self.count = 0
+
+            def emit(self):
+                self.count += 1
+
+        dataset_key = DatasetKey(database_path, viewer_dataset.guid)
+        window = plotWidget.__new__(plotWidget)
+        window._dataset_key = dataset_key
+        window._dataset_holder = {
+            dataset_key: DatasetHandle(viewer_dataset),
+            }
+        window._guid = viewer_dataset.guid
+        window.param = parameter
+        window.worker = failed_worker
+        window.monitor = Monitor()
+        window.spinBox = SpinBox()
+        window.end_wait = EndWait()
+        window._last_error_text = None
+        window.show_status = lambda *_args, **_kwargs: None
+        window.show_plot_state = lambda *_args, **_kwargs: None
+        window.hide_plot_state = lambda: None
+        window._set_param_axis_labels = lambda: None
+        monitor_restarts = []
+
+        def restart_monitor(interval):
+            monitor_restarts.append(interval)
+            window.monitor.active = True
+
+        window.monitorIntervalChanged = restart_monitor
+
+        assert plotWidget.refreshPlot(window, False, worker=failed_worker) is False
+        window.last_ds_len = viewer_dataset.number_of_results
+        retry_requests = []
+        window.load_data = lambda: retry_requests.append(True)
+
+        plotWidget.refreshWindow(window)
+
+        assert retry_requests == [True]
+        assert monitor_restarts == [0.1]
+        assert window.monitor.active
+
+        monkeypatch.setattr(
+            worker_module,
+            "load_param_data_from_db",
+            original_load,
+            )
+        successful_worker = loader(
+            viewer_dataset.cache,
+            parameter,
+            parameters,
+            axes,
+            )
+        successful_worker.started_at = perf_counter()
+        successful_worker.dataset_length_at_start = viewer_dataset.number_of_results
+        successful_errors = run_plot_worker_on_thread(successful_worker)
+
+        assert successful_errors == []
+        assert successful_worker.dataset_completed is True
+        assert viewer_dataset.running
+
+        window.worker = successful_worker
+        assert plotWidget.refreshPlot(window, True, worker=successful_worker) is True
+
+        np.testing.assert_array_equal(
+            cache_parameter_data(viewer_dataset.cache, parameter.name)["gate"],
+            [0.0, 1.0, 2.0],
+            )
+        np.testing.assert_array_equal(
+            cache_parameter_data(viewer_dataset.cache, parameter.name)["signal"],
+            [10.0, 11.0, 12.0],
+            )
+        np.testing.assert_array_equal(window.axis_data["x"], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(window.axis_data["y"], [10.0, 11.0, 12.0])
+        assert viewer_dataset.completed
+        assert not viewer_dataset.running
+        assert parameter._complete
+
+        previous_restart_count = len(monitor_restarts)
+        plotWidget.refreshWindow(window)
+        assert len(monitor_restarts) == previous_restart_count
+        assert not window.monitor.active
+        assert retry_requests == [True]
+        assert database_artifact_state(database_path) == writer_complete_artifacts
+    finally:
+        finish_writer.set()
+        writer_thread.join(10)
+        if viewer_dataset is not None:
+            viewer_dataset.conn.close()
+        qcodes.config.core.db_location = original_database_path


### PR DESCRIPTION
## Summary

- carry QCoDeS run-completion observations out of worker preparation without mutating the viewer dataset
- update only the viewer-owned private completion flag, never the public QCoDeS setter or a write-capable database API
- publish terminal completion only after a successful monotonic cache commit, while preserving direct-SQL heatmap completion behavior
- keep failed or stale final loads retryable so monitoring cannot stop before final rows are available

## Root cause

In QCoDeS 0.58, assigning `DataSet.completed = True` changes `_completed` and then calls `mark_run_complete`. qPlot performed that assignment in a plot worker even though the dataset connection belonged to the GUI thread. SQLite raised `ProgrammingError` after `_completed` had already changed, so `dataset.running` became false and monitoring could permanently miss the final committed rows.

## Regression coverage

A real threaded QCoDeS WAL lifecycle test now:

- opens a running measurement and loads the viewer dataset on the test thread
- writes final rows and completes the external writer
- runs qPlot preparation/loading on another thread
- injects one final-load failure and verifies monitoring remains active and retryable
- verifies the retry commits all final rows to the QCoDeS cache and plot arrays before completion becomes terminal
- records database, WAL, SHM, and journal existence/content metadata after writer completion and proves qPlot leaves it unchanged

## Validation

- `python -m pytest` — 605 passed
- `python -m ruff check .` — passed
- `python -m mypy` — passed
- `QT_QPA_PLATFORM=offscreen python -m qplot` — initialized successfully
