### PR TITLE
Harden live-run completion and database replacement handling

### DIFF
--- a/src/qplot/datahandling/LoadFromDB.py
+++ b/src/qplot/datahandling/LoadFromDB.py
@@ -21,7 +21,7 @@ from qplot.datahandling.qcodes_cache import (
     cache_dataset_run_id,
     cache_is_live,
     cache_lock,
-    parameter_is_complete,
+    cache_parameter_is_synchronized,
     prepare_cache_if_empty,
 )
 
@@ -101,7 +101,7 @@ def load_param_data_from_db_prep(
             "in-memory."
         )
 
-    if parameter_is_complete(param): # Altered to be per param
+    if cache_parameter_is_synchronized(cache, param.name):
         return True, cache_dataset_completed(cache)
 
     with cache_lock(cache):

--- a/src/qplot/datahandling/database.py
+++ b/src/qplot/datahandling/database.py
@@ -5,6 +5,7 @@ This module keeps blocking database probes, cloud-file hydration, background
 load workers, and diagnostic report generation outside the GUI class.
 """
 
+import json
 import os
 import queue
 import stat
@@ -16,7 +17,11 @@ from time import perf_counter
 
 from PyQt6 import QtCore
 
-from qplot.datahandling.readonly import sqlite_read_only_connection
+from qplot.datahandling.file_identity import database_file_identity
+from qplot.datahandling.readonly import (
+    replacement_wal_is_quarantined,
+    sqlite_read_only_connection,
+)
 from qplot.datahandling.readSQL import (
     find_new_runs,
     get_run_status,
@@ -77,11 +82,24 @@ def database_access_error(database_path, timeout=DATABASE_ACCESS_TIMEOUT_SECONDS
     first so a stuck access check can be timed out without freezing qPlot.
 
     """
+    # The child has a fresh replacement registry. Carry the identity observed
+    # before its launch so it cannot combine a later main-file replacement
+    # with a retained WAL sidecar.
+    expected_database_identity = database_file_identity(database_path)
+    ignore_unpaired_wal = replacement_wal_is_quarantined(database_path)
     probe = (
+        "import json\n"
         "import sys\n"
         "from qplot.datahandling.readonly import probe_read_only_database\n"
         "try:\n"
-        "    probe_read_only_database(sys.argv[1])\n"
+        "    expected_database_identity = json.loads(sys.argv[3])\n"
+        "    if expected_database_identity is not None:\n"
+        "        expected_database_identity = tuple(expected_database_identity)\n"
+        "    probe_read_only_database(\n"
+        "        sys.argv[1],\n"
+        "        ignore_unpaired_wal=(sys.argv[2] == '1'),\n"
+        "        expected_database_identity=expected_database_identity,\n"
+        "    )\n"
         "except Exception as err:\n"
         "    print(err, file=sys.stderr)\n"
         "    raise SystemExit(1)\n"
@@ -89,7 +107,14 @@ def database_access_error(database_path, timeout=DATABASE_ACCESS_TIMEOUT_SECONDS
 
     try:
         result = subprocess.run(
-            [sys.executable, "-c", probe, database_path],
+            [
+                sys.executable,
+                "-c",
+                probe,
+                database_path,
+                "1" if ignore_unpaired_wal else "0",
+                json.dumps(expected_database_identity),
+            ],
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/src/qplot/datahandling/file_identity.py
+++ b/src/qplot/datahandling/file_identity.py
@@ -1,14 +1,65 @@
-"""Stable identities for database files that may be atomically replaced."""
+"""Stable paths and identities for databases that may be replaced."""
 
 import os
+from dataclasses import dataclass
 from typing import TypeAlias
 
-DatabaseFileIdentity: TypeAlias = tuple[int, int] | tuple[str, str, int]
+DatabaseFileIdentity: TypeAlias = (
+    tuple[int, int]
+    | tuple[str, int, int]
+    | tuple[str, str, int]
+)
+
+
+def logical_database_path(database_path: str | os.PathLike[str]) -> str:
+    """Return the normalised path selected by the user without resolving links."""
+
+    return os.path.normcase(os.path.abspath(os.fspath(database_path)))
 
 
 def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
-    """Return a stable, platform-normalised identity for a database file."""
+    """Return the currently resolved, platform-normalised database path."""
     return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseInstance:
+    """One database instance accepted through a stable logical path."""
+
+    logical_path: str
+    resolved_path: str
+    identity: DatabaseFileIdentity | None
+
+
+def database_instance(
+        database_path: str | os.PathLike[str],
+        ) -> DatabaseInstance:
+    """Capture the logical path, its resolved target, and that target's identity."""
+
+    logical_path = logical_database_path(database_path)
+    resolved_path = canonical_database_path(logical_path)
+    return DatabaseInstance(
+        logical_path=logical_path,
+        resolved_path=resolved_path,
+        identity=database_file_identity(resolved_path),
+    )
+
+
+def database_instances_differ(
+        first: DatabaseInstance | None,
+        second: DatabaseInstance | None,
+        ) -> bool:
+    """Return whether two observations prove that the file instance changed."""
+
+    if first is None or second is None:
+        return first is not second
+    if first.logical_path != second.logical_path:
+        return True
+    if first.resolved_path != second.resolved_path:
+        return True
+    if first.identity is None or second.identity is None:
+        return first.identity != second.identity
+    return first.identity != second.identity
 
 
 def database_file_identity(
@@ -34,6 +85,11 @@ def database_file_identity(
         device = int(getattr(stat_result, "st_dev", 0) or 0)
         return (device, inode)
 
+    if os.name == "nt":
+        windows_identity = _windows_file_identity(canonical_path)
+        if windows_identity is not None:
+            return windows_identity
+
     birthtime_ns = getattr(stat_result, "st_birthtime_ns", None)
     if birthtime_ns is None:
         birthtime = getattr(stat_result, "st_birthtime", None)
@@ -46,3 +102,82 @@ def database_file_identity(
     if birthtime_ns is None:
         return None
     return ("birthtime", canonical_path, int(birthtime_ns))
+
+
+def _windows_file_identity(canonical_path: str) -> DatabaseFileIdentity | None:
+    """Return Windows' volume/file-index identity without opening for writes."""
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except (ImportError, AttributeError):
+        return None
+
+    class ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("last_access_time", wintypes.FILETIME),
+            ("last_write_time", wintypes.FILETIME),
+            ("volume_serial_number", wintypes.DWORD),
+            ("file_size_high", wintypes.DWORD),
+            ("file_size_low", wintypes.DWORD),
+            ("number_of_links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    get_information = kernel32.GetFileInformationByHandle
+    get_information.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ByHandleFileInformation),
+    ]
+    get_information.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    file_read_attributes = 0x0080
+    share_read_write_delete = 0x0001 | 0x0002 | 0x0004
+    open_existing = 3
+    handle = create_file(
+        canonical_path,
+        file_read_attributes,
+        share_read_write_delete,
+        None,
+        open_existing,
+        0,
+        None,
+    )
+    invalid_handle = wintypes.HANDLE(-1).value
+    if handle in (None, invalid_handle):
+        return None
+    try:
+        information = ByHandleFileInformation()
+        if not get_information(handle, ctypes.byref(information)):
+            return None
+        file_index = (
+            int(information.file_index_high) << 32
+            | int(information.file_index_low)
+        )
+        if file_index == 0:
+            return None
+        return (
+            "windows-file-id",
+            int(information.volume_serial_number),
+            file_index,
+        )
+    finally:
+        close_handle(handle)

--- a/src/qplot/datahandling/file_identity.py
+++ b/src/qplot/datahandling/file_identity.py
@@ -1,0 +1,48 @@
+"""Stable identities for database files that may be atomically replaced."""
+
+import os
+from typing import TypeAlias
+
+DatabaseFileIdentity: TypeAlias = tuple[int, int] | tuple[str, str, int]
+
+
+def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
+    """Return a stable, platform-normalised identity for a database file."""
+    return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
+
+
+def database_file_identity(
+        database_path: str | os.PathLike[str],
+        ) -> DatabaseFileIdentity | None:
+    """Return an identity that changes only when the file instance changes.
+
+    Device and inode are the preferred cross-platform identity. Some Windows
+    and network filesystems do not expose a useful inode, so a creation-time
+    identity is used only when the platform exposes one. Size, modification
+    time, and POSIX change time are deliberately excluded because normal
+    database and WAL activity can change them without replacing the file.
+    """
+
+    canonical_path = canonical_database_path(database_path)
+    try:
+        stat_result = os.stat(canonical_path)
+    except OSError:
+        return None
+
+    inode = int(getattr(stat_result, "st_ino", 0) or 0)
+    if inode:
+        device = int(getattr(stat_result, "st_dev", 0) or 0)
+        return (device, inode)
+
+    birthtime_ns = getattr(stat_result, "st_birthtime_ns", None)
+    if birthtime_ns is None:
+        birthtime = getattr(stat_result, "st_birthtime", None)
+        if birthtime is not None:
+            birthtime_ns = round(float(birthtime) * 1_000_000_000)
+    if birthtime_ns is None and os.name == "nt":
+        # On supported Python versions Windows st_ctime is file creation time,
+        # unlike POSIX st_ctime. Prefer st_birthtime above when it is available.
+        birthtime_ns = getattr(stat_result, "st_ctime_ns", None)
+    if birthtime_ns is None:
+        return None
+    return ("birthtime", canonical_path, int(birthtime_ns))

--- a/src/qplot/datahandling/qcodes_cache.py
+++ b/src/qplot/datahandling/qcodes_cache.py
@@ -83,7 +83,40 @@ def set_cache_dataset_completed(cache, completed):
         cache_dataset(cache)._completed = bool(completed)
 
 
+def cache_parameter_is_synchronized(cache, parameter_name):
+    """Return whether qPlot has committed this parameter's final cache rows."""
+
+    with cache_lock(cache):
+        synchronized = getattr(cache, "_qplot_synchronized_parameters", ())
+        return parameter_name in synchronized
+
+
+def set_cache_parameter_synchronized(cache, parameter_name, synchronized=True):
+    """Publish viewer-owned, cache-wide final synchronization state."""
+
+    with cache_lock(cache):
+        completed_parameters = getattr(
+            cache,
+            "_qplot_synchronized_parameters",
+            None,
+            )
+        if completed_parameters is None:
+            completed_parameters = set()
+            cache._qplot_synchronized_parameters = completed_parameters
+
+        if synchronized:
+            completed_parameters.add(parameter_name)
+        else:
+            completed_parameters.discard(parameter_name)
+
+
 def parameter_is_complete(param):
+    """Return the legacy ParamSpec-local completion mirror.
+
+    QCoDeS can reconstruct ParamSpec instances, so this is not authoritative;
+    use :func:`cache_parameter_is_synchronized` for refresh decisions.
+    """
+
     return param._complete is True
 
 
@@ -123,8 +156,10 @@ def update_cache_parameter_data(
     data read from SQLite.  ``_write_status`` is instead an in-memory array
     insertion offset.  In particular, QCoDeS reports ``0`` after appending to
     an unshaped parameter tree, so it cannot safely be used to order refresh
-    workers. Database completion is monotonic and is published last so an
-    older in-flight refresh cannot revert a successful final commit.
+    workers. Parameter synchronization and database completion are monotonic
+    and are published only after the full parameter cache commit, so another
+    plot can distinguish global source completion from its own outstanding
+    final read.
     """
 
     with cache_lock(cache):
@@ -142,8 +177,9 @@ def update_cache_parameter_data(
         cache_write_status(cache)[parameter_name] = next_write_status
         cache_data(cache)[parameter_name] = updated_data[parameter_name]
         if dataset_completed is True:
-            # Completion is terminal for monitoring, so publish it only after
-            # every part of the successful cache commit above.
+            set_cache_parameter_synchronized(cache, parameter_name, True)
+            # Source completion is global, but individual plots still track
+            # whether their final display commit succeeded.
             set_cache_dataset_completed(cache, dataset_completed)
         return True
 

--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -1,6 +1,7 @@
 import shutil
 import sqlite3
 import tempfile
+import threading
 import weakref
 from pathlib import Path
 
@@ -8,12 +9,26 @@ import qcodes
 from qcodes.dataset import load_by_guid, load_by_id
 from qcodes.dataset.sqlite.database import connect, get_DB_debug, get_DB_location
 
+from qplot.datahandling.file_identity import (
+    DatabaseFileIdentity,
+    database_file_identity,
+)
+
 SQLITE_READ_ONLY_CACHE_KIB = 16 * 1024
 WAL_SNAPSHOT_ATTEMPTS = 5
+_DATABASE_INSTANCE_REGISTRY: dict[
+    Path,
+    tuple[DatabaseFileIdentity | None, bool],
+] = {}
+_DATABASE_INSTANCE_REGISTRY_LOCK = threading.Lock()
 
 
 class ReadOnlyDatabaseAccessError(RuntimeError):
     """Raised when qPlot cannot take a non-mutating view of a database."""
+
+
+class DatabaseInstanceChangedError(ReadOnlyDatabaseAccessError):
+    """Raised when a database was atomically replaced during a requested read."""
 
 
 class _ManagedSQLiteConnection(sqlite3.Connection):
@@ -38,6 +53,71 @@ def set_qcodes_database_location(database_path):
     qcodes.config.core.db_location = str(database_path)
 
 
+def quarantine_wal_for_replaced_database(database_path):
+    """Keep an unpaired WAL out of a newly replaced database view.
+
+    Atomic replacement changes the main database file but can leave an old
+    writer's ``-wal`` sidecar behind. SQLite can otherwise combine those two
+    unrelated files and expose the old database. Once a replacement is
+    detected, qPlot deliberately opens the new main file immutable for as
+    long as qPlot is viewing that path. A sidecar can vanish and later be
+    recreated by the old writer, so a transient absence is not enough to prove
+    a later WAL belongs to the replacement. qPlot never changes the source
+    database or any sidecar to make that happen.
+
+    A changed WAL identity is not enough to prove it belongs to the replacement
+    main file: an old writer can rotate or recreate its WAL after the main file
+    has been atomically replaced. Therefore the whole sidecar lifetime is
+    treated conservatively as ambiguous.
+    """
+
+    source_path = _resolved_database_path(database_path)
+    database_identity = database_file_identity(source_path)
+    with _DATABASE_INSTANCE_REGISTRY_LOCK:
+        _DATABASE_INSTANCE_REGISTRY[source_path] = (database_identity, True)
+    return database_identity is not None
+
+
+def _observe_database_instance(database_path):
+    """Record replacement history for every source opened by qPlot.
+
+    The quarantine intentionally survives a momentary missing WAL and later
+    main-file replacements. An old writer can recreate either sidecar after a
+    transient gap, so absence alone cannot prove that a future WAL belongs to
+    the current main file.
+    """
+
+    source_path = _resolved_database_path(database_path)
+    database_identity = database_file_identity(source_path)
+    with _DATABASE_INSTANCE_REGISTRY_LOCK:
+        prior = _DATABASE_INSTANCE_REGISTRY.get(source_path)
+        if prior is None:
+            quarantined = False
+        else:
+            prior_identity, quarantined = prior
+            if prior_identity is not None and prior_identity != database_identity:
+                quarantined = True
+        _DATABASE_INSTANCE_REGISTRY[source_path] = (
+            database_identity,
+            quarantined,
+        )
+    return database_identity, quarantined
+
+
+def _require_expected_database_instance(database_path, expected_database_identity):
+    """Reject a read whose source identity no longer matches its dataset key."""
+
+    if expected_database_identity is None:
+        return
+    database_identity, _quarantined = _observe_database_instance(database_path)
+    if database_identity == expected_database_identity:
+        return
+    quarantine_wal_for_replaced_database(database_path)
+    raise DatabaseInstanceChangedError(
+        "The database was replaced while qPlot was preparing a read."
+    )
+
+
 def configure_read_only_sqlite_connection(conn):
     """Keep read-only SQLite scans from growing qPlot's memory footprint."""
     pragmas = (
@@ -53,7 +133,12 @@ def configure_read_only_sqlite_connection(conn):
     return conn
 
 
-def qcodes_read_only_connection(database_path):
+def qcodes_read_only_connection(
+        database_path,
+        *,
+        ignore_unpaired_wal=False,
+        expected_database_identity=None,
+        ):
     """Open a source-preserving, AtomicConnection-compatible database view.
 
     A checkpointed database with no WAL is opened directly as immutable. If a
@@ -63,19 +148,40 @@ def qcodes_read_only_connection(database_path):
     """
     source_path = _resolved_database_path(database_path)
     for _attempt in range(2):
-        target_path, immutable, snapshot = _prepare_read_target(source_path)
+        target_path, immutable, snapshot, ignore_wal = _prepare_read_target(
+            source_path,
+            ignore_unpaired_wal=ignore_unpaired_wal,
+            expected_database_identity=expected_database_identity,
+        )
+        conn = None
         try:
             conn = connect(
                 _qcodes_uri_path(target_path, immutable=immutable),
                 get_DB_debug(),
                 read_only=True,
                 )
+            _require_expected_database_instance(
+                source_path,
+                expected_database_identity,
+            )
         except Exception:
+            if conn is not None:
+                conn.close()
             if snapshot is not None:
                 snapshot.cleanup()
             raise
 
-        if immutable and _wal_path(source_path).exists():
+        if (
+                immutable
+                and _wal_path(source_path).exists()
+                and not (
+                    ignore_wal
+                    and (
+                        ignore_unpaired_wal
+                        or replacement_wal_is_quarantined(source_path)
+                    )
+                )
+                ):
             conn.close()
             continue
 
@@ -90,11 +196,19 @@ def qcodes_read_only_connection(database_path):
         )
 
 
-def load_by_guid_read_only(guid, database_path=None):
+def load_by_guid_read_only(
+        guid,
+        database_path=None,
+        *,
+        expected_database_identity=None,
+        ):
     """Load a QCoDeS dataset by GUID through a read-only connection."""
     if database_path is None:
         database_path = get_DB_location()
-    conn = qcodes_read_only_connection(database_path)
+    conn = qcodes_read_only_connection(
+        database_path,
+        expected_database_identity=expected_database_identity,
+    )
     try:
         return load_by_guid(guid, conn=conn)
     except Exception:
@@ -102,9 +216,19 @@ def load_by_guid_read_only(guid, database_path=None):
         raise
 
 
-def load_by_id_read_only(run_id):
+def load_by_id_read_only(
+        run_id,
+        database_path=None,
+        *,
+        expected_database_identity=None,
+        ):
     """Load a QCoDeS dataset by run ID through a read-only connection."""
-    conn = qcodes_read_only_connection(get_DB_location())
+    if database_path is None:
+        database_path = get_DB_location()
+    conn = qcodes_read_only_connection(
+        database_path,
+        expected_database_identity=expected_database_identity,
+    )
     try:
         return load_by_id(run_id, conn=conn)
     except Exception:
@@ -129,7 +253,14 @@ def sqlite_read_only_uri(database_path, *, immutable=False):
     return uri
 
 
-def sqlite_read_only_connection(database_path, timeout=10, **kwargs):
+def sqlite_read_only_connection(
+        database_path,
+        timeout=10,
+        *,
+        ignore_unpaired_wal=False,
+        expected_database_identity=None,
+        **kwargs,
+        ):
     """Open a direct source-preserving SQLite connection.
 
     Static databases are opened immutable in place. WAL databases are opened
@@ -140,7 +271,12 @@ def sqlite_read_only_connection(database_path, timeout=10, **kwargs):
     kwargs.setdefault("factory", _ManagedSQLiteConnection)
 
     for _attempt in range(2):
-        target_path, immutable, snapshot = _prepare_read_target(source_path)
+        target_path, immutable, snapshot, ignore_wal = _prepare_read_target(
+            source_path,
+            ignore_unpaired_wal=ignore_unpaired_wal,
+            expected_database_identity=expected_database_identity,
+        )
+        conn = None
         try:
             conn = sqlite3.connect(
                 sqlite_read_only_uri(target_path, immutable=immutable),
@@ -148,12 +284,28 @@ def sqlite_read_only_connection(database_path, timeout=10, **kwargs):
                 uri=True,
                 **kwargs,
                 )
+            _require_expected_database_instance(
+                source_path,
+                expected_database_identity,
+            )
         except Exception:
+            if conn is not None:
+                conn.close()
             if snapshot is not None:
                 snapshot.cleanup()
             raise
 
-        if immutable and _wal_path(source_path).exists():
+        if (
+                immutable
+                and _wal_path(source_path).exists()
+                and not (
+                    ignore_wal
+                    and (
+                        ignore_unpaired_wal
+                        or replacement_wal_is_quarantined(source_path)
+                    )
+                )
+                ):
             conn.close()
             continue
 
@@ -175,9 +327,19 @@ def sqlite_read_only_connection(database_path, timeout=10, **kwargs):
         )
 
 
-def probe_read_only_database(database_path):
+def probe_read_only_database(
+        database_path,
+        *,
+        ignore_unpaired_wal=False,
+        expected_database_identity=None,
+        ):
     """Exercise the same non-mutating open policy used by all viewer reads."""
-    conn = sqlite_read_only_connection(database_path, timeout=1)
+    conn = sqlite_read_only_connection(
+        database_path,
+        timeout=1,
+        ignore_unpaired_wal=ignore_unpaired_wal,
+        expected_database_identity=expected_database_identity,
+    )
     try:
         conn.execute("PRAGMA user_version").fetchone()
     finally:
@@ -201,6 +363,18 @@ def _wal_path(database_path):
     return Path(f"{database_path}-wal")
 
 
+def replacement_wal_is_quarantined(database_path):
+    """Return whether an unpaired WAL must be omitted from this read.
+
+    Replacement history is path-local and intentionally carries forward to a
+    later main-file identity. A changed sidecar or a transient missing sidecar
+    cannot prove it belongs to the current main file.
+    """
+
+    _database_identity, quarantined = _observe_database_instance(database_path)
+    return bool(quarantined)
+
+
 def _file_signature(path):
     try:
         stat_result = path.stat()
@@ -222,21 +396,50 @@ def _source_signature(database_path):
         )
 
 
-def _prepare_read_target(database_path):
+def _prepare_read_target(
+        database_path,
+        *,
+        ignore_unpaired_wal=False,
+        expected_database_identity=None,
+        ):
     """Select immutable static access or make a stable private WAL snapshot."""
     if not database_path.is_file():
         raise FileNotFoundError(database_path)
 
+    _require_expected_database_instance(
+        database_path,
+        expected_database_identity,
+    )
+
     wal_path = _wal_path(database_path)
+    if ignore_unpaired_wal or replacement_wal_is_quarantined(database_path):
+        return database_path, True, None, True
     if not wal_path.exists():
-        return database_path, True, None
+        _require_expected_database_instance(
+            database_path,
+            expected_database_identity,
+        )
+        return database_path, True, None, False
 
     for _attempt in range(WAL_SNAPSHOT_ATTEMPTS):
+        _require_expected_database_instance(
+            database_path,
+            expected_database_identity,
+        )
         before = _source_signature(database_path)
         if before[0] is None:
             raise FileNotFoundError(database_path)
         if before[1] is None:
-            return database_path, True, None
+            _require_expected_database_instance(
+                database_path,
+                expected_database_identity,
+            )
+            return (
+                database_path,
+                True,
+                None,
+                replacement_wal_is_quarantined(database_path),
+            )
 
         snapshot = tempfile.TemporaryDirectory(prefix="qplot-readonly-")
         snapshot_path = Path(snapshot.name) / "database.db"
@@ -253,7 +456,18 @@ def _prepare_read_target(database_path):
                 ) from err
 
         if _source_signature(database_path) == before:
-            return snapshot_path, False, snapshot
+            try:
+                _require_expected_database_instance(
+                    database_path,
+                    expected_database_identity,
+                )
+            except Exception:
+                snapshot.cleanup()
+                raise
+            if replacement_wal_is_quarantined(database_path):
+                snapshot.cleanup()
+                return database_path, True, None, True
+            return snapshot_path, False, snapshot, False
         snapshot.cleanup()
 
     raise ReadOnlyDatabaseAccessError(

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -18,6 +18,7 @@ from qplot.datahandling.qcodes_cache import (
     snapshot_cache_parameter_state,
 )
 from qplot.datahandling.readonly import (
+    DatabaseInstanceChangedError,
     qcodes_read_only_connection,
     sqlite_read_only_connection,
 )
@@ -64,6 +65,7 @@ class loader(QtCore.QRunnable):
                  max_full_heatmap_points: int = MAX_FULL_HEATMAP_POINTS,
                  heatmap_axis_ranges: dict | None = None,
                  heatmap_full_axis_ranges: dict | None = None,
+                 database_identity=None,
                  ):
         """
         Sets up worker with required data for run()
@@ -111,6 +113,8 @@ class loader(QtCore.QRunnable):
         self.max_full_heatmap_points = max(1, int(max_full_heatmap_points))
         self.heatmap_axis_ranges = heatmap_axis_ranges
         self.heatmap_full_axis_ranges = heatmap_full_axis_ranges
+        self.database_identity = database_identity
+        self.database_replaced = False
         self.sampled_heatmap_source = False
         self.aggregated_heatmap_source = False
         self.loaded_from_sql_heatmap = False
@@ -210,7 +214,12 @@ class loader(QtCore.QRunnable):
                     self.read_data = False
                 else:
                     completion_conn = qcodes_read_only_connection(
-                        cache_database_path(cache)
+                        cache_database_path(cache),
+                        expected_database_identity=getattr(
+                            self,
+                            "database_identity",
+                            None,
+                        ),
                         )
                     self._set_sql_connection(completion_conn)
                     try:
@@ -242,7 +251,14 @@ class loader(QtCore.QRunnable):
                     write_status, read_status, existing_data = (
                         snapshot_cache_parameter_state(cache, self.param.name)
                         )
-                    conn = qcodes_read_only_connection(cache_database_path(cache))
+                    conn = qcodes_read_only_connection(
+                        cache_database_path(cache),
+                        expected_database_identity=getattr(
+                            self,
+                            "database_identity",
+                            None,
+                        ),
+                    )
                     self._set_sql_connection(conn)
                     try:
                         self._check_cancelled()
@@ -315,6 +331,14 @@ class loader(QtCore.QRunnable):
 
         except PlotWorkCancelled:
             self._finish_cancelled()
+            return
+        except DatabaseInstanceChangedError as err:
+            self.database_replaced = True
+            if self.is_cancelled():
+                self._finish_cancelled()
+                return
+            self.emitter.errorOccurred.emit(err)
+            self._emit_finished(False)
             return
         except Exception as err: # Raise error in main thread
             if self.is_cancelled():
@@ -424,7 +448,10 @@ class loader(QtCore.QRunnable):
             self.total_point_count_estimate = setpoint_count
             return setpoint_count
 
-        conn = sqlite_read_only_connection(cache_database_path(self.cache))
+        conn = sqlite_read_only_connection(
+            cache_database_path(self.cache),
+            expected_database_identity=getattr(self, "database_identity", None),
+        )
         self._set_sql_connection(conn)
         try:
             self._check_cancelled()
@@ -461,7 +488,10 @@ class loader(QtCore.QRunnable):
 
 
     def _load_large_heatmap_from_sql(self):
-        conn = sqlite_read_only_connection(cache_database_path(self.cache))
+        conn = sqlite_read_only_connection(
+            cache_database_path(self.cache),
+            expected_database_identity=getattr(self, "database_identity", None),
+        )
         self._set_sql_connection(conn)
         try:
             self._check_cancelled()

--- a/src/qplot/tools/worker.py
+++ b/src/qplot/tools/worker.py
@@ -10,11 +10,11 @@ from qplot.datahandling import load_param_data_from_db, load_param_data_from_db_
 from qplot.datahandling.dimensions import ensure_supported_plot_dimensions
 from qplot.datahandling.qcodes_cache import (
     cache_database_path,
+    cache_dataset_completed,
     cache_is_live,
     cache_parameter_data,
     cache_rundescriber,
     cache_table_name,
-    set_parameter_complete,
     snapshot_cache_parameter_state,
 )
 from qplot.datahandling.readonly import (
@@ -206,6 +206,7 @@ class loader(QtCore.QRunnable):
             # are already authoritative and should never be read via SQLite.
             if self.read_data:
                 if cache_live:
+                    self.dataset_completed = cache_dataset_completed(cache)
                     self.read_data = False
                 else:
                     completion_conn = qcodes_read_only_connection(
@@ -234,7 +235,6 @@ class loader(QtCore.QRunnable):
                 and self._should_use_sql_heatmap()
                 )
             if use_sql_heatmap:
-                set_parameter_complete(self.param, False)
                 self._load_large_heatmap_from_sql()
 
             else:
@@ -500,7 +500,6 @@ class loader(QtCore.QRunnable):
         # The direct SQL path deliberately does not populate QCoDeS' full
         # in-memory cache. Keep future refreshes on the database path.
         self.read_data = False
-        set_parameter_complete(self.param, False)
 
 
     def _rowid_span(self, conn):

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -17,7 +17,11 @@ from qplot.datahandling.database import (
     DatabaseRefreshWorker,
     database_info_rows,
 )
-from qplot.datahandling.readonly import set_qcodes_database_location
+from qplot.datahandling.readonly import (
+    quarantine_wal_for_replaced_database,
+    replacement_wal_is_quarantined,
+    set_qcodes_database_location,
+)
 from qplot.diagnostics import log_event, log_exception
 from qplot.testdata import (
     GenerationCancelled,
@@ -27,27 +31,22 @@ from qplot.testdata import (
     write_example_csv,
 )
 
-from ._dataset_handle import canonical_database_path
+from ._dataset_handle import (
+    canonical_database_path,
+    database_file_identity,
+)
 from ._widgets.details_tables import (
     CopyableTableWidget,
     copy_to_clipboard,
     format_value,
 )
 
+_database_file_identity = database_file_identity
 
-def _database_file_identity(database_path):
-    """Return a stable identity that changes when a database is replaced."""
-    try:
-        stat_result = os.stat(database_path)
-    except OSError:
-        return None
-    return (
-        stat_result.st_dev,
-        stat_result.st_ino,
-        stat_result.st_size,
-        stat_result.st_mtime_ns,
-        stat_result.st_ctime_ns,
-    )
+
+def _database_instances_differ(first, second):
+    """Return whether two available identities name different file instances."""
+    return first is not None and second is not None and first != second
 
 
 class DatabaseInfoDialog(qtw.QDialog):
@@ -546,6 +545,11 @@ class DatabaseActionsMixin:
         if not database_path:
             self.show_status("No database is loaded.", 5000)
             return
+        if DatabaseActionsMixin._reload_if_database_instance_changed(
+                self,
+                database_path,
+                ):
+            return
 
         try:
             rows = database_info_rows(database_path)
@@ -556,6 +560,16 @@ class DatabaseActionsMixin:
                 "Could not read database information.",
                 str(err),
             )
+            return
+
+        # A read-only query can legitimately take long enough for an external
+        # process to atomically replace the main file.  Do not show metadata
+        # from that later instance while the UI still represents the earlier
+        # one.
+        if DatabaseActionsMixin._reload_if_database_instance_changed(
+                self,
+                database_path,
+                ):
             return
 
         dialog = DatabaseInfoDialog(rows, parent=self)
@@ -575,6 +589,19 @@ class DatabaseActionsMixin:
             self.show_status("Load a database before refreshing.", 5000)
             return
 
+        if getattr(self, "_database_load_active", False):
+            self.show_status("Database reload already in progress.", 3000)
+            return
+
+        database_path = self.fileTextbox.text()
+        if DatabaseActionsMixin._reload_if_database_instance_changed(
+                self,
+                database_path,
+                ):
+            return
+
+        current_identity = _database_file_identity(database_path)
+
         if getattr(self, "_database_refresh_active", False):
             self._database_refresh_pending = True
             self.show_status("Database refresh queued.", 3000)
@@ -587,7 +614,7 @@ class DatabaseActionsMixin:
         generation = self._database_refresh_generation
         self._database_refresh_active = True
         self._database_refresh_pending = False
-        database_path = self.fileTextbox.text()
+        self._database_refresh_identity = current_identity
         watched_guids = [
             run.guid
             for run in list(self.RunList.watching)
@@ -623,6 +650,15 @@ class DatabaseActionsMixin:
         try:
             if database_path != self.fileTextbox.text():
                 return
+            refresh_identity = getattr(self, "_database_refresh_identity", None)
+            current_identity = _database_file_identity(database_path)
+            loaded_identity = getattr(self, "_loaded_database_identity", None)
+            if (
+                    _database_instances_differ(refresh_identity, current_identity)
+                    or _database_instances_differ(loaded_identity, current_identity)
+                    ):
+                self._reload_replaced_database(database_path)
+                return
             if error is not None:
                 log_exception("Main-window refresh failed", error, __name__)
                 self.show_error(
@@ -636,6 +672,7 @@ class DatabaseActionsMixin:
         finally:
             self._database_refresh_active = False
             self._database_refresh_worker = None
+            self._database_refresh_identity = None
             pending = bool(getattr(self, "_database_refresh_pending", False))
             self._database_refresh_pending = False
             if pending and database_path == self.fileTextbox.text():
@@ -685,6 +722,23 @@ class DatabaseActionsMixin:
         self._database_refresh_active = False
         self._database_refresh_pending = False
         self._database_refresh_worker = None
+        self._database_refresh_identity = None
+
+
+    def _reload_replaced_database(self, database_path):
+        """Invalidate one replaced database instance and force a safe reload."""
+        return self.load_file(database_path, force=True, replacement=True)
+
+
+    def _reload_if_database_instance_changed(self, database_path):
+        """Start replacement reload before any action reads a changed source."""
+
+        loaded_identity = getattr(self, "_loaded_database_identity", None)
+        current_identity = _database_file_identity(database_path)
+        if not _database_instances_differ(loaded_identity, current_identity):
+            return False
+        self._reload_replaced_database(database_path)
+        return True
 
 
     @QtCore.pyqtSlot()
@@ -883,7 +937,14 @@ class DatabaseActionsMixin:
             self.recentDatabaseMenu.addAction(action)
 
 
-    def load_file(self, abspath, load_started_at=None, *, force=False):
+    def load_file(
+            self,
+            abspath,
+            load_started_at=None,
+            *,
+            force=False,
+            replacement=False,
+            ):
         """
         Updates the database for RunList display and loading datasets.
 
@@ -896,8 +957,6 @@ class DatabaseActionsMixin:
             self.show_status("Wait for the current database load to finish.", 5000)
             return False
 
-        DatabaseActionsMixin._cancel_database_refresh(self)
-
         qcodes_database = get_DB_location()
         displayed_database = self.fileTextbox.text()
         same_loaded_database = bool(
@@ -909,8 +968,21 @@ class DatabaseActionsMixin:
         )
         current_identity = _database_file_identity(abspath)
         loaded_identity = getattr(self, "_loaded_database_identity", None)
+        replacement = bool(
+            replacement
+            or (
+                same_loaded_database
+                and _database_instances_differ(loaded_identity, current_identity)
+            )
+        )
+
+        DatabaseActionsMixin._cancel_database_refresh(self)
+        if replacement:
+            self._prepare_replaced_database_reload(abspath)
+
         if (
                 same_loaded_database
+                and not replacement
                 and not force
                 and loaded_identity is not None
                 and current_identity == loaded_identity
@@ -925,7 +997,12 @@ class DatabaseActionsMixin:
             self.remember_loaded_database(abspath)
             return True
 
-        load_message = f"Loading database {os.path.basename(abspath)}..."
+        if replacement:
+            load_message = (
+                f"Database was replaced; reloading {os.path.basename(abspath)}..."
+            )
+        else:
+            load_message = f"Loading database {os.path.basename(abspath)}..."
 
         self._database_load_generation += 1
         generation = self._database_load_generation
@@ -934,6 +1011,8 @@ class DatabaseActionsMixin:
             "abspath": abspath,
             "load_started_at": load_started_at,
             "reload_same_path": force or same_loaded_database,
+            "load_identity": current_identity,
+            "replacement_reload": replacement,
         }
 
         self._set_database_load_controls_enabled(False)
@@ -950,6 +1029,35 @@ class DatabaseActionsMixin:
         worker.signals.finished.connect(self.database_load_finished)
         self.databaseLoadThreadPool.start(worker)
         return True
+
+
+    def _prepare_replaced_database_reload(self, abspath):
+        """Discard every runtime object tied to a replaced file instance."""
+        quarantine_wal_for_replaced_database(abspath)
+        self.monitor.stop()
+        self._cancel_database_detail_load()
+
+        cancel_plot_work = getattr(self, "_cancel_plot_work", None)
+        if callable(cancel_plot_work):
+            cancel_plot_work()
+
+        invalidate_runtime_state = getattr(
+            self,
+            "_invalidate_database_runtime_state",
+            None,
+        )
+        if callable(invalidate_runtime_state):
+            invalidate_runtime_state(abspath)
+
+        run_id_signals_blocked = self.run_idBox.blockSignals(True)
+        run_list_signals_blocked = self.RunList.blockSignals(True)
+        try:
+            self._prepare_database_load_ui(abspath)
+            self.infoBox.preview.set_database_runs(abspath, {})
+        finally:
+            self.RunList.blockSignals(run_list_signals_blocked)
+            self.run_idBox.blockSignals(run_id_signals_blocked)
+        self._sync_empty_state()
 
 
     def _prepare_database_load_ui(self, abspath):
@@ -1083,6 +1191,21 @@ class DatabaseActionsMixin:
         self._set_database_load_controls_enabled(True)
         self._hide_database_load_panel()
         load_started_at = state.get("load_started_at") or perf_counter()
+        load_identity = state.get("load_identity")
+        current_identity = _database_file_identity(abspath)
+
+        if _database_instances_differ(load_identity, current_identity):
+            self.show_status("Database changed while loading; retrying...", 0)
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.load_file(
+                    abspath,
+                    load_started_at,
+                    force=True,
+                    replacement=True,
+                ),
+            )
+            return
 
         if error is not None:
             log_exception("Database load failed", error, __name__)
@@ -1094,7 +1217,7 @@ class DatabaseActionsMixin:
             return
 
         self._cancel_database_detail_load()
-        if state.get("reload_same_path"):
+        if state.get("reload_same_path") and not state.get("replacement_reload"):
             invalidate_runtime_state = getattr(
                 self,
                 "_invalidate_database_runtime_state",
@@ -1103,7 +1226,6 @@ class DatabaseActionsMixin:
             if callable(invalidate_runtime_state):
                 invalidate_runtime_state(abspath)
         set_qcodes_database_location(abspath)
-        self._loaded_database_identity = _database_file_identity(abspath)
         runs = runs or {}
         run_id_signals_blocked = self.run_idBox.blockSignals(True)
         run_list_signals_blocked = self.RunList.blockSignals(True)
@@ -1114,7 +1236,28 @@ class DatabaseActionsMixin:
         finally:
             self.RunList.blockSignals(run_list_signals_blocked)
             self.run_idBox.blockSignals(run_id_signals_blocked)
+
+        accepted_identity = _database_file_identity(abspath)
+        if _database_instances_differ(load_identity, accepted_identity):
+            self._prepare_replaced_database_reload(abspath)
+            self.show_status("Database changed while loading; retrying...", 0)
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.load_file(
+                    abspath,
+                    load_started_at,
+                    force=True,
+                    replacement=True,
+                ),
+            )
+            return
+
+        self._loaded_database_identity = accepted_identity
         self.select_default_run()
+        final_identity = _database_file_identity(abspath)
+        if _database_instances_differ(accepted_identity, final_identity):
+            self._reload_replaced_database(abspath)
+            return
         prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
         if callable(prioritize_previews):
             prioritize_previews()
@@ -1126,7 +1269,15 @@ class DatabaseActionsMixin:
         elapsed = perf_counter() - load_started_at
         self.remember_loaded_database(abspath)
         run_count = self.RunList.topLevelItemCount()
-        if run_count == 0:
+        if state.get("replacement_reload"):
+            run_word = "run" if run_count == 1 else "runs"
+            status = (
+                f"Database was replaced and reloaded: "
+                f"{os.path.basename(abspath)} ({run_count} {run_word})."
+            )
+            if replacement_wal_is_quarantined(abspath):
+                status += " WAL sidecars are ignored for this replacement view."
+        elif run_count == 0:
             status = self._loaded_empty_database_status(abspath, elapsed)
         else:
             status = (
@@ -1307,6 +1458,11 @@ class DatabaseActionsMixin:
             return
         if abspath != self.fileTextbox.text():
             return
+        if DatabaseActionsMixin._reload_if_database_instance_changed(
+                self,
+                abspath,
+                ):
+            return
 
         self._apply_database_detail_batch(runs)
 
@@ -1328,6 +1484,11 @@ class DatabaseActionsMixin:
         if not getattr(self, "_database_expensive_detail_active", False):
             return
         if abspath != self.fileTextbox.text():
+            return
+        if DatabaseActionsMixin._reload_if_database_instance_changed(
+                self,
+                abspath,
+                ):
             return
 
         self._apply_database_detail_batch(runs)

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -17,6 +17,12 @@ from qplot.datahandling.database import (
     DatabaseRefreshWorker,
     database_info_rows,
 )
+from qplot.datahandling.file_identity import (
+    DatabaseInstance,
+    database_instance,
+    database_instances_differ,
+    logical_database_path,
+)
 from qplot.datahandling.readonly import (
     quarantine_wal_for_replaced_database,
     replacement_wal_is_quarantined,
@@ -47,6 +53,16 @@ _database_file_identity = database_file_identity
 def _database_instances_differ(first, second):
     """Return whether two available identities name different file instances."""
     return first is not None and second is not None and first != second
+
+
+def _database_observations_differ(first, second):
+    """Compare saved observations, retaining compatibility with test harnesses."""
+
+    if isinstance(first, DatabaseInstance) and isinstance(second, DatabaseInstance):
+        return database_instances_differ(first, second)
+    first_identity = getattr(first, "identity", first)
+    second_identity = getattr(second, "identity", second)
+    return _database_instances_differ(first_identity, second_identity)
 
 
 class DatabaseInfoDialog(qtw.QDialog):
@@ -211,6 +227,7 @@ class DatabaseActionsMixin:
     """
 
     _database_refresh_worker: DatabaseRefreshWorker | None
+    _database_refresh_instance: DatabaseInstance | None
     _test_database_generation_worker: TestDatabaseGenerationWorker | None
 
     def load_startup_database(self):
@@ -508,6 +525,7 @@ class DatabaseActionsMixin:
         self._database_load_state = None
         self._database_load_worker = None
         self._loaded_database_identity = None
+        self._loaded_database_instance = None
         if hasattr(self, "_set_database_load_controls_enabled"):
             self._set_database_load_controls_enabled(True)
         if hasattr(self, "_hide_database_load_panel"):
@@ -619,7 +637,8 @@ class DatabaseActionsMixin:
                 ):
             return
 
-        current_identity = _database_file_identity(database_path)
+        current_instance = database_instance(database_path)
+        current_identity = current_instance.identity
 
         if getattr(self, "_database_refresh_active", False):
             self._database_refresh_pending = True
@@ -634,6 +653,7 @@ class DatabaseActionsMixin:
         self._database_refresh_active = True
         self._database_refresh_pending = False
         self._database_refresh_identity = current_identity
+        self._database_refresh_instance = current_instance
         watched_guids = [
             run.guid
             for run in list(self.RunList.watching)
@@ -670,11 +690,19 @@ class DatabaseActionsMixin:
             if database_path != self.fileTextbox.text():
                 return
             refresh_identity = getattr(self, "_database_refresh_identity", None)
-            current_identity = _database_file_identity(database_path)
+            refresh_instance = getattr(self, "_database_refresh_instance", None)
+            current_instance = database_instance(database_path)
             loaded_identity = getattr(self, "_loaded_database_identity", None)
+            loaded_instance = getattr(self, "_loaded_database_instance", None)
             if (
-                    _database_instances_differ(refresh_identity, current_identity)
-                    or _database_instances_differ(loaded_identity, current_identity)
+                    _database_observations_differ(
+                        refresh_instance or refresh_identity,
+                        current_instance,
+                    )
+                    or _database_observations_differ(
+                        loaded_instance or loaded_identity,
+                        current_instance,
+                    )
                     ):
                 self._reload_replaced_database(database_path)
                 return
@@ -692,6 +720,7 @@ class DatabaseActionsMixin:
             self._database_refresh_active = False
             self._database_refresh_worker = None
             self._database_refresh_identity = None
+            self._database_refresh_instance = None
             pending = bool(getattr(self, "_database_refresh_pending", False))
             self._database_refresh_pending = False
             if pending and database_path == self.fileTextbox.text():
@@ -742,6 +771,7 @@ class DatabaseActionsMixin:
         self._database_refresh_pending = False
         self._database_refresh_worker = None
         self._database_refresh_identity = None
+        self._database_refresh_instance = None
 
 
     def _reload_replaced_database(self, database_path):
@@ -753,8 +783,18 @@ class DatabaseActionsMixin:
         """Start replacement reload before any action reads a changed source."""
 
         loaded_identity = getattr(self, "_loaded_database_identity", None)
-        current_identity = _database_file_identity(database_path)
-        if not _database_instances_differ(loaded_identity, current_identity):
+        loaded_instance = getattr(self, "_loaded_database_instance", None)
+        if loaded_instance is None:
+            changed = _database_instances_differ(
+                loaded_identity,
+                _database_file_identity(database_path),
+            )
+        else:
+            changed = database_instances_differ(
+                loaded_instance,
+                database_instance(database_path),
+            )
+        if not changed:
             return False
         self._reload_replaced_database(database_path)
         return True
@@ -981,17 +1021,37 @@ class DatabaseActionsMixin:
         same_loaded_database = bool(
             qcodes_database
             and displayed_database
-            and canonical_database_path(abspath)
-            == canonical_database_path(qcodes_database)
-            == canonical_database_path(displayed_database)
+            and logical_database_path(abspath)
+            == logical_database_path(qcodes_database)
+            == logical_database_path(displayed_database)
         )
-        current_identity = _database_file_identity(abspath)
+        current_instance = database_instance(abspath)
+        current_identity = current_instance.identity
         loaded_identity = getattr(self, "_loaded_database_identity", None)
+        loaded_instance = getattr(self, "_loaded_database_instance", None)
+        if current_identity is None and os.path.isfile(abspath):
+            if same_loaded_database and loaded_instance is not None:
+                self._prepare_replaced_database_reload(abspath)
+                self._loaded_database_identity = None
+                self._loaded_database_instance = None
+            self.show_error(
+                "Database Identity Unavailable",
+                "qPlot cannot safely monitor this database for replacement.",
+                (
+                    "The filesystem did not provide a stable file identity. "
+                    "The database was not loaded because qPlot cannot safely "
+                    "distinguish normal live writes from a replaced file."
+                ),
+            )
+            return False
         replacement = bool(
             replacement
             or (
                 same_loaded_database
-                and _database_instances_differ(loaded_identity, current_identity)
+                and _database_observations_differ(
+                    loaded_instance or loaded_identity,
+                    current_instance,
+                )
             )
         )
 
@@ -1031,6 +1091,7 @@ class DatabaseActionsMixin:
             "load_started_at": load_started_at,
             "reload_same_path": force or same_loaded_database,
             "load_identity": current_identity,
+            "load_instance": current_instance,
             "replacement_reload": replacement,
         }
 
@@ -1052,6 +1113,7 @@ class DatabaseActionsMixin:
 
     def _prepare_replaced_database_reload(self, abspath):
         """Discard every runtime object tied to a replaced file instance."""
+        old_instance = getattr(self, "_loaded_database_instance", None)
         quarantine_wal_for_replaced_database(abspath)
         self.monitor.stop()
         self._cancel_database_detail_load()
@@ -1066,7 +1128,7 @@ class DatabaseActionsMixin:
             None,
         )
         if callable(invalidate_runtime_state):
-            invalidate_runtime_state(abspath)
+            invalidate_runtime_state(old_instance or abspath)
 
         run_id_signals_blocked = self.run_idBox.blockSignals(True)
         run_list_signals_blocked = self.RunList.blockSignals(True)
@@ -1211,9 +1273,13 @@ class DatabaseActionsMixin:
         self._hide_database_load_panel()
         load_started_at = state.get("load_started_at") or perf_counter()
         load_identity = state.get("load_identity")
-        current_identity = _database_file_identity(abspath)
+        load_instance = state.get("load_instance")
+        current_instance = database_instance(abspath)
 
-        if _database_instances_differ(load_identity, current_identity):
+        if _database_observations_differ(
+                load_instance or load_identity,
+                current_instance,
+                ):
             self.show_status("Database changed while loading; retrying...", 0)
             QtCore.QTimer.singleShot(
                 0,
@@ -1243,7 +1309,9 @@ class DatabaseActionsMixin:
                 None,
             )
             if callable(invalidate_runtime_state):
-                invalidate_runtime_state(abspath)
+                invalidate_runtime_state(
+                    getattr(self, "_loaded_database_instance", None) or abspath
+                )
         set_qcodes_database_location(abspath)
         runs = runs or {}
         run_id_signals_blocked = self.run_idBox.blockSignals(True)
@@ -1256,8 +1324,12 @@ class DatabaseActionsMixin:
             self.RunList.blockSignals(run_list_signals_blocked)
             self.run_idBox.blockSignals(run_id_signals_blocked)
 
-        accepted_identity = _database_file_identity(abspath)
-        if _database_instances_differ(load_identity, accepted_identity):
+        accepted_instance = database_instance(abspath)
+        accepted_identity = accepted_instance.identity
+        if _database_observations_differ(
+                load_instance or load_identity,
+                accepted_instance,
+                ):
             self._prepare_replaced_database_reload(abspath)
             self.show_status("Database changed while loading; retrying...", 0)
             QtCore.QTimer.singleShot(
@@ -1272,9 +1344,10 @@ class DatabaseActionsMixin:
             return
 
         self._loaded_database_identity = accepted_identity
+        self._loaded_database_instance = accepted_instance
         self.select_default_run()
-        final_identity = _database_file_identity(abspath)
-        if _database_instances_differ(accepted_identity, final_identity):
+        final_instance = database_instance(abspath)
+        if _database_observations_differ(accepted_instance, final_instance):
             self._reload_replaced_database(abspath)
             return
         prioritize_previews = getattr(self, "_prioritize_preview_runs", None)

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -401,6 +401,25 @@ class DatabaseActionsMixin:
             database_path += ".db"
         database_path = os.path.abspath(database_path)
 
+        file_textbox = getattr(self, "fileTextbox", None)
+        current_database = file_textbox.text() if file_textbox is not None else ""
+        if (
+                current_database
+                and canonical_database_path(current_database)
+                == canonical_database_path(database_path)
+                ):
+            # qPlot deliberately replaces this source. Release its read-only
+            # dataset handles before the worker publishes the temporary file:
+            # Windows otherwise forbids replacing a database that qPlot still
+            # has open. The replacement completion path reloads the same view.
+            prepare_replacement = getattr(
+                self,
+                "_prepare_replaced_database_reload",
+                None,
+            )
+            if callable(prepare_replacement):
+                prepare_replacement(database_path)
+
         self._test_database_generation_active = True
         action = getattr(self, "generateTestDatabaseAction", None)
         if action is not None:

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -1,7 +1,12 @@
-import os
 from dataclasses import dataclass
 
 from PyQt6 import QtCore
+
+from qplot.datahandling.file_identity import (
+    DatabaseFileIdentity,
+    canonical_database_path,
+    database_file_identity,
+)
 
 
 def close_dataset_connection(dataset: object) -> bool:
@@ -15,21 +20,23 @@ def close_dataset_connection(dataset: object) -> bool:
     return True
 
 
-def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
-    """Return a stable, platform-normalised identity for a database file."""
-    return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
-
-
 @dataclass(frozen=True, slots=True)
 class DatasetKey:
     """Identifies a dataset within one particular database file."""
 
     database_path: str
     guid: str
+    database_identity: DatabaseFileIdentity | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "database_path", canonical_database_path(self.database_path))
         object.__setattr__(self, "guid", str(self.guid))
+        if self.database_identity is None:
+            object.__setattr__(
+                self,
+                "database_identity",
+                database_file_identity(self.database_path),
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +64,7 @@ class DatasetHandle:
     users: int = 1
     delete_timer: QtCore.QTimer | None = None
     closed: bool = False
+    database_identity: DatabaseFileIdentity | None = None
 
     def retain(self):
         """

--- a/src/qplot/windows/_dataset_handle.py
+++ b/src/qplot/windows/_dataset_handle.py
@@ -6,6 +6,7 @@ from qplot.datahandling.file_identity import (
     DatabaseFileIdentity,
     canonical_database_path,
     database_file_identity,
+    logical_database_path,
 )
 
 
@@ -27,15 +28,31 @@ class DatasetKey:
     database_path: str
     guid: str
     database_identity: DatabaseFileIdentity | None = None
+    resolved_database_path: str | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "database_path", canonical_database_path(self.database_path))
+        logical_path = logical_database_path(self.database_path)
+        object.__setattr__(self, "database_path", logical_path)
         object.__setattr__(self, "guid", str(self.guid))
+        if self.resolved_database_path is None:
+            object.__setattr__(
+                self,
+                "resolved_database_path",
+                canonical_database_path(logical_path),
+            )
+        else:
+            object.__setattr__(
+                self,
+                "resolved_database_path",
+                canonical_database_path(self.resolved_database_path),
+            )
         if self.database_identity is None:
+            resolved_path = self.resolved_database_path
+            assert resolved_path is not None
             object.__setattr__(
                 self,
                 "database_identity",
-                database_file_identity(self.database_path),
+                database_file_identity(resolved_path),
             )
 
 

--- a/src/qplot/windows/_plot1d_traces.py
+++ b/src/qplot/windows/_plot1d_traces.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
 from ._dragdrop import make_run_preview_mime
+from ._plot_refresh import plot_refresh_required
 from ._subplots import subplot1d
 from ._widgets import picker_1d
 
@@ -417,7 +418,7 @@ class Plot1DTraceMixin(_Plot1DTraceBase):
             from_win = line.from_win
             if (
                 not from_win.visible
-                and from_win.ds.running
+                and plot_refresh_required(from_win)
                 and not from_win.monitor.isActive()
                 ):
                 from_win.monitorIntervalChanged(from_win.spinBox.value())

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -152,6 +152,7 @@ class plotWidget(
     """
     
     closed = QtCore.pyqtSignal([object])
+    database_replaced = QtCore.pyqtSignal(str)
     end_wait = QtCore.pyqtSignal()
     make_ds = QtCore.pyqtSignal([object])
     previewTraceDropRequested = QtCore.pyqtSignal(object, object, str)

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -6,7 +6,6 @@ import pyqtgraph as pg
 from PyQt6 import QtCore, QtGui
 from PyQt6 import QtWidgets as qtw
 
-from qplot.datahandling.qcodes_cache import set_parameter_complete
 from qplot.tools import (
     unpack_param,
 )
@@ -203,8 +202,8 @@ class plotWidget(
         self._dataset_key = dataset_key
         self._guid = dataset_key.guid
         self.param = param
-        if not hasattr(self.param, "_complete"): # Add completed load track
-            set_parameter_complete(self.param, False)
+        self._qplot_display_synchronized = False
+        self._qplot_display_uses_direct_sql = False
         self.name = str(self)
         self.label = f"ID:{self.ds.run_id} {self.param.name}"
         self._trace_key = TraceKey(self._dataset_key, self.param.name)
@@ -272,8 +271,9 @@ class plotWidget(
             w.setLayout(self._window_layout)
             self.setCentralWidget(w)
         
-        #start refresh cycle if live
-        if self.ds.running:
+        # Keep the timer alive through this plot's own terminal display commit,
+        # even if another parameter publishes shared dataset completion first.
+        if self._refresh_monitor_required(self.ds):
             self.monitorIntervalChanged(self.spinBox.value())
 
 
@@ -1225,6 +1225,7 @@ class plotWidget(
         if self.__dict__.get("_merged_trace_users", 0) <= 0:
             self.monitor.stop()
             self._refresh_pending = False
+            self._refresh_pending_force = False
             worker = self.__dict__.get("worker")
             cancel = getattr(worker, "cancel", None)
             if callable(cancel):
@@ -1235,7 +1236,7 @@ class plotWidget(
 
         if (
                 self.__dict__.get("_merged_trace_users", 0) > 0
-                and self.ds.running
+                and self._refresh_monitor_required(self.ds)
                 and not self.monitor.isActive()
                 ):
             self.monitorIntervalChanged(self.spinBox.value())

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -9,6 +9,10 @@ from qplot.datahandling.dimensions import (
     MAX_SUPPORTED_PLOT_DIMENSIONS,
     unsupported_plot_message,
 )
+from qplot.datahandling.file_identity import (
+    DatabaseInstance,
+    logical_database_path,
+)
 from qplot.datahandling.readonly import (
     DatabaseInstanceChangedError,
     load_by_guid_read_only,
@@ -66,8 +70,11 @@ class PlotActionsMixin:
     @staticmethod
     def _dataset_key_is_current(dataset_key):
         expected_identity = dataset_key.database_identity
+        current_resolved_path = canonical_database_path(dataset_key.database_path)
+        if current_resolved_path != dataset_key.resolved_database_path:
+            return False
         if expected_identity is None:
-            return True
+            return not os.path.isfile(dataset_key.database_path)
         return database_file_identity(dataset_key.database_path) == expected_identity
 
 
@@ -78,7 +85,7 @@ class PlotActionsMixin:
         current_path = file_textbox.text() if file_textbox is not None else ""
         return bool(
             current_path
-            and canonical_database_path(current_path) == dataset_key.database_path
+            and logical_database_path(current_path) == dataset_key.database_path
         )
 
 
@@ -248,7 +255,31 @@ class PlotActionsMixin:
                 log_exception("Plot dataset cleanup failed", err, __name__)
 
 
-    def _detach_replaced_secondary_traces(self, database_path):
+    @staticmethod
+    def _dataset_key_matches_replaced_instance(dataset_key, database_source):
+        """Match a key against saved old-instance information."""
+
+        if dataset_key is None:
+            return False
+        if isinstance(database_source, DatasetKey):
+            logical_path = database_source.database_path
+            resolved_path = database_source.resolved_database_path
+            identity = database_source.database_identity
+        elif isinstance(database_source, DatabaseInstance):
+            logical_path = database_source.logical_path
+            resolved_path = database_source.resolved_path
+            identity = database_source.identity
+        else:
+            return dataset_key.database_path == logical_database_path(database_source)
+
+        if dataset_key.database_path != logical_path:
+            return False
+        if identity is not None and dataset_key.database_identity is not None:
+            return dataset_key.database_identity == identity
+        return dataset_key.resolved_database_path == resolved_path
+
+
+    def _detach_replaced_secondary_traces(self, database_source):
         """Remove secondary lines whose source belongs to a replaced database.
 
         A merged source can be closed and therefore absent from ``windows``
@@ -256,14 +287,19 @@ class PlotActionsMixin:
         alive. Retire those consumers before evicting the source handle so a
         plot backed by another database cannot retain or refresh stale data.
         """
-        canonical_path = canonical_database_path(database_path)
+        def source_matches(dataset_key):
+            return self._dataset_key_matches_replaced_instance(
+                dataset_key,
+                database_source,
+            )
+
         for host in list(getattr(self, "windows", [])):
             host_key = getattr(host, "_dataset_key", None)
             # Hosts from the replaced database are closed below, and their
             # close event already detaches every secondary line.
             if (
                     host_key is not None
-                    and host_key.database_path == canonical_path
+                    and source_matches(host_key)
                     ):
                 continue
 
@@ -281,8 +317,7 @@ class PlotActionsMixin:
                     and line is not main_line
                     and getattr(getattr(line, "from_win", None), "_dataset_key", None)
                     is not None
-                    and getattr(line.from_win._dataset_key, "database_path", None)
-                    == canonical_path
+                    and source_matches(line.from_win._dataset_key)
                     )
                 ]
             for trace_key, line in stale_traces:
@@ -297,14 +332,16 @@ class PlotActionsMixin:
                     )
 
 
-    def _invalidate_database_runtime_state(self, database_path):
+    def _invalidate_database_runtime_state(self, database_source):
         """Close datasets and plot windows backed by a replaced database."""
-        canonical_path = canonical_database_path(database_path)
-        self._detach_replaced_secondary_traces(canonical_path)
+        self._detach_replaced_secondary_traces(database_source)
         selected_key = getattr(self, "_selected_dataset_key", None)
         if (
                 selected_key is not None
-                and selected_key.database_path == canonical_path
+                and self._dataset_key_matches_replaced_instance(
+                    selected_key,
+                    database_source,
+                )
                 ):
             self._release_selected_dataset()
             self.selected_run_id = None
@@ -313,7 +350,10 @@ class PlotActionsMixin:
             dataset_key = getattr(win, "_dataset_key", None)
             if (
                     dataset_key is None
-                    or dataset_key.database_path != canonical_path
+                    or not self._dataset_key_matches_replaced_instance(
+                        dataset_key,
+                        database_source,
+                    )
                     ):
                 continue
             try:
@@ -322,7 +362,10 @@ class PlotActionsMixin:
                 log_exception("Replaced database plot cleanup failed", err, __name__)
 
         for dataset_key in list(self.dataset_holder):
-            if dataset_key.database_path == canonical_path:
+            if self._dataset_key_matches_replaced_instance(
+                    dataset_key,
+                    database_source,
+                    ):
                 self._evict_dataset_handle(dataset_key)
 
 
@@ -330,17 +373,22 @@ class PlotActionsMixin:
         """Reload the current source, or retire a stale plot from another DB."""
 
         current_path = self.fileTextbox.text()
+        source_key = getattr(source_window, "_dataset_key", None)
+        logical_source_path = (
+            source_key.database_path
+            if source_key is not None
+            else logical_database_path(database_path)
+        )
         if (
                 current_path
-                and canonical_database_path(current_path)
-                == canonical_database_path(database_path)
+                and logical_database_path(current_path) == logical_source_path
                 ):
-            return self._reload_replaced_database(database_path)
+            return self._reload_replaced_database(current_path)
 
         # qPlot may retain plots from a database that is no longer selected in
         # MainWindow. A replacement there must not switch the main UI back to
         # that path; discard only those stale runtime objects instead.
-        self._invalidate_database_runtime_state(database_path)
+        self._invalidate_database_runtime_state(source_key or database_path)
         return False
 
     @QtCore.pyqtSlot(object)
@@ -1276,7 +1324,20 @@ class PlotActionsMixin:
 
 
     def _current_dataset_key(self, guid: str) -> DatasetKey:
-        return DatasetKey(self.fileTextbox.text(), guid)
+        database_path = self.fileTextbox.text()
+        loaded_instance = getattr(self, "_loaded_database_instance", None)
+        if (
+                isinstance(loaded_instance, DatabaseInstance)
+                and loaded_instance.logical_path
+                == logical_database_path(database_path)
+                ):
+            return DatasetKey(
+                loaded_instance.logical_path,
+                guid,
+                loaded_instance.identity,
+                loaded_instance.resolved_path,
+            )
+        return DatasetKey(database_path, guid)
 
 
     def _load_dataset(self, dataset_key: DatasetKey):

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -9,7 +9,11 @@ from qplot.datahandling.dimensions import (
     MAX_SUPPORTED_PLOT_DIMENSIONS,
     unsupported_plot_message,
 )
-from qplot.datahandling.readonly import load_by_guid_read_only, load_by_id_read_only
+from qplot.datahandling.readonly import (
+    DatabaseInstanceChangedError,
+    load_by_guid_read_only,
+    load_by_id_read_only,
+)
 from qplot.diagnostics import log_exception
 
 from ._dataset_handle import (
@@ -17,6 +21,7 @@ from ._dataset_handle import (
     DatasetKey,
     canonical_database_path,
     close_dataset_connection,
+    database_file_identity,
 )
 from ._plot_refresh import plot_refresh_required
 from ._subplots.subplot1d import _subplot_axis_order
@@ -57,6 +62,97 @@ class PlotActionsMixin:
     """
 
     _selected_dataset_key: DatasetKey | None
+
+    @staticmethod
+    def _dataset_key_is_current(dataset_key):
+        expected_identity = dataset_key.database_identity
+        if expected_identity is None:
+            return True
+        return database_file_identity(dataset_key.database_path) == expected_identity
+
+
+    def _dataset_key_targets_loaded_database(self, dataset_key):
+        """Return whether a key names the database currently shown in the UI."""
+
+        file_textbox = getattr(self, "fileTextbox", None)
+        current_path = file_textbox.text() if file_textbox is not None else ""
+        return bool(
+            current_path
+            and canonical_database_path(current_path) == dataset_key.database_path
+        )
+
+
+    def _ensure_dataset_key_can_be_read(self, dataset_key):
+        """Reject a plot read until an atomically replaced source is reloaded."""
+
+        if self._dataset_key_targets_loaded_database(dataset_key):
+            reload_if_changed = getattr(
+                self,
+                "_reload_if_database_instance_changed",
+                None,
+            )
+            if callable(reload_if_changed) and reload_if_changed(
+                    dataset_key.database_path,
+                    ):
+                raise RuntimeError(
+                    "The database was replaced and is being reloaded before "
+                    "its dataset can be opened."
+                )
+
+        if not self._dataset_key_is_current(dataset_key):
+            raise RuntimeError(
+                "The database was replaced before its dataset could be loaded."
+            )
+
+
+    def _discard_dataset_handle(self, dataset_key, handle):
+        """Remove and close one handle that cannot represent its key safely."""
+        if self.dataset_holder.get(dataset_key) is handle:
+            self.dataset_holder.pop(dataset_key, None)
+        if handle.dataset is getattr(self, "ds", None):
+            self.ds = None
+            self._selected_dataset_key = None
+            self.selected_run_id = None
+        try:
+            handle.close()
+        except Exception as err:
+            log_exception("Stale plot dataset cleanup failed", err, __name__)
+
+
+    def _dataset_handle_for_key(self, dataset_key):
+        """Return only a handle opened for the key's current file instance."""
+        key_is_current = self._dataset_key_is_current(dataset_key)
+        if not key_is_current:
+            stale_handle = self.dataset_holder.get(dataset_key)
+            if stale_handle is not None:
+                self._discard_dataset_handle(dataset_key, stale_handle)
+            return None
+
+        for cached_key in list(self.dataset_holder):
+            if (
+                    cached_key != dataset_key
+                    and cached_key.database_path == dataset_key.database_path
+                    and cached_key.guid == dataset_key.guid
+                    ):
+                superseded = self.dataset_holder.get(cached_key)
+                if superseded is not None:
+                    self._discard_dataset_handle(cached_key, superseded)
+
+        handle = self.dataset_holder.get(dataset_key)
+        if handle is None:
+            return None
+        if (
+                handle.closed
+                or (
+                    handle.database_identity is not None
+                    and handle.database_identity != dataset_key.database_identity
+                )
+                ):
+            self._discard_dataset_handle(dataset_key, handle)
+            return None
+        if handle.database_identity is None:
+            handle.database_identity = dataset_key.database_identity
+        return handle
 
     def _dataset_is_held(self, dataset):
         return dataset is not None and any(
@@ -152,9 +248,59 @@ class PlotActionsMixin:
                 log_exception("Plot dataset cleanup failed", err, __name__)
 
 
+    def _detach_replaced_secondary_traces(self, database_path):
+        """Remove secondary lines whose source belongs to a replaced database.
+
+        A merged source can be closed and therefore absent from ``windows``
+        while its subplot still owns a dataset handle and keeps its monitor
+        alive. Retire those consumers before evicting the source handle so a
+        plot backed by another database cannot retain or refresh stale data.
+        """
+        canonical_path = canonical_database_path(database_path)
+        for host in list(getattr(self, "windows", [])):
+            host_key = getattr(host, "_dataset_key", None)
+            # Hosts from the replaced database are closed below, and their
+            # close event already detaches every secondary line.
+            if (
+                    host_key is not None
+                    and host_key.database_path == canonical_path
+                    ):
+                continue
+
+            lines = getattr(host, "lines", None)
+            remove_line = getattr(host, "remove_line", None)
+            if not isinstance(lines, dict) or not callable(remove_line):
+                continue
+
+            main_line = getattr(host, "line", None)
+            stale_traces = [
+                (trace_key, line)
+                for trace_key, line in list(lines.items())
+                if (
+                    line is not None
+                    and line is not main_line
+                    and getattr(getattr(line, "from_win", None), "_dataset_key", None)
+                    is not None
+                    and getattr(line.from_win._dataset_key, "database_path", None)
+                    == canonical_path
+                    )
+                ]
+            for trace_key, line in stale_traces:
+                source = line.from_win
+                try:
+                    remove_line(getattr(source, "label", ""), trace_key=trace_key)
+                except Exception as err:
+                    log_exception(
+                        "Replaced database secondary-trace cleanup failed",
+                        err,
+                        __name__,
+                    )
+
+
     def _invalidate_database_runtime_state(self, database_path):
         """Close datasets and plot windows backed by a replaced database."""
         canonical_path = canonical_database_path(database_path)
+        self._detach_replaced_secondary_traces(canonical_path)
         selected_key = getattr(self, "_selected_dataset_key", None)
         if (
                 selected_key is not None
@@ -178,6 +324,24 @@ class PlotActionsMixin:
         for dataset_key in list(self.dataset_holder):
             if dataset_key.database_path == canonical_path:
                 self._evict_dataset_handle(dataset_key)
+
+
+    def _handle_plot_database_replaced(self, database_path, source_window=None):
+        """Reload the current source, or retire a stale plot from another DB."""
+
+        current_path = self.fileTextbox.text()
+        if (
+                current_path
+                and canonical_database_path(current_path)
+                == canonical_database_path(database_path)
+                ):
+            return self._reload_replaced_database(database_path)
+
+        # qPlot may retain plots from a database that is no longer selected in
+        # MainWindow. A replacement there must not switch the main UI back to
+        # that path; discard only those stale runtime objects instead.
+        self._invalidate_database_runtime_state(database_path)
+        return False
 
     @QtCore.pyqtSlot(object)
     def onClose(self, win):
@@ -220,7 +384,8 @@ class PlotActionsMixin:
                 dataset_key = self._current_dataset_key(ds.guid)
 
         assert dataset_key is not None
-        shared_handle = self.dataset_holder.get(dataset_key)
+        self._ensure_dataset_key_can_be_read(dataset_key)
+        shared_handle = self._dataset_handle_for_key(dataset_key)
         loaded_for_construction = shared_handle is None and ds is None
         if shared_handle is not None:
             construction_ds = shared_handle.dataset
@@ -231,10 +396,17 @@ class PlotActionsMixin:
 
         assert construction_ds.guid == dataset_key.guid
         construction_holder = {
-            held_key: DatasetHandle(dataset=handle.dataset, users=handle.users)
+            held_key: DatasetHandle(
+                dataset=handle.dataset,
+                users=handle.users,
+                database_identity=handle.database_identity,
+            )
             for held_key, handle in self.dataset_holder.items()
         }
-        construction_holder[dataset_key] = DatasetHandle(dataset=construction_ds)
+        construction_holder[dataset_key] = DatasetHandle(
+            dataset=construction_ds,
+            database_identity=dataset_key.database_identity,
+        )
 
         try:
             win = widget(
@@ -267,6 +439,17 @@ class PlotActionsMixin:
         self.windows.append(win)
 
         win.closed.connect(self.onClose)
+        database_replaced = getattr(win, "database_replaced", None)
+        connect_replacement = getattr(database_replaced, "connect", None)
+        if callable(connect_replacement):
+            connect_replacement(
+                lambda database_path, source_window=win: (
+                    self._handle_plot_database_replaced(
+                        database_path,
+                        source_window,
+                    )
+                )
+            )
         win.make_ds.connect(self.add_ds_at)
         win.previewTraceDropRequested.connect(self.add_dropped_preview_to_plot)
         if window_type == "plot1d":
@@ -342,7 +525,7 @@ class PlotActionsMixin:
             if self.ds is not None and getattr(self, "_selected_dataset_key", None) == dataset_key:
                 pass
             else:
-                handle = self.dataset_holder.get(dataset_key)
+                handle = self._dataset_handle_for_key(dataset_key)
                 if handle is None:
                     dataset = self._load_dataset(dataset_key)
                 else:
@@ -593,8 +776,9 @@ class PlotActionsMixin:
 
         loaded_by_open_plot = False
         try:
+            self._ensure_dataset_key_can_be_read(dataset_key)
             if not self.ds or getattr(self, "_selected_dataset_key", None) != dataset_key:
-                handle = self.dataset_holder.get(dataset_key)
+                handle = self._dataset_handle_for_key(dataset_key)
                 if handle is None:
                     ds = self._load_dataset(dataset_key)
                     loaded_by_open_plot = True
@@ -755,7 +939,7 @@ class PlotActionsMixin:
         dataset_key = self._current_dataset_key(guid)
         if not self.ds or getattr(self, "_selected_dataset_key", None) != dataset_key:
             try:
-                handle = self.dataset_holder.get(dataset_key)
+                handle = self._dataset_handle_for_key(dataset_key)
                 if handle is None:
                     dataset = self._load_dataset(dataset_key)
                 else:
@@ -882,7 +1066,7 @@ class PlotActionsMixin:
 
 
     def _dataset_for_key(self, dataset_key):
-        handle = self.dataset_holder.get(dataset_key)
+        handle = self._dataset_handle_for_key(dataset_key)
         if handle is not None:
             return handle.dataset
         return self._load_dataset(dataset_key)
@@ -957,8 +1141,36 @@ class PlotActionsMixin:
             self.show_status("Enter a Run ID before plotting or exporting.", 5000)
             return None
 
+        reload_if_changed = getattr(
+            self,
+            "_reload_if_database_instance_changed",
+            None,
+        )
+        if callable(reload_if_changed) and reload_if_changed(self.fileTextbox.text()):
+            self.show_status(
+                "Database was replaced; reloading before opening the run.",
+                5000,
+            )
+            return None
+
+        expected_identity = getattr(self, "_loaded_database_identity", None)
+        load_kwargs = {}
+        if expected_identity is not None:
+            load_kwargs["expected_database_identity"] = expected_identity
         try:
-            return load_by_id_read_only(self.selected_run_id)
+            return load_by_id_read_only(
+                self.selected_run_id,
+                self.fileTextbox.text(),
+                **load_kwargs,
+            )
+        except DatabaseInstanceChangedError:
+            if callable(reload_if_changed):
+                reload_if_changed(self.fileTextbox.text())
+            self.show_status(
+                "Database was replaced; reloading before opening the run.",
+                5000,
+            )
+            return None
         except Exception as error:
             log_exception("Run ID load failed", error, __name__)
             self.show_error(
@@ -1012,12 +1224,24 @@ class PlotActionsMixin:
         Tracks a dataset used by one or more plot windows.
 
         """
-        handle = self.dataset_holder.get(dataset_key)
+        self._ensure_dataset_key_can_be_read(dataset_key)
+        handle = self._dataset_handle_for_key(dataset_key)
         if handle is None:
             ds = self._load_dataset(dataset_key) if ds is None else ds
             assert ds.guid == dataset_key.guid
 
-            self.dataset_holder[dataset_key] = DatasetHandle(dataset=ds)
+            if not self._dataset_key_is_current(dataset_key):
+                self._close_dataset_if_unowned(
+                    ds,
+                    context="Replaced database dataset cleanup failed",
+                )
+                raise RuntimeError(
+                    "The database was replaced while its dataset was being acquired."
+                )
+            self.dataset_holder[dataset_key] = DatasetHandle(
+                dataset=ds,
+                database_identity=dataset_key.database_identity,
+            )
         else:
             handle.retain()
 
@@ -1055,9 +1279,34 @@ class PlotActionsMixin:
         return DatasetKey(self.fileTextbox.text(), guid)
 
 
-    @staticmethod
-    def _load_dataset(dataset_key: DatasetKey):
-        return load_by_guid_read_only(dataset_key.guid, dataset_key.database_path)
+    def _load_dataset(self, dataset_key: DatasetKey):
+        self._ensure_dataset_key_can_be_read(dataset_key)
+
+        try:
+            load_kwargs = {}
+            if dataset_key.database_identity is not None:
+                load_kwargs["expected_database_identity"] = (
+                    dataset_key.database_identity
+                )
+            dataset = load_by_guid_read_only(
+                dataset_key.guid,
+                dataset_key.database_path,
+                **load_kwargs,
+            )
+        except Exception:
+            # A replacement can race the check above. The read layer rejects
+            # that identity change without consuming its sidecar; this second
+            # check starts MainWindow's replacement reload when applicable.
+            self._ensure_dataset_key_can_be_read(dataset_key)
+            raise
+        try:
+            self._ensure_dataset_key_can_be_read(dataset_key)
+        except Exception:
+            try:
+                close_dataset_connection(dataset)
+            finally:
+                raise
+        return dataset
 
 
     def post_admin(self):

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -809,7 +809,12 @@ class PlotActionsMixin:
         Opens plot windows for the selected or requested run.
 
         """
-        if not self.ds and not guid:
+        # ``DataSet`` implements truthiness through ``__len__``, which queries
+        # its SQLite connection.  A Windows replacement test (and a real
+        # replacement race) may have deliberately released that old read-only
+        # connection before this requested DatasetKey is invalidated.  Presence
+        # of a selected dataset is the relevant check here, not its row count.
+        if self.ds is None and not guid:
             self.show_status("Select a run before opening plots.", 5000)
             return
 
@@ -825,7 +830,10 @@ class PlotActionsMixin:
         loaded_by_open_plot = False
         try:
             self._ensure_dataset_key_can_be_read(dataset_key)
-            if not self.ds or getattr(self, "_selected_dataset_key", None) != dataset_key:
+            if (
+                self.ds is None
+                or getattr(self, "_selected_dataset_key", None) != dataset_key
+            ):
                 handle = self._dataset_handle_for_key(dataset_key)
                 if handle is None:
                     ds = self._load_dataset(dataset_key)

--- a/src/qplot/windows/_plot_actions.py
+++ b/src/qplot/windows/_plot_actions.py
@@ -18,6 +18,7 @@ from ._dataset_handle import (
     canonical_database_path,
     close_dataset_connection,
 )
+from ._plot_refresh import plot_refresh_required
 from ._subplots.subplot1d import _subplot_axis_order
 from .plot1d import plot1d
 from .plot2d import plot2d
@@ -906,7 +907,7 @@ class PlotActionsMixin:
                 continue
             try:
                 if win._dataset_key == source_key and win.param.name == param.name:
-                    if win.ds.running:
+                    if plot_refresh_required(win):
                         target_win.toolbarRef.show()
                     return win
             except AttributeError:

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -1,10 +1,14 @@
+import os
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
-from qplot.datahandling.file_identity import database_file_identity
+from qplot.datahandling.file_identity import (
+    canonical_database_path,
+    database_file_identity,
+)
 from qplot.datahandling.qcodes_cache import (
     cache_has_no_written_data,
     cache_is_live,
@@ -105,9 +109,26 @@ class PlotRefreshMixin(_PlotRefreshBase):
         dataset_key = self.__dict__.get("_dataset_key")
         expected_identity = getattr(dataset_key, "database_identity", None)
         database_path = getattr(dataset_key, "database_path", None)
-        if expected_identity is None or not database_path:
+        expected_resolved_path = getattr(
+            dataset_key,
+            "resolved_database_path",
+            None,
+        )
+        if not database_path:
             return True
-        if database_file_identity(database_path) == expected_identity:
+        current_resolved_path = canonical_database_path(database_path)
+        current_identity = database_file_identity(database_path)
+        if (
+                expected_identity is None
+                and current_identity is None
+                and not os.path.isfile(database_path)
+                ):
+            return True
+        if (
+                expected_identity is not None
+                and current_identity == expected_identity
+                and current_resolved_path == expected_resolved_path
+                ):
             return True
 
         quarantine_wal_for_replaced_database(database_path)

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
+from qplot.datahandling.file_identity import database_file_identity
 from qplot.datahandling.qcodes_cache import (
     cache_has_no_written_data,
     cache_is_live,
@@ -12,6 +13,7 @@ from qplot.datahandling.qcodes_cache import (
     set_cache_parameter_synchronized,
     update_cache_parameter_data,
 )
+from qplot.datahandling.readonly import quarantine_wal_for_replaced_database
 from qplot.diagnostics import log_exception
 from qplot.tools import loader
 from qplot.tools.operation_registry import OperationValidationError
@@ -95,6 +97,39 @@ class PlotRefreshMixin(_PlotRefreshBase):
 
         handle = dataset_holder.get(dataset_key)
         return handle is not None and getattr(handle, "users", 0) > 0
+
+
+    def _source_database_is_current(self) -> bool:
+        """Stop this plot before a replaced main file can be read as its source."""
+
+        dataset_key = self.__dict__.get("_dataset_key")
+        expected_identity = getattr(dataset_key, "database_identity", None)
+        database_path = getattr(dataset_key, "database_path", None)
+        if expected_identity is None or not database_path:
+            return True
+        if database_file_identity(database_path) == expected_identity:
+            return True
+
+        quarantine_wal_for_replaced_database(database_path)
+        worker = self.__dict__.get("worker")
+        if worker is not None and getattr(worker, "running", False):
+            cancel = getattr(worker, "cancel", None)
+            if callable(cancel):
+                cancel()
+        monitor = self.__dict__.get("monitor")
+        if monitor is not None:
+            monitor.stop()
+        self.show_status("Database was replaced; reloading source data.", 5000)
+        self.show_plot_state(
+            "Database replaced",
+            "qPlot is reloading the replacement before this plot can refresh.",
+            kind="info",
+        )
+        replacement_signal = getattr(self, "database_replaced", None)
+        emit = getattr(replacement_signal, "emit", None)
+        if callable(emit):
+            emit(str(database_path))
+        return False
 
     def _refresh_monitor_required(self, dataset: Any | None = None) -> bool:
         """Keep polling until this plot has committed its terminal display."""
@@ -205,6 +240,8 @@ class PlotRefreshMixin(_PlotRefreshBase):
         """
         if not self._can_process_refresh():
             return False
+        if not self._source_database_is_current():
+            return False
 
         try:
             operations = self.oper_widget.get_data()
@@ -218,19 +255,30 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 )
             return False
 
+        loader_kwargs = {
+            "read_data": True,
+            "operations": operations,
+            "force_sql_heatmap": force_sql_heatmap,
+            "max_full_heatmap_points": self.config.get(
+                "runtime_settings.max_full_heatmap_points"
+                ),
+            "heatmap_axis_ranges": heatmap_axis_ranges,
+            "heatmap_full_axis_ranges": heatmap_full_axis_ranges,
+        }
+        database_identity = getattr(
+            getattr(self, "_dataset_key", None),
+            "database_identity",
+            None,
+        )
+        if database_identity is not None:
+            loader_kwargs["database_identity"] = database_identity
+
         worker: Any = loader(
             self.ds.cache,
             self.param,
             self.param_dict,
             self.axis_options,
-            read_data=True,
-            operations=operations,
-            force_sql_heatmap=force_sql_heatmap,
-            max_full_heatmap_points=self.config.get(
-                "runtime_settings.max_full_heatmap_points"
-                ),
-            heatmap_axis_ranges=heatmap_axis_ranges,
-            heatmap_full_axis_ranges=heatmap_full_axis_ranges,
+            **loader_kwargs,
             )
         worker.dataset_length_at_start = self.ds.number_of_results
 
@@ -300,6 +348,8 @@ class PlotRefreshMixin(_PlotRefreshBase):
         """
         self.monitor.stop()
         if not self._can_process_refresh():
+            return
+        if not self._source_database_is_current():
             return
 
         retry = False
@@ -440,6 +490,13 @@ class PlotRefreshMixin(_PlotRefreshBase):
             )
 
         if not self._can_process_refresh():
+            worker.running = False
+            self.end_wait.emit()
+            return False
+        if not self._source_database_is_current():
+            # A worker can finish from a private snapshot after the source main
+            # file was atomically replaced.  Do not let that stale result reach
+            # the shared cache or the concrete display callback.
             worker.running = False
             self.end_wait.emit()
             return False
@@ -601,6 +658,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
             return
 
         if worker is not None and worker is not self.worker:
+            return
+
+        if worker is not None and getattr(worker, "database_replaced", False):
+            self._source_database_is_current()
             return
 
         message = f"{type(err).__name__}: {err}"

--- a/src/qplot/windows/_plot_refresh.py
+++ b/src/qplot/windows/_plot_refresh.py
@@ -5,10 +5,11 @@ from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
 from qplot.datahandling.qcodes_cache import (
-    cache_dataset_completed,
     cache_has_no_written_data,
+    cache_is_live,
+    cache_parameter_is_synchronized,
     set_cache_dataset_completed,
-    set_parameter_complete,
+    set_cache_parameter_synchronized,
     update_cache_parameter_data,
 )
 from qplot.diagnostics import log_exception
@@ -61,6 +62,17 @@ else:
         pass
 
 
+def plot_refresh_required(source: Any) -> bool:
+    """Return whether a source plot still needs live/final refresh work."""
+
+    predicate = getattr(source, "_refresh_monitor_required", None)
+    if callable(predicate):
+        return bool(predicate())
+
+    dataset = getattr(source, "ds", None)
+    return bool(getattr(dataset, "running", False))
+
+
 class PlotRefreshMixin(_PlotRefreshBase):
     """
     Worker-backed plot refresh orchestration shared by plot windows.
@@ -84,18 +96,89 @@ class PlotRefreshMixin(_PlotRefreshBase):
         handle = dataset_holder.get(dataset_key)
         return handle is not None and getattr(handle, "users", 0) > 0
 
-    def _sync_dataset_completion(self, dataset: Any) -> None:
-        """Schedule a final worker read so completion and data commit together."""
+    def _refresh_monitor_required(self, dataset: Any | None = None) -> bool:
+        """Keep polling until this plot has committed its terminal display."""
 
-        if not getattr(dataset, "running", False):
+        if dataset is None:
+            dataset = self.ds
+        if getattr(dataset, "running", False):
+            return True
+
+        state = self.__dict__
+        if not state.get("_qplot_display_synchronized", True):
+            return True
+
+        # A direct-SQL heatmap deliberately bypasses the QCoDeS cache. Its
+        # successful display commit is therefore the terminal per-plot state.
+        if state.get("_qplot_display_uses_direct_sql", False):
+            return False
+
+        cache = getattr(dataset, "cache", None)
+        param = state.get("param")
+        if cache is None or param is None:
+            return False
+        return not cache_parameter_is_synchronized(cache, param.name)
+
+    def _sync_dataset_completion(self, dataset: Any) -> None:
+        """Schedule this plot's outstanding final worker read."""
+
+        if not self._refresh_monitor_required(dataset):
             return
 
         worker = getattr(self, "worker", None)
         if worker is not None and getattr(worker, "running", False):
-            self._refresh_pending = True
+            self._queue_pending_refresh()
             return
 
         self.load_data()
+
+    def _ensure_refresh_monitor(self) -> None:
+        """Restart polling when a terminal worker/display remains pending."""
+
+        if not self._can_process_refresh():
+            return
+        try:
+            dataset = self.ds
+        except (AttributeError, KeyError, RuntimeError):
+            return
+        if not self._refresh_monitor_required(dataset):
+            return
+
+        state = self.__dict__
+        monitor = state.get("monitor")
+        spin_box = state.get("spinBox")
+        if monitor is None or spin_box is None:
+            return
+        is_active = getattr(monitor, "isActive", None)
+        if callable(is_active) and is_active():
+            return
+        self.monitorIntervalChanged(spin_box.value())
+
+    def _mark_display_synchronized(self, worker: Any) -> bool:
+        """Publish terminal plot state after the concrete display commit."""
+
+        if worker is None or worker is not self.__dict__.get("worker"):
+            return False
+        if getattr(worker, "is_cancelled", lambda: False)():
+            return False
+        if not getattr(worker, "_qplot_display_commit_ready", False):
+            return False
+        if getattr(worker, "dataset_completed", None) is not True:
+            return False
+
+        loaded_from_sql = bool(
+            getattr(worker, "loaded_from_sql_heatmap", False)
+            )
+        if not loaded_from_sql and not cache_parameter_is_synchronized(
+                self.ds.cache,
+                self.param.name,
+                ):
+            return False
+
+        self._qplot_display_synchronized = True
+        self._qplot_display_uses_direct_sql = loaded_from_sql
+        worker._qplot_display_commit_ready = False
+        return True
 
     def load_data(
             self,
@@ -186,6 +269,11 @@ class PlotRefreshMixin(_PlotRefreshBase):
             hold_up = QtCore.QEventLoop()
             self.end_wait.connect(hold_up.quit)  # Release main thread event
 
+        if not getattr(self.ds, "running", False):
+            # A terminal reload supersedes the previous displayed snapshot.
+            # Keep it retryable until this worker's concrete display commit.
+            self._qplot_display_synchronized = False
+
         # Run worker
         self.worker = worker
         self.threadPool.start(worker)
@@ -230,7 +318,7 @@ class PlotRefreshMixin(_PlotRefreshBase):
             # Check if new data has been added to the dataset
             if current_ds_len != self.last_ds_len or force:
                 if self.worker.running:  # No need to run if already updating
-                    self._refresh_pending = True
+                    self._queue_pending_refresh(force=force)
                     if force:
                         self.show_status("Refresh queued after the current load.", 3000)
                     return
@@ -238,10 +326,9 @@ class PlotRefreshMixin(_PlotRefreshBase):
                 # The actual refresh line
                 self.load_data()
 
-            elif dataset.running:
-                # Completion is a runs-table update and need not add a final
-                # result row. Keep QCoDeS' cached ``running`` flag in sync even
-                # when there is no plot data to reload.
+            elif self._refresh_monitor_required(dataset):
+                # Source completion is global, but this parameter/cache/display
+                # may still need its own successful terminal refresh.
                 self._sync_dataset_completion(dataset)
 
         except Exception:
@@ -251,7 +338,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
         finally:  # Ran after return or otherwise
 
             # restart monitor
-            if retry or (dataset is not None and dataset.running):
+            if retry or (
+                    dataset is not None
+                    and self._refresh_monitor_required(dataset)
+                    ):
                 self.monitorIntervalChanged(self.spinBox.value())
 
             # restard monitor if any subplots are live
@@ -263,11 +353,10 @@ class PlotRefreshMixin(_PlotRefreshBase):
                         if subplot is main_line:
                             continue
                         source = getattr(subplot, "from_win", None)
-                        source_dataset = getattr(source, "ds", None)
-                        running = getattr(
-                            source_dataset,
-                            "running",
-                            getattr(subplot, "running", False),
+                        running = (
+                            plot_refresh_required(source)
+                            if source is not None
+                            else bool(getattr(subplot, "running", False))
                             )
                         subplot.running = bool(running)
                         if running:
@@ -286,19 +375,35 @@ class PlotRefreshMixin(_PlotRefreshBase):
         QtCore.QTimer.singleShot(0, self._run_pending_refresh)
 
 
+    def _queue_pending_refresh(self, *, force: bool = False) -> None:
+        """Coalesce refreshes while retaining explicit-force provenance."""
+
+        state = self.__dict__
+        if not state.get("_refresh_pending", False):
+            self._refresh_pending_force = False
+        self._refresh_pending = True
+        if force:
+            self._refresh_pending_force = True
+
+
     def _run_pending_refresh(self) -> None:
         self._refresh_pending_scheduled = False
         if not self.__dict__.get("_refresh_pending", False):
             return
         if not self._can_process_refresh():
             self._refresh_pending = False
+            self._refresh_pending_force = False
             return
         if getattr(getattr(self, "worker", None), "running", False):
             self._schedule_pending_refresh()
             return
 
+        force = bool(self.__dict__.get("_refresh_pending_force", False))
         self._refresh_pending = False
-        self.refreshWindow(force=True)
+        self._refresh_pending_force = False
+        if not force and not self._refresh_monitor_required():
+            return
+        self.refreshWindow(force=force)
 
 
     @QtCore.pyqtSlot(bool)
@@ -340,6 +445,7 @@ class PlotRefreshMixin(_PlotRefreshBase):
             return False
 
         try:
+            worker._qplot_display_commit_ready = False
             if was_cancelled:
                 worker.running = False
                 return False
@@ -371,18 +477,27 @@ class PlotRefreshMixin(_PlotRefreshBase):
                         ),
                     )
                 if not cache_updated:
-                    self._refresh_pending = True
+                    self._queue_pending_refresh()
                     self.show_status(
                         "A newer refresh finished first; synchronising this plot...",
                         5000,
                         )
                     return False
 
-                if cache_dataset_completed(cache):
-                    set_parameter_complete(self.param, True)
-
                 if not cache_has_no_written_data(cache):
                     self._live = False
+
+            if (
+                    getattr(worker, "dataset_completed", None) is True
+                    and cache_is_live(self.ds.cache)
+                    ):
+                # An in-memory live cache is already authoritative; no database
+                # cache commit is needed before its terminal display refresh.
+                set_cache_parameter_synchronized(
+                    self.ds.cache,
+                    self.param.name,
+                    True,
+                    )
 
             # set data to be called by plot<1/2>d.refreshPlot()
             self.axis_data = {
@@ -438,10 +553,21 @@ class PlotRefreshMixin(_PlotRefreshBase):
             if (
                     getattr(worker, "loaded_from_sql_heatmap", False)
                     and getattr(worker, "dataset_completed", None) is True
-                    ):
+                ):
                 # Direct SQL heatmaps intentionally bypass the QCoDeS cache.
-                # Publish completion only after their final plot data commits.
+                # Publish the global source observation here; the concrete
+                # heatmap publishes its per-plot state only after rendering.
                 set_cache_dataset_completed(self.ds.cache, True)
+            worker._qplot_display_commit_ready = bool(
+                getattr(worker, "dataset_completed", None) is True
+                and (
+                    getattr(worker, "loaded_from_sql_heatmap", False)
+                    or cache_parameter_is_synchronized(
+                        self.ds.cache,
+                        self.param.name,
+                        )
+                    )
+                )
             return True
 
         except AttributeError as err:
@@ -455,6 +581,8 @@ class PlotRefreshMixin(_PlotRefreshBase):
             if worker is self.worker:
                 worker.running = False
                 self.end_wait.emit()
+                if not getattr(worker, "_qplot_display_commit_ready", False):
+                    self._ensure_refresh_monitor()
                 self._schedule_pending_refresh()
 
 

--- a/src/qplot/windows/_subplots/subplot1d.py
+++ b/src/qplot/windows/_subplots/subplot1d.py
@@ -2,6 +2,8 @@ import pyqtgraph as pg
 from PyQt6 import QtCore
 from PyQt6.QtGui import QColor
 
+from .._plot_refresh import plot_refresh_required
+
 
 def _subplot_axis_order(
         parent_options: dict[str, str],
@@ -30,7 +32,7 @@ class subplot1d(pg.PlotDataItem):
         
         self.label = from_win.label
         self.param_dict = from_win.param_dict
-        self.running = from_win.ds.running
+        self.running = plot_refresh_required(from_win)
         
         self.parent = parent
         self.from_win = from_win
@@ -70,7 +72,7 @@ class subplot1d(pg.PlotDataItem):
         self._disconnect_pending_update()
 
         # Update live state
-        self.running = from_win.ds.running
+        self.running = plot_refresh_required(from_win)
         
         # Get which data is on which axis
         parent_options = parent.axis_options
@@ -146,7 +148,7 @@ class subplot1d(pg.PlotDataItem):
 
         if (
                 getattr(source, "_closed", False)
-                and getattr(source.ds, "running", False)
+                and plot_refresh_required(source)
                 and not source.monitor.isActive()
                 ):
             source.monitorIntervalChanged(source.spinBox.value())

--- a/src/qplot/windows/_subplots/subplot2d.py
+++ b/src/qplot/windows/_subplots/subplot2d.py
@@ -180,6 +180,7 @@ class sweeper(plotWidget):
                     kind="empty",
                     )
                 self.trace_updated.emit()
+                self._mark_display_synchronized(plot_worker)
                 return
 
             row_count = min(fixed_data.size, data_grid.shape[0])
@@ -208,8 +209,10 @@ class sweeper(plotWidget):
 
             else:
                 self.update_sweep()
+            self._mark_display_synchronized(plot_worker)
         finally:
             plot_worker.running = False
+            self._ensure_refresh_monitor()
         
         
     @property

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -161,6 +161,7 @@ class MainWindow(
         self._database_refresh_active = False
         self._database_refresh_pending = False
         self._database_refresh_worker: DatabaseRefreshWorker | None = None
+        self._database_refresh_identity = None
         self._test_database_generation_active = False
         self._test_database_generation_worker: TestDatabaseGenerationWorker | None = None
         self._shutdown_started = False
@@ -523,6 +524,7 @@ class MainWindow(
         self._database_refresh_active = False
         self._database_refresh_pending = False
         self._database_refresh_worker = None
+        self._database_refresh_identity = None
         self._test_database_generation_active = False
         self._test_database_generation_worker = None
         self.monitor.stop()

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -151,6 +151,7 @@ class MainWindow(
         self._database_load_state = None
         self._database_load_worker = None
         self._loaded_database_identity = None
+        self._loaded_database_instance = None
         self._database_detail_generation = 0
         self._database_detail_active = False
         self._database_detail_worker = None
@@ -162,6 +163,7 @@ class MainWindow(
         self._database_refresh_pending = False
         self._database_refresh_worker: DatabaseRefreshWorker | None = None
         self._database_refresh_identity = None
+        self._database_refresh_instance = None
         self._test_database_generation_active = False
         self._test_database_generation_worker: TestDatabaseGenerationWorker | None = None
         self._shutdown_started = False

--- a/src/qplot/windows/plot1d.py
+++ b/src/qplot/windows/plot1d.py
@@ -193,6 +193,7 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
                     kind="empty",
                     )
                 self.trace_updated.emit()
+                self._mark_display_synchronized(plot_worker)
                 return
 
             # Main line
@@ -205,8 +206,10 @@ class plot1d(Plot1DSnapMixin, Plot1DTraceMixin, plotWidget):
 
             self.trace_updated.emit()
             self.refresh_secondary_lines()
+            self._mark_display_synchronized(plot_worker)
         finally:
             plot_worker.running = False
+            self._ensure_refresh_monitor()
 
 
     def _has_plottable_line_data(self) -> bool:

--- a/src/qplot/windows/plot2d.py
+++ b/src/qplot/windows/plot2d.py
@@ -211,6 +211,7 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                     f"{self.param.name} has no finite heatmap data yet.",
                     kind="empty",
                     )
+                self._mark_display_synchronized(plot_worker)
                 return
 
             try:
@@ -252,9 +253,11 @@ class plot2d(Plot2DSweepMixin, Plot2DColorbarMixin, plotWidget):
                 self._set_colorbar_levels(*self._colorbar_manual_levels)
             
             self._restore_heatmap_interactions()
+            self._mark_display_synchronized(plot_worker)
         finally:
             # Allow new workers after empty live loads or display errors.
             plot_worker.running = False
+            self._ensure_refresh_monitor()
             if full_sql_refresh:
                 self._schedule_visible_heatmap_reload()
 

--- a/tests/datahandling/test_qcodes_cache.py
+++ b/tests/datahandling/test_qcodes_cache.py
@@ -9,10 +9,12 @@ from qplot.datahandling.qcodes_cache import (
     cache_has_no_written_data,
     cache_is_live,
     cache_parameter_data,
+    cache_parameter_is_synchronized,
     cache_table_name,
     parameter_is_complete,
     prepare_cache_if_empty,
     set_cache_dataset_completed,
+    set_cache_parameter_synchronized,
     set_parameter_complete,
     snapshot_cache_parameter_state,
     update_cache_parameter_data,
@@ -47,6 +49,7 @@ class Cache:
 
 class Param:
     def __init__(self):
+        self.name = "signal"
         self._complete = False
 
 
@@ -139,6 +142,7 @@ def test_cache_update_publishes_completion_after_parameter_state():
 
     assert committed
     assert cache_dataset_completed(cache)
+    assert cache_parameter_is_synchronized(cache, "signal")
     assert cache._data["signal"] == {"signal": [3, 4]}
 
 
@@ -178,6 +182,7 @@ def test_cache_update_rejects_result_older_than_current_parameter_state():
     assert cache._write_status["signal"] == 8
     assert cache._data["signal"] == {"signal": [1, 2]}
     assert not cache_dataset_completed(cache)
+    assert not cache_parameter_is_synchronized(cache, "signal")
 
 
 def test_cache_update_accepts_newer_read_with_reset_unshaped_write_status():
@@ -261,13 +266,14 @@ def test_load_param_data_from_db_prep_defers_parameter_completion_until_commit(m
     assert dataset_completed is True
     assert not cache._dataset.completed
     assert not param._complete
+    assert not cache_parameter_is_synchronized(cache, "signal")
     assert cache.prepare_called
 
 
 def test_load_param_data_from_db_prep_skips_completed_param(monkeypatch):
     cache = Cache()
     param = Param()
-    param._complete = True
+    set_cache_parameter_synchronized(cache, "signal", True)
 
     def fail_if_called(conn, run_id):
         raise AssertionError("completed should not be queried for completed params")
@@ -276,6 +282,23 @@ def test_load_param_data_from_db_prep_skips_completed_param(monkeypatch):
 
     assert load_from_db.load_param_data_from_db_prep(cache, param) == (True, False)
     assert not cache.prepare_called
+
+
+def test_parameter_synchronization_is_shared_across_reconstructed_params(monkeypatch):
+    cache = Cache()
+    first_param = Param()
+    reconstructed_param = Param()
+    set_cache_parameter_synchronized(cache, first_param.name, True)
+
+    def fail_if_called(conn, run_id):
+        raise AssertionError("completed should not be queried after cache sync")
+
+    monkeypatch.setattr(load_from_db, "completed", fail_if_called)
+
+    assert load_from_db.load_param_data_from_db_prep(
+        cache,
+        reconstructed_param,
+        ) == (True, False)
 
 
 def test_load_param_data_from_db_prep_rejects_live_cache():

--- a/tests/datahandling/test_readonly.py
+++ b/tests/datahandling/test_readonly.py
@@ -409,6 +409,12 @@ def test_replaced_main_quarantines_unpaired_wal_without_source_changes(tmp_path)
         writer.commit()
         assert database_file_identity(f"{database_path}-wal") is not None
         assert Path(f"{database_path}-shm").is_file()
+        shutil.copyfile(f"{database_path}-wal", parked_wal_path)
+        # Windows cannot rename a WAL while SQLite has it open. Preserve a
+        # byte-for-byte old sidecar, then close the unrelated writer before
+        # simulating the external replacement.
+        writer.close()
+        writer = None
 
         generate_database(
             [
@@ -435,7 +441,6 @@ def test_replaced_main_quarantines_unpaired_wal_without_source_changes(tmp_path)
         # The old writer can temporarily remove its sidecar before the main
         # file is replaced, then recreate it later. Register the replacement
         # epoch while no WAL exists and restore that proven-old WAL afterwards.
-        os.replace(f"{database_path}-wal", parked_wal_path)
         os.replace(replacement_path, database_path)
         assert quarantine_wal_for_replaced_database(database_path)
         assert replacement_wal_is_quarantined(database_path)
@@ -450,7 +455,7 @@ def test_replaced_main_quarantines_unpaired_wal_without_source_changes(tmp_path)
             conn.close()
         assert _directory_state(tmp_path) == absent_wal_state
 
-        os.replace(parked_wal_path, f"{database_path}-wal")
+        shutil.copyfile(parked_wal_path, f"{database_path}-wal")
         source_state = _directory_state(tmp_path)
         for opener in (
                 sqlite_read_only_connection,
@@ -465,17 +470,9 @@ def test_replaced_main_quarantines_unpaired_wal_without_source_changes(tmp_path)
         assert database_access_error(database_path) is None
         assert _directory_state(tmp_path) == source_state
 
-        # A single missing-WAL observation must not expire the replacement
-        # epoch: the old writer can put the same sidecar back afterwards.
-        os.replace(f"{database_path}-wal", parked_wal_path)
+        # The missing-WAL observation immediately before restoration above
+        # must not expire the replacement epoch.
         assert replacement_wal_is_quarantined(database_path)
-        conn = sqlite_read_only_connection(database_path)
-        try:
-            assert conn.execute("SELECT guid, result_counter FROM runs").fetchone() == expected_run
-        finally:
-            conn.close()
-        os.replace(parked_wal_path, f"{database_path}-wal")
-        source_state = _directory_state(tmp_path)
 
         generate_database(
             [
@@ -558,9 +555,13 @@ def test_expected_identity_rejects_replacement_during_read_preparation(
         replaced = False
 
         def replace_after_initial_identity_check(path, expected_identity):
-            nonlocal replaced, replaced_state
+            nonlocal replaced, replaced_state, writer
             result = real_require(path, expected_identity)
             if not replaced and expected_identity is not None:
+                # The identity race itself does not depend on keeping the old
+                # writer open. Close it so Windows permits the atomic swap.
+                writer.close()
+                writer = None
                 os.replace(replacement_path, database_path)
                 replaced_state = _directory_state(tmp_path)
                 replaced = True
@@ -583,7 +584,8 @@ def test_expected_identity_rejects_replacement_during_read_preparation(
     finally:
         if replacement_writer is not None:
             replacement_writer.close()
-        writer.close()
+        if writer is not None:
+            writer.close()
 
 
 def test_database_access_probe_rejects_replacement_before_child_open(

--- a/tests/datahandling/test_readonly.py
+++ b/tests/datahandling/test_readonly.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import qcodes
@@ -16,6 +17,7 @@ from qcodes.dataset.sqlite.connection import AtomicConnection
 from qcodes.parameters import ManualParameter
 
 from qplot._repair import repair
+from qplot.datahandling import file_identity as file_identity_module
 from qplot.datahandling.database import database_access_error, database_info_rows
 from qplot.datahandling.file_identity import database_file_identity
 from qplot.datahandling.readonly import (
@@ -31,6 +33,44 @@ from qplot.datahandling.readonly import (
 )
 from qplot.datahandling.readSQL import get_runs_via_sql
 from qplot.testdata import RunSpecification, generate_database
+
+
+def test_windows_file_index_is_used_when_stat_inode_is_zero(monkeypatch):
+    stat_result = SimpleNamespace(st_ino=0, st_dev=9)
+    windows_identity = ("windows-file-id", 17, 23)
+    monkeypatch.setattr(
+        file_identity_module,
+        "canonical_database_path",
+        lambda _path: "C:/data/view.db",
+    )
+    monkeypatch.setattr(file_identity_module.os, "stat", lambda _path: stat_result)
+    monkeypatch.setattr(file_identity_module.os, "name", "nt")
+    monkeypatch.setattr(
+        file_identity_module,
+        "_windows_file_identity",
+        lambda _path: windows_identity,
+    )
+
+    assert file_identity_module.database_file_identity("view.db") == windows_identity
+
+
+def test_unavailable_identity_does_not_fall_back_to_mutable_metadata(monkeypatch):
+    stat_result = SimpleNamespace(
+        st_ino=0,
+        st_dev=9,
+        st_size=100,
+        st_mtime_ns=200,
+        st_ctime_ns=300,
+    )
+    monkeypatch.setattr(
+        file_identity_module,
+        "canonical_database_path",
+        lambda _path: "/data/view.db",
+    )
+    monkeypatch.setattr(file_identity_module.os, "stat", lambda _path: stat_result)
+    monkeypatch.setattr(file_identity_module.os, "name", "posix")
+
+    assert file_identity_module.database_file_identity("view.db") is None
 
 
 def _directory_state(directory):

--- a/tests/datahandling/test_readonly.py
+++ b/tests/datahandling/test_readonly.py
@@ -1,5 +1,7 @@
 import hashlib
+import json
 import os
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -15,15 +17,20 @@ from qcodes.parameters import ManualParameter
 
 from qplot._repair import repair
 from qplot.datahandling.database import database_access_error, database_info_rows
+from qplot.datahandling.file_identity import database_file_identity
 from qplot.datahandling.readonly import (
+    DatabaseInstanceChangedError,
     ReadOnlyDatabaseAccessError,
     load_by_guid_read_only,
     load_by_id_read_only,
     qcodes_read_only_connection,
+    quarantine_wal_for_replaced_database,
+    replacement_wal_is_quarantined,
     set_qcodes_database_location,
     sqlite_read_only_connection,
 )
 from qplot.datahandling.readSQL import get_runs_via_sql
+from qplot.testdata import RunSpecification, generate_database
 
 
 def _directory_state(directory):
@@ -357,6 +364,289 @@ def test_live_wal_refreshes_see_new_rows_without_source_changes(tmp_path):
         experiment.conn.close()
     finally:
         qcodes.config.core.db_location = original_database_path
+
+
+def test_replaced_main_quarantines_unpaired_wal_without_source_changes(tmp_path):
+    """An unknown WAL must never be paired with an atomically replaced main."""
+
+    database_path = tmp_path / "replace-live.db"
+    replacement_path = tmp_path / "replacement.db"
+    second_replacement_path = tmp_path / "second-replacement.db"
+    parked_wal_path = tmp_path / "parked-old-wal"
+    original_database_path = qcodes.config.core.db_location
+    old_dataset = None
+    experiment = None
+    writer = None
+    try:
+        # qPlot can legitimately have loaded this checkpointed instance before
+        # an external process changes it to WAL mode. No prior WAL identity is
+        # available when the later atomic replacement happens.
+        initialise_or_create_database_at(str(database_path), journal_mode="DELETE")
+        experiment = load_or_create_experiment(
+            "stale_wal",
+            sample_name="replacement",
+        )
+        setpoint = ManualParameter("stale_wal_setpoint")
+        signal = ManualParameter("stale_wal_signal")
+        measurement = Measurement(exp=experiment, name="old_live_run")
+        measurement.register_parameter(setpoint)
+        measurement.register_parameter(signal, setpoints=(setpoint,))
+
+        with measurement.run(write_in_background=False) as datasaver:
+            old_dataset = datasaver.dataset
+            datasaver.add_result((setpoint, 1.0), (signal, 2.0))
+        old_dataset.conn.close()
+        old_dataset = None
+        experiment.conn.close()
+        experiment = None
+
+        # An unrelated writer creates a WAL after the static viewer state was
+        # accepted. It remains live while a replacement main file is installed.
+        writer = sqlite3.connect(database_path)
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("UPDATE runs SET name = ?", ("old_wal_run",))
+        writer.commit()
+        assert database_file_identity(f"{database_path}-wal") is not None
+        assert Path(f"{database_path}-shm").is_file()
+
+        generate_database(
+            [
+                RunSpecification(
+                    1,
+                    "replacement_signal",
+                    "Replacement signal",
+                    "V",
+                    -1.0,
+                    1.0,
+                    4,
+                )
+            ],
+            replacement_path,
+        )
+        replacement_conn = sqlite3.connect(replacement_path)
+        try:
+            expected_run = replacement_conn.execute(
+                "SELECT guid, result_counter FROM runs"
+                ).fetchone()
+        finally:
+            replacement_conn.close()
+
+        # The old writer can temporarily remove its sidecar before the main
+        # file is replaced, then recreate it later. Register the replacement
+        # epoch while no WAL exists and restore that proven-old WAL afterwards.
+        os.replace(f"{database_path}-wal", parked_wal_path)
+        os.replace(replacement_path, database_path)
+        assert quarantine_wal_for_replaced_database(database_path)
+        assert replacement_wal_is_quarantined(database_path)
+
+        absent_wal_state = _directory_state(tmp_path)
+        conn = sqlite_read_only_connection(database_path)
+        try:
+            assert conn.execute("SELECT guid, result_counter FROM runs").fetchone() == (
+                expected_run
+            )
+        finally:
+            conn.close()
+        assert _directory_state(tmp_path) == absent_wal_state
+
+        os.replace(parked_wal_path, f"{database_path}-wal")
+        source_state = _directory_state(tmp_path)
+        for opener in (
+                sqlite_read_only_connection,
+                qcodes_read_only_connection,
+                ):
+            conn = opener(database_path)
+            try:
+                assert conn.execute("SELECT guid, result_counter FROM runs").fetchone() == expected_run
+            finally:
+                conn.close()
+
+        assert database_access_error(database_path) is None
+        assert _directory_state(tmp_path) == source_state
+
+        # A single missing-WAL observation must not expire the replacement
+        # epoch: the old writer can put the same sidecar back afterwards.
+        os.replace(f"{database_path}-wal", parked_wal_path)
+        assert replacement_wal_is_quarantined(database_path)
+        conn = sqlite_read_only_connection(database_path)
+        try:
+            assert conn.execute("SELECT guid, result_counter FROM runs").fetchone() == expected_run
+        finally:
+            conn.close()
+        os.replace(parked_wal_path, f"{database_path}-wal")
+        source_state = _directory_state(tmp_path)
+
+        generate_database(
+            [
+                RunSpecification(
+                    1,
+                    "second_replacement_signal",
+                    "Second replacement signal",
+                    "V",
+                    -1.0,
+                    1.0,
+                    5,
+                )
+            ],
+            second_replacement_path,
+        )
+        second_conn = sqlite3.connect(second_replacement_path)
+        try:
+            expected_second_run = second_conn.execute(
+                "SELECT guid, result_counter FROM runs"
+                ).fetchone()
+        finally:
+            second_conn.close()
+
+        # Carry the same quarantine forward across N1 -> N2 while the old WAL
+        # is still beside the path.
+        os.replace(second_replacement_path, database_path)
+        source_state = _directory_state(tmp_path)
+        assert replacement_wal_is_quarantined(database_path)
+        for opener in (
+                sqlite_read_only_connection,
+                qcodes_read_only_connection,
+                ):
+            conn = opener(database_path)
+            try:
+                assert conn.execute("SELECT guid, result_counter FROM runs").fetchone() == expected_second_run
+            finally:
+                conn.close()
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writer is not None:
+            writer.close()
+        if old_dataset is not None:
+            old_dataset.conn.close()
+        if experiment is not None:
+            experiment.conn.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_expected_identity_rejects_replacement_during_read_preparation(
+        tmp_path,
+        monkeypatch,
+        ):
+    """A source replacement between UI checks and open cannot form a snapshot."""
+
+    from qplot.datahandling import readonly
+
+    database_path = tmp_path / "identity-race.db"
+    replacement_path = tmp_path / "identity-race-replacement.db"
+    writer = sqlite3.connect(database_path)
+    replacement_writer = None
+    replaced_state = None
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("CREATE TABLE old_rows (value TEXT)")
+        writer.execute("INSERT INTO old_rows VALUES ('old')")
+        writer.commit()
+        expected_identity = database_file_identity(database_path)
+        assert expected_identity is not None
+        assert Path(f"{database_path}-wal").is_file()
+
+        replacement_writer = sqlite3.connect(replacement_path)
+        replacement_writer.execute("CREATE TABLE replacement_rows (value TEXT)")
+        replacement_writer.execute("INSERT INTO replacement_rows VALUES ('new')")
+        replacement_writer.commit()
+        replacement_writer.close()
+        replacement_writer = None
+
+        real_require = readonly._require_expected_database_instance
+        replaced = False
+
+        def replace_after_initial_identity_check(path, expected_identity):
+            nonlocal replaced, replaced_state
+            result = real_require(path, expected_identity)
+            if not replaced and expected_identity is not None:
+                os.replace(replacement_path, database_path)
+                replaced_state = _directory_state(tmp_path)
+                replaced = True
+            return result
+
+        monkeypatch.setattr(
+            readonly,
+            "_require_expected_database_instance",
+            replace_after_initial_identity_check,
+        )
+        with pytest.raises(DatabaseInstanceChangedError, match="replaced"):
+            sqlite_read_only_connection(
+                database_path,
+                expected_database_identity=expected_identity,
+            )
+
+        assert replaced
+        assert replacement_wal_is_quarantined(database_path)
+        assert _directory_state(tmp_path) == replaced_state
+    finally:
+        if replacement_writer is not None:
+            replacement_writer.close()
+        writer.close()
+
+
+def test_database_access_probe_rejects_replacement_before_child_open(
+        tmp_path,
+        monkeypatch,
+        ):
+    """The probe child must reject a main file replaced after parent setup."""
+
+    from qplot.datahandling import database as database_module
+
+    database_path = tmp_path / "probe-identity-race.db"
+    replacement_path = tmp_path / "probe-identity-race-replacement.db"
+    parked_wal_path = tmp_path / "probe-old-wal"
+    writer = sqlite3.connect(database_path)
+    replacement_writer = None
+    replaced_state = None
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("CREATE TABLE stale_rows (value TEXT)")
+        writer.execute("INSERT INTO stale_rows VALUES ('old')")
+        writer.commit()
+        expected_identity = database_file_identity(database_path)
+        assert expected_identity is not None
+        assert Path(f"{database_path}-wal").is_file()
+        shutil.copyfile(f"{database_path}-wal", parked_wal_path)
+        writer.close()
+        writer = None
+
+        replacement_writer = sqlite3.connect(replacement_path)
+        replacement_writer.execute("CREATE TABLE replacement_rows (value TEXT)")
+        replacement_writer.execute("INSERT INTO replacement_rows VALUES ('new')")
+        replacement_writer.commit()
+        replacement_writer.close()
+        replacement_writer = None
+
+        real_run = database_module.subprocess.run
+
+        def replace_before_child_open(command, **kwargs):
+            nonlocal replaced_state
+            assert tuple(json.loads(command[-1])) == expected_identity
+            os.replace(replacement_path, database_path)
+            shutil.copyfile(parked_wal_path, f"{database_path}-wal")
+            replaced_state = _directory_state(tmp_path)
+            return real_run(command, **kwargs)
+
+        monkeypatch.setattr(
+            database_module.subprocess,
+            "run",
+            replace_before_child_open,
+        )
+
+        error = database_module.database_access_error(database_path)
+
+        assert error is not None
+        assert "replaced" in error
+        assert replaced_state is not None
+        assert _directory_state(tmp_path) == replaced_state
+    finally:
+        if replacement_writer is not None:
+            replacement_writer.close()
+        if writer is not None:
+            writer.close()
 
 
 def test_unstable_live_wal_fails_instead_of_using_immutable_data(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -319,15 +319,11 @@ class ToolFunctionTestCase(unittest.TestCase):
             worker = self._sql_heatmap_worker(database_path)
 
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             old_grid_side = worker_module.MAX_SQL_HEATMAP_GRID_SIDE
             try:
                 worker_module.cache_database_path = lambda _cache: database_path
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 60
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 16
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = 4
@@ -335,7 +331,6 @@ class ToolFunctionTestCase(unittest.TestCase):
                 loader._load_large_heatmap_from_sql(worker)
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
@@ -385,14 +380,10 @@ class ToolFunctionTestCase(unittest.TestCase):
             worker.cache.rundescriber.shapes = None
 
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             try:
                 worker_module.cache_database_path = lambda _cache: database_path
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 2
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 3
 
@@ -400,7 +391,6 @@ class ToolFunctionTestCase(unittest.TestCase):
                 loader._canonicalize_heatmap(worker)
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
 
@@ -425,15 +415,11 @@ class ToolFunctionTestCase(unittest.TestCase):
             worker.cache.rundescriber.shapes = None
 
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             old_grid_side = worker_module.MAX_SQL_HEATMAP_GRID_SIDE
             try:
                 worker_module.cache_database_path = lambda _cache: database_path
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 2
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 4
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = 2
@@ -442,7 +428,6 @@ class ToolFunctionTestCase(unittest.TestCase):
                 loader._canonicalize_heatmap(worker)
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
@@ -465,14 +450,10 @@ class ToolFunctionTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             results = []
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             old_grid_side = worker_module.MAX_SQL_HEATMAP_GRID_SIDE
             try:
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 60
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 16
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = 4
@@ -506,7 +487,6 @@ class ToolFunctionTestCase(unittest.TestCase):
                         ))
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
                 worker_module.MAX_SQL_HEATMAP_GRID_SIDE = old_grid_side
@@ -558,14 +538,10 @@ class ToolFunctionTestCase(unittest.TestCase):
             worker.cache.rundescriber.shapes = {"signal": (3, 4)}
 
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             try:
                 worker_module.cache_database_path = lambda _cache: database_path
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 12
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 12
 
@@ -573,7 +549,6 @@ class ToolFunctionTestCase(unittest.TestCase):
                 loader._canonicalize_heatmap(worker)
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
 
@@ -599,24 +574,19 @@ class ToolFunctionTestCase(unittest.TestCase):
             worker.heatmap_full_axis_ranges = {
                 "x": (0.0, 39.0),
                 "y": (0.0, 29.0),
-                }
+            }
 
             old_database_path = worker_module.cache_database_path
-            old_set_complete = worker_module.set_parameter_complete
             old_source_rows = worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS
             old_grid_cells = worker_module.MAX_SQL_HEATMAP_GRID_CELLS
             try:
                 worker_module.cache_database_path = lambda _cache: database_path
-                worker_module.set_parameter_complete = (
-                    lambda param, complete=False: setattr(param, "_complete", complete)
-                    )
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = 1_000
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = 1_000
 
                 loader._load_large_heatmap_from_sql(worker)
             finally:
                 worker_module.cache_database_path = old_database_path
-                worker_module.set_parameter_complete = old_set_complete
                 worker_module.MAX_SQL_HEATMAP_SOURCE_ROWS = old_source_rows
                 worker_module.MAX_SQL_HEATMAP_GRID_CELLS = old_grid_cells
 

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -16,7 +16,12 @@ from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.windows import _database_actions as database_actions
 from qplot.windows import main as main_window
 from qplot.windows._commands import command_spec
-from qplot.windows._dataset_handle import DatasetHandle, DatasetKey, TraceKey
+from qplot.windows._dataset_handle import (
+    DatasetHandle,
+    DatasetKey,
+    TraceKey,
+    database_file_identity,
+)
 from qplot.windows._plot_actions import PlotActionsMixin
 from qplot.windows._plotWin import plotWidget
 from qplot.windows._run_controls import AUTO_PLOT_KEY
@@ -87,6 +92,28 @@ class MeasurementExportDataFrameTestCase(unittest.TestCase):
 
 
 class DatasetHandleTestCase(unittest.TestCase):
+    def test_database_identity_changes_on_replacement_but_not_content_updates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "database.db"
+            replacement_path = Path(temp_dir) / "replacement.db"
+            database_path.write_bytes(b"first")
+            replacement_path.write_bytes(b"replacement")
+
+            original_identity = database_file_identity(database_path)
+            database_path.write_bytes(b"ordinary database update")
+
+            self.assertEqual(
+                database_file_identity(database_path),
+                original_identity,
+            )
+
+            os.replace(replacement_path, database_path)
+
+            self.assertNotEqual(
+                database_file_identity(database_path),
+                original_identity,
+            )
+
     def test_close_is_idempotent_and_closes_backing_connection(self):
         class Connection:
             def __init__(self):
@@ -180,6 +207,38 @@ class DatasetHandleTestCase(unittest.TestCase):
 
         self.assertTrue(dataset.conn.closed)
         self.assertEqual(harness.dataset_holder, {})
+
+    def test_new_instance_key_discards_same_path_guid_handle_from_old_instance(self):
+        class Connection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "database.db"
+            replacement_path = Path(temp_dir) / "replacement.db"
+            database_path.write_bytes(b"first")
+            replacement_path.write_bytes(b"replacement")
+            old_key = DatasetKey(database_path, "shared-guid")
+            dataset = type("Dataset", (), {"conn": Connection()})()
+            old_handle = DatasetHandle(
+                dataset,
+                database_identity=old_key.database_identity,
+            )
+            harness = type("Harness", (PlotActionsMixin,), {})()
+            harness.dataset_holder = {old_key: old_handle}
+            harness.ds = None
+
+            os.replace(replacement_path, database_path)
+            new_key = DatasetKey(database_path, "shared-guid")
+
+            self.assertNotEqual(new_key, old_key)
+            self.assertIsNone(harness._dataset_handle_for_key(new_key))
+            self.assertTrue(old_handle.closed)
+            self.assertTrue(dataset.conn.closed)
+            self.assertEqual(harness.dataset_holder, {})
 
     def test_replaced_database_invalidation_closes_only_matching_state(self):
         class Connection:
@@ -2191,6 +2250,9 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         _prepare_database_load_ui = (
             main_window.MainWindow._prepare_database_load_ui
             )
+        _prepare_replaced_database_reload = (
+            main_window.MainWindow._prepare_replaced_database_reload
+            )
         _set_database_load_controls_enabled = (
             main_window.MainWindow._set_database_load_controls_enabled
             )
@@ -2746,6 +2808,42 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         self.assertEqual(harness.infoBox.preview.added_runs, [(runs, False)])
         self.assertEqual(harness.refreshed_runs, [runs])
 
+    def test_database_detail_batch_drops_results_from_a_replaced_instance(self):
+        class RunList:
+            def __init__(self):
+                self.updated_runs = []
+
+            def updateRuns(self, runs):
+                self.updated_runs.append(runs)
+                return runs
+
+        class Harness:
+            database_detail_batch_ready = main_window.MainWindow.database_detail_batch_ready
+
+            def __init__(self):
+                self._database_detail_generation = 4
+                self._database_detail_active = True
+                self._loaded_database_identity = (1, 1)
+                self.fileTextbox = DatabaseLoadUiTestCase.Field("loaded.db")
+                self.RunList = RunList()
+                self.reloads = []
+
+            def _reload_replaced_database(self, database_path):
+                self.reloads.append(database_path)
+
+        harness = Harness()
+        runs = {1: {"guid": "guid-1", "result_count": 10}}
+
+        with patch.object(
+                database_actions,
+                "_database_file_identity",
+                return_value=(1, 2),
+                ):
+            harness.database_detail_batch_ready(4, "loaded.db", runs)
+
+        self.assertEqual(harness.reloads, ["loaded.db"])
+        self.assertEqual(harness.RunList.updated_runs, [])
+
     def test_database_detail_priority_uses_explicit_selected_and_visible_runs(self):
         harness = self.Harness()
         priority = harness._database_detail_priority_run_ids(run_ids=[7, 8])
@@ -2940,6 +3038,48 @@ class RefreshMainEmptyDatabaseTestCase(unittest.TestCase):
 
         self.assertEqual(len(harness.databaseRefreshThreadPool.workers), 2)
         self.assertTrue(harness._database_refresh_active)
+
+    def test_replacement_during_active_worker_discards_result_and_pending_refresh(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "database.db"
+            replacement_path = Path(temp_dir) / "replacement.db"
+            database_path.write_bytes(b"first")
+            replacement_path.write_bytes(b"replacement")
+            harness = self.Harness()
+            harness.fileTextbox.setText(str(database_path))
+            harness._loaded_database_identity = database_file_identity(database_path)
+            reloads = []
+
+            def reload_replacement(path, **_kwargs):
+                reloads.append(path)
+                main_window.MainWindow._cancel_database_refresh(harness)
+                return True
+
+            harness._reload_replaced_database = reload_replacement
+            harness.refreshMain()
+            worker = harness.databaseRefreshThreadPool.workers[0]
+            harness.refreshMain()
+            os.replace(replacement_path, database_path)
+
+            with patch.object(
+                    database_actions.QtCore.QTimer,
+                    "singleShot",
+                    ) as single_shot:
+                harness.database_refresh_finished(
+                    harness._database_refresh_generation,
+                    str(database_path),
+                    {1: {"guid": "stale-guid"}},
+                    {},
+                    None,
+                    )
+
+            self.assertEqual(reloads, [str(database_path)])
+            self.assertTrue(worker._cancelled.is_set())
+            self.assertFalse(harness.RunList.checked_watching)
+            self.assertFalse(harness._database_refresh_active)
+            self.assertFalse(harness._database_refresh_pending)
+            self.assertEqual(len(harness.databaseRefreshThreadPool.workers), 1)
+            single_shot.assert_not_called()
 
 
 class RefreshMainPreviewUpdateTestCase(unittest.TestCase):

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -12,6 +12,11 @@ from PyQt6 import QtWidgets as qtw
 from qcodes.dataset.sqlite.database import get_DB_location
 
 from qplot.datahandling import database as database_module
+from qplot.datahandling.file_identity import (
+    DatabaseInstance,
+    canonical_database_path,
+    logical_database_path,
+)
 from qplot.datahandling.readonly import set_qcodes_database_location
 from qplot.windows import _database_actions as database_actions
 from qplot.windows import main as main_window
@@ -113,6 +118,35 @@ class DatasetHandleTestCase(unittest.TestCase):
                 database_file_identity(database_path),
                 original_identity,
             )
+
+    def test_dataset_key_preserves_logical_symlink_and_accepted_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target_a = root / "target-a.db"
+            target_b = root / "target-b.db"
+            view_path = root / "view.db"
+            next_link = root / "next-view.db"
+            target_a.write_bytes(b"a")
+            target_b.write_bytes(b"b")
+            try:
+                view_path.symlink_to(target_a)
+                next_link.symlink_to(target_b)
+            except OSError as error:
+                self.skipTest(f"This platform cannot create symlinks: {error}")
+
+            old_key = DatasetKey(view_path, "shared-guid")
+            os.replace(next_link, view_path)
+
+            self.assertEqual(
+                old_key.database_path,
+                logical_database_path(view_path),
+            )
+            self.assertEqual(
+                old_key.resolved_database_path,
+                canonical_database_path(target_a),
+            )
+            self.assertFalse(PlotActionsMixin._dataset_key_is_current(old_key))
+            self.assertNotEqual(old_key, DatasetKey(view_path, "shared-guid"))
 
     def test_close_is_idempotent_and_closes_backing_connection(self):
         class Connection:
@@ -2403,6 +2437,71 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
         finally:
             set_qcodes_database_location(active_database)
 
+    def test_database_without_stable_identity_is_rejected_before_loading(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "unidentifiable.db"
+            database_path.write_bytes(b"database")
+            harness = self.Harness()
+            unavailable = DatabaseInstance(
+                logical_path=str(database_path),
+                resolved_path=str(database_path.resolve()),
+                identity=None,
+            )
+
+            with patch.object(
+                    database_actions,
+                    "database_instance",
+                    return_value=unavailable,
+                    ):
+                self.assertFalse(harness.load_file(str(database_path)))
+
+            self.assertEqual(harness.databaseLoadThreadPool.started, [])
+            self.assertEqual(
+                harness.error_messages[-1][0],
+                "Database Identity Unavailable",
+            )
+
+    def test_symlink_replacement_during_load_retries_without_committing_stale_runs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target_a = root / "target-a.db"
+            target_b = root / "target-b.db"
+            view_path = root / "view.db"
+            next_link = root / "next-view.db"
+            target_a.write_bytes(b"a")
+            target_b.write_bytes(b"b")
+            try:
+                view_path.symlink_to(target_a)
+                next_link.symlink_to(target_b)
+            except OSError as error:
+                self.skipTest(f"This platform cannot create symlinks: {error}")
+
+            harness = self.Harness()
+            self.assertTrue(harness.load_file(str(view_path)))
+            generation = harness._database_load_generation
+            stale_runs = {1: {"guid": "stale-guid"}}
+            os.replace(next_link, view_path)
+
+            with patch.object(
+                    database_actions.QtCore.QTimer,
+                    "singleShot",
+                    side_effect=lambda _delay, callback: callback(),
+                    ):
+                harness.database_load_finished(
+                    generation,
+                    str(view_path),
+                    stale_runs,
+                    None,
+                )
+
+            self.assertTrue(harness._database_load_active)
+            self.assertEqual(len(harness.databaseLoadThreadPool.started), 2)
+            self.assertEqual(harness.RunList.runs, {})
+            self.assertEqual(
+                harness._database_load_state["load_instance"].resolved_path,
+                canonical_database_path(target_b),
+            )
+
     def test_existing_qcodes_database_is_not_displayed_before_it_is_loaded(self):
         class Harness(qtw.QMainWindow):
             load_database_path = lambda *_args: True
@@ -2594,6 +2693,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
                     {},
                     None,
                 )
+                old_instance = harness._loaded_database_instance
                 started_workers = len(harness.databaseLoadThreadPool.started)
                 invalidated = []
                 harness._invalidate_database_runtime_state = invalidated.append
@@ -2613,7 +2713,7 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
                     {},
                     None,
                 )
-                self.assertEqual(invalidated, [str(database_path)])
+                self.assertEqual(invalidated, [old_instance])
                 self.assertTrue(harness.infoBox.database_cache_cleared)
             finally:
                 set_qcodes_database_location(active_database)
@@ -2843,6 +2943,57 @@ class DatabaseLoadUiTestCase(unittest.TestCase):
 
         self.assertEqual(harness.reloads, ["loaded.db"])
         self.assertEqual(harness.RunList.updated_runs, [])
+
+    def test_database_detail_batch_rejects_a_retargeted_symlink(self):
+        class RunList:
+            def __init__(self):
+                self.updated_runs = []
+
+            def updateRuns(self, runs):
+                self.updated_runs.append(runs)
+                return runs
+
+        class Harness:
+            database_detail_batch_ready = main_window.MainWindow.database_detail_batch_ready
+
+            def __init__(self, view_path):
+                self._database_detail_generation = 4
+                self._database_detail_active = True
+                self._loaded_database_instance = database_actions.database_instance(
+                    view_path
+                )
+                self._loaded_database_identity = self._loaded_database_instance.identity
+                self.fileTextbox = DatabaseLoadUiTestCase.Field(str(view_path))
+                self.RunList = RunList()
+                self.reloads = []
+
+            def _reload_replaced_database(self, database_path):
+                self.reloads.append(database_path)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target_a = root / "target-a.db"
+            target_b = root / "target-b.db"
+            view_path = root / "view.db"
+            next_link = root / "next-view.db"
+            target_a.write_bytes(b"a")
+            target_b.write_bytes(b"b")
+            try:
+                view_path.symlink_to(target_a)
+                next_link.symlink_to(target_b)
+            except OSError as error:
+                self.skipTest(f"This platform cannot create symlinks: {error}")
+            harness = Harness(view_path)
+            os.replace(next_link, view_path)
+
+            harness.database_detail_batch_ready(
+                4,
+                str(view_path),
+                {1: {"guid": "stale-guid", "result_count": 3}},
+            )
+
+            self.assertEqual(harness.reloads, [str(view_path)])
+            self.assertEqual(harness.RunList.updated_runs, [])
 
     def test_database_detail_priority_uses_explicit_selected_and_visible_runs(self):
         harness = self.Harness()

--- a/tests/windows/test_plot2d.py
+++ b/tests/windows/test_plot2d.py
@@ -6,6 +6,7 @@ import pyqtgraph as pg
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
 
+from qplot.datahandling.qcodes_cache import cache_parameter_is_synchronized
 from qplot.tools.heatmap_geometry import HeatmapGeometry
 from qplot.windows._dataset_handle import DatasetHandle, DatasetKey, TraceKey
 from qplot.windows._plot2d_sweeps import Plot2DSweepMixin
@@ -480,6 +481,139 @@ class Plot2dLiveRefreshTestCase(unittest.TestCase):
 
         self.assertFalse(worker.running)
         self.assertEqual(scheduled_after_release, [True])
+
+    def test_terminal_direct_sql_display_failure_remains_retryable(self):
+        class Cache:
+            live = False
+
+        class Dataset:
+            def __init__(self):
+                self._completed = False
+                self.number_of_results = 4
+                self.cache = Cache()
+                self.cache._dataset = self
+
+            @property
+            def completed(self):
+                return self._completed
+
+            @property
+            def running(self):
+                return not self._completed
+
+        class Monitor:
+            def __init__(self):
+                self.active = False
+
+            def stop(self):
+                self.active = False
+
+            def isActive(self):
+                return self.active
+
+        class SpinBox:
+            def value(self):
+                return 0.2
+
+        class Toggle:
+            def isChecked(self):
+                return False
+
+        class EndWait:
+            def emit(self):
+                pass
+
+        class Worker:
+            def __init__(self):
+                self.read_data = False
+                self.loaded_from_sql_heatmap = True
+                self.heatmap_axis_ranges = {"x": (0.0, 1.0)}
+                self.dataset_completed = True
+                self.dataset_length_at_start = 4
+                self.axis_data = {
+                    "x": np.array([0.0, 1.0]),
+                    "y": np.array([0.0, 1.0]),
+                    }
+                self.axis_param = {"x": object(), "y": object()}
+                self.display_param = object()
+                self.dataGrid = np.array([[1.0, 2.0], [3.0, 4.0]])
+                self.loaded_point_count = 4
+                self.aggregated_heatmap_source = False
+                self.started_at = 0.0
+                self.running = True
+
+            def is_cancelled(self):
+                return False
+
+        window = plot2d.__new__(plot2d)
+        qtw.QMainWindow.__init__(window)
+        dataset = Dataset()
+        dataset_key = DatasetKey("database.db", "guid")
+        window._dataset_key = dataset_key
+        window._dataset_holder = {dataset_key: DatasetHandle(dataset)}
+        window.param = type("Param", (), {"name": "signal"})()
+        window._qplot_display_synchronized = False
+        window._qplot_display_uses_direct_sql = False
+        window._set_param_axis_labels = lambda: None
+        window.show_status = lambda *_args: None
+        window.hide_plot_state = lambda: None
+        window._update_large_heatmap_state = lambda _worker: None
+        window._has_plottable_heatmap_data = lambda: True
+        window._update_heatmap_geometry = lambda: None
+        window.relevel_refresh = Toggle()
+        window.bar = object()
+        window._sync_colorbar_axis_scaling = lambda: None
+        window._restore_heatmap_interactions = lambda: None
+        window._colorbar_manual_levels = None
+        window.monitor = Monitor()
+        window.spinBox = SpinBox()
+        window.end_wait = EndWait()
+        window.last_ds_len = 4
+        loads = []
+        restarts = []
+        window.load_data = lambda: loads.append(True)
+        window.monitorIntervalChanged = lambda interval: (
+            restarts.append(interval),
+            setattr(window.monitor, "active", True),
+            )
+
+        failed_worker = Worker()
+        window.worker = failed_worker
+        window._render_heatmap = lambda: (_ for _ in ()).throw(
+            RuntimeError("injected direct-SQL display failure")
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "direct-SQL display failure"):
+            plot2d.refreshPlot(window, True, worker=failed_worker)
+
+        self.assertTrue(dataset.completed)
+        self.assertFalse(dataset.running)
+        self.assertFalse(window._qplot_display_synchronized)
+        self.assertTrue(window._refresh_monitor_required())
+        self.assertFalse(cache_parameter_is_synchronized(dataset.cache, "signal"))
+        self.assertEqual(restarts, [0.2])
+        self.assertTrue(window.monitor.active)
+
+        plotWidget.refreshWindow(window)
+
+        self.assertEqual(loads, [True])
+        self.assertEqual(restarts, [0.2, 0.2])
+        self.assertTrue(window.monitor.active)
+
+        successful_worker = Worker()
+        window.worker = successful_worker
+        window._render_heatmap = lambda: None
+        plot2d.refreshPlot(window, True, worker=successful_worker)
+
+        self.assertTrue(window._qplot_display_synchronized)
+        self.assertTrue(window._qplot_display_uses_direct_sql)
+        self.assertFalse(window._refresh_monitor_required())
+        self.assertFalse(cache_parameter_is_synchronized(dataset.cache, "signal"))
+
+        plotWidget.refreshWindow(window)
+
+        self.assertEqual(loads, [True])
+        self.assertFalse(window.monitor.active)
 
     def test_zoom_to_all_reloads_full_large_heatmap(self):
         class ViewBox:

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -207,7 +207,13 @@ def release_windows_database_locks(window, database_path, *extra_datasets):
         return
 
     source_path = Path(database_path).resolve()
-    datasets = [getattr(window, "ds", None), *extra_datasets]
+    datasets = list(extra_datasets)
+    selected_key = getattr(window, "_selected_dataset_key", None)
+    if (
+            selected_key is not None
+            and Path(selected_key.database_path).resolve() == source_path
+            ):
+        datasets.append(getattr(window, "ds", None))
     for dataset_key, handle in getattr(window, "dataset_holder", {}).items():
         if Path(dataset_key.database_path).resolve() == source_path:
             datasets.append(handle.dataset)
@@ -537,7 +543,11 @@ def test_atomic_replacement_of_live_wal_uses_new_main_without_source_writes(
                 "load_by_guid_read_only",
                 record_direct_dataset_read,
             )
-            window.openPlot(params=[old_parameter], show=False)
+            window.openPlot(
+                guid=old_plot._dataset_key,
+                params=[old_parameter],
+                show=False,
+            )
             assert direct_dataset_reads == []
 
         wait_for(

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -18,7 +18,10 @@ from qcodes.parameters import ManualParameter
 
 import qplot.tools.worker as worker_module
 from qplot.configuration.config import config
-from qplot.datahandling.qcodes_cache import cache_parameter_data
+from qplot.datahandling.qcodes_cache import (
+    cache_parameter_data,
+    cache_parameter_is_synchronized,
+)
 from qplot.datahandling.readonly import (
     load_by_id_read_only,
     set_qcodes_database_location,
@@ -415,4 +418,547 @@ def test_threaded_live_run_completion_commits_final_rows_before_stopping_monitor
         writer_thread.join(10)
         if viewer_dataset is not None:
             viewer_dataset.conn.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_threaded_multi_parameter_completion_retries_each_real_plot(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    database_path = Path(tmp_path) / "threaded-live-run.db"
+    original_database_path = qcodes.config.core.db_location
+    initial_row_written = threading.Event()
+    finish_writer = threading.Event()
+    writer_completed = threading.Event()
+    release_writer_connection = threading.Event()
+    writer_state = {}
+    writer_errors = []
+    window = None
+
+    def write_measurement():
+        writer_dataset = None
+        try:
+            initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+            experiment = load_or_create_experiment(
+                "threaded_live_run",
+                sample_name="completion_race",
+                )
+            gate = ManualParameter("gate")
+            signal_a = ManualParameter("signal_a")
+            signal_b = ManualParameter("signal_b")
+            measurement = Measurement(exp=experiment, name="completion_race")
+            measurement.register_parameter(gate)
+            measurement.register_parameter(signal_a, setpoints=(gate,))
+            measurement.register_parameter(signal_b, setpoints=(gate,))
+            with measurement.run(write_in_background=False) as datasaver:
+                writer_dataset = datasaver.dataset
+                datasaver.add_result(
+                    (gate, 0.0),
+                    (signal_a, 10.0),
+                    (signal_b, 20.0),
+                    )
+                datasaver.flush_data_to_database(block=True)
+                writer_state["run_id"] = writer_dataset.run_id
+                initial_row_written.set()
+                if not finish_writer.wait(30):
+                    raise TimeoutError("Test did not release the measurement writer")
+                datasaver.add_result(
+                    (gate, 1.0),
+                    (signal_a, 11.0),
+                    (signal_b, 21.0),
+                    )
+                datasaver.add_result(
+                    (gate, 2.0),
+                    (signal_a, 12.0),
+                    (signal_b, 22.0),
+                    )
+            writer_completed.set()
+            if not release_writer_connection.wait(30):
+                raise TimeoutError("Test did not release the writer connection")
+        except BaseException as error:
+            writer_errors.append(error)
+            initial_row_written.set()
+            writer_completed.set()
+        finally:
+            if writer_dataset is not None:
+                writer_dataset.conn.close()
+
+    writer_thread = threading.Thread(target=write_measurement)
+    writer_thread.start()
+
+    try:
+        assert initial_row_written.wait(30)
+        assert writer_errors == []
+
+        window = main_window.MainWindow()
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        viewer_dataset = window.ds
+        assert viewer_dataset is not None
+        assert viewer_dataset.run_id == writer_state["run_id"]
+        assert viewer_dataset.running
+        # QCoDeS stores one result-table row per dependent parameter tree.
+        assert viewer_dataset.number_of_results == 2
+
+        parameters = {
+            candidate.name: candidate
+            for candidate in viewer_dataset.get_parameters()
+            if candidate.depends_on
+            }
+        window.openPlot(
+            params=[parameters["signal_a"], parameters["signal_b"]],
+            show=False,
+            )
+        plot_a, hidden_plot_b = window.windows[-2:]
+        wait_for(
+            lambda: all(
+                not getattr(plot.worker, "running", False)
+                for plot in (plot_a, hidden_plot_b)
+            )
+        )
+        for plot in (plot_a, hidden_plot_b):
+            plot.spinBox.setValue(60.0)
+            plot.monitor.stop()
+
+        def cache_values(parameter_name):
+            return np.asarray(
+                cache_parameter_data(
+                    viewer_dataset.cache,
+                    parameter_name,
+                    )[parameter_name]
+                )
+
+        def line_values(plot):
+            return np.asarray(plot.line.getData()[1])
+
+        np.testing.assert_array_equal(cache_values("signal_a"), [10.0])
+        np.testing.assert_array_equal(cache_values("signal_b"), [20.0])
+        np.testing.assert_array_equal(line_values(plot_a), [10.0])
+        np.testing.assert_array_equal(line_values(hidden_plot_b), [20.0])
+
+        assert window.add_trace_to_plot(
+            plot_a,
+            hidden_plot_b._dataset_key,
+            "signal_b",
+            param=hidden_plot_b.param,
+            )
+        merged_b = plot_a.lines[hidden_plot_b._trace_key]
+        assert hidden_plot_b._closed
+        assert hidden_plot_b not in window.windows
+        assert hidden_plot_b._merged_trace_users == 1
+        np.testing.assert_array_equal(np.asarray(merged_b.getData()[1]), [20.0])
+
+        # Keep two plots open during the transition while the original B is a
+        # closed-and-retained hidden source for the merged secondary trace.
+        window.openPlot(params=[parameters["signal_b"]], show=False)
+        plot_b = window.windows[-1]
+        wait_for(lambda: not getattr(plot_b.worker, "running", False))
+        plot_b.spinBox.setValue(60.0)
+        plot_b.monitor.stop()
+        plot_b.monitorIntervalChanged(plot_b.spinBox.value())
+        assert window.windows == [plot_a, plot_b]
+        assert not plot_b._closed
+        np.testing.assert_array_equal(line_values(plot_b), [20.0])
+        plot_a.monitor.stop()
+        hidden_plot_b.monitor.stop()
+
+        finish_writer.set()
+        assert writer_completed.wait(30)
+        assert writer_thread.is_alive()
+        assert writer_errors == []
+        assert viewer_dataset.running
+        # The source-preserving viewer connection is intentionally pinned to
+        # the WAL snapshot from when the run was opened. Plot workers must use
+        # fresh read-only snapshots to discover the committed final rows.
+        assert viewer_dataset.number_of_results == 2
+
+        writer_complete_artifacts = database_artifact_state(database_path)
+        assert set(writer_complete_artifacts) == {"", "-wal", "-shm", "-journal"}
+        assert writer_complete_artifacts[""] is not None
+        assert writer_complete_artifacts["-wal"] is not None
+        assert writer_complete_artifacts["-shm"] is not None
+
+        original_load = worker_module.load_param_data_from_db
+        final_loads = []
+        failed_b_load = False
+
+        def record_and_fail_first_b_load(*args, **kwargs):
+            nonlocal failed_b_load
+            parameter_name = (
+                kwargs["meas_parameter"]
+                if "meas_parameter" in kwargs
+                else args[3]
+                )
+            final_loads.append(parameter_name)
+            if parameter_name == "signal_b" and not failed_b_load:
+                failed_b_load = True
+                raise RuntimeError("injected signal_b final-load failure")
+            return original_load(*args, **kwargs)
+
+        monkeypatch.setattr(
+            worker_module,
+            "load_param_data_from_db",
+            record_and_fail_first_b_load,
+            )
+        import qcodes.dataset.data_set as qcodes_data_set
+
+        def reject_qcodes_completion_write(*_args, **_kwargs):
+            raise AssertionError("qPlot must not call mark_run_complete")
+
+        monkeypatch.setattr(
+            qcodes_data_set,
+            "mark_run_complete",
+            reject_qcodes_completion_write,
+            )
+
+        plot_a.refreshWindow()
+        wait_for(
+            lambda: (
+                line_values(plot_a).size == 3
+                and not getattr(plot_a.worker, "running", False)
+            )
+        )
+
+        np.testing.assert_array_equal(cache_values("signal_a"), [10.0, 11.0, 12.0])
+        np.testing.assert_array_equal(plot_a.line.getData()[0], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(line_values(plot_a), [10.0, 11.0, 12.0])
+        np.testing.assert_array_equal(cache_values("signal_b"), [20.0])
+        np.testing.assert_array_equal(line_values(plot_b), [20.0])
+        np.testing.assert_array_equal(line_values(hidden_plot_b), [20.0])
+        np.testing.assert_array_equal(np.asarray(merged_b.getData()[1]), [20.0])
+        assert final_loads == ["signal_a"]
+        assert viewer_dataset.completed
+        assert not viewer_dataset.running
+        assert cache_parameter_is_synchronized(viewer_dataset.cache, "signal_a")
+        assert not cache_parameter_is_synchronized(viewer_dataset.cache, "signal_b")
+        assert window.windows == [plot_a, plot_b]
+        assert plot_a._qplot_display_synchronized
+        assert not plot_b._qplot_display_synchronized
+        assert not hidden_plot_b._qplot_display_synchronized
+        assert merged_b.running
+        assert plot_b.monitor.isActive()
+        assert hidden_plot_b.monitor.isActive()
+        assert database_artifact_state(database_path) == writer_complete_artifacts
+
+        plot_b.show_error = lambda *_args, **_kwargs: None
+        plot_b.refreshWindow()
+        wait_for(
+            lambda: (
+                final_loads.count("signal_b") == 1
+                and not getattr(plot_b.worker, "running", False)
+            )
+        )
+
+        np.testing.assert_array_equal(cache_values("signal_b"), [20.0])
+        np.testing.assert_array_equal(line_values(plot_b), [20.0])
+        np.testing.assert_array_equal(line_values(hidden_plot_b), [20.0])
+        assert not cache_parameter_is_synchronized(viewer_dataset.cache, "signal_b")
+        assert not plot_b._qplot_display_synchronized
+        assert plot_b.monitor.isActive()
+        assert hidden_plot_b.monitor.isActive()
+        assert database_artifact_state(database_path) == writer_complete_artifacts
+
+        original_set_data = plot_b.line.setData
+        original_refresh_plot = plot_b.refreshPlot
+        display_errors = []
+        fail_display = True
+
+        def fail_first_final_display(*args, **kwargs):
+            nonlocal fail_display
+            y_data = np.asarray(kwargs.get("y", []))
+            if fail_display and y_data.size == 3:
+                fail_display = False
+                raise RuntimeError("injected signal_b display failure")
+            return original_set_data(*args, **kwargs)
+
+        def capture_display_failure(finished=True, worker=None):
+            try:
+                return original_refresh_plot(finished, worker=worker)
+            except RuntimeError as error:
+                display_errors.append(error)
+                return None
+
+        plot_b.line.setData = fail_first_final_display
+        plot_b.refreshPlot = capture_display_failure
+        plot_b.refreshWindow()
+        wait_for(
+            lambda: (
+                cache_values("signal_b").size == 3
+                and not getattr(plot_b.worker, "running", False)
+                and bool(display_errors)
+            )
+        )
+
+        np.testing.assert_array_equal(cache_values("signal_b"), [20.0, 21.0, 22.0])
+        np.testing.assert_array_equal(line_values(plot_b), [20.0])
+        np.testing.assert_array_equal(line_values(hidden_plot_b), [20.0])
+        np.testing.assert_array_equal(np.asarray(merged_b.getData()[1]), [20.0])
+        assert final_loads == ["signal_a", "signal_b", "signal_b"]
+        assert cache_parameter_is_synchronized(viewer_dataset.cache, "signal_b")
+        assert not plot_b._qplot_display_synchronized
+        assert "injected signal_b display failure" in str(display_errors[0])
+        assert plot_b.monitor.isActive()
+        assert hidden_plot_b.monitor.isActive()
+        assert database_artifact_state(database_path) == writer_complete_artifacts
+
+        plot_b.refreshWindow()
+        wait_for(
+            lambda: (
+                plot_b._qplot_display_synchronized
+                and line_values(plot_b).size == 3
+                and not getattr(plot_b.worker, "running", False)
+            )
+        )
+
+        np.testing.assert_array_equal(line_values(plot_b), [20.0, 21.0, 22.0])
+        np.testing.assert_array_equal(plot_b.line.getData()[0], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(line_values(hidden_plot_b), [20.0])
+        np.testing.assert_array_equal(
+            np.asarray(merged_b.getData()[1]),
+            [20.0],
+            )
+        assert final_loads == ["signal_a", "signal_b", "signal_b"]
+        assert not plot_b._refresh_monitor_required()
+
+        hidden_plot_b.refreshWindow()
+        wait_for(
+            lambda: (
+                hidden_plot_b._qplot_display_synchronized
+                and line_values(hidden_plot_b).size == 3
+                and not getattr(hidden_plot_b.worker, "running", False)
+            )
+        )
+
+        np.testing.assert_array_equal(
+            line_values(hidden_plot_b),
+            [20.0, 21.0, 22.0],
+            )
+        np.testing.assert_array_equal(
+            np.asarray(merged_b.getData()[1]),
+            [20.0, 21.0, 22.0],
+            )
+        assert final_loads == ["signal_a", "signal_b", "signal_b"]
+        assert not hidden_plot_b._refresh_monitor_required()
+
+        terminal_worker = plot_b.worker
+        hidden_terminal_worker = hidden_plot_b.worker
+        plot_b.refreshWindow()
+        hidden_plot_b.refreshWindow()
+        plot_a.refreshWindow()
+        assert plot_b.worker is terminal_worker
+        assert hidden_plot_b.worker is hidden_terminal_worker
+        assert not plot_b.monitor.isActive()
+        assert not hidden_plot_b.monitor.isActive()
+        assert not plot_a.monitor.isActive()
+        assert not merged_b.running
+        assert final_loads == ["signal_a", "signal_b", "signal_b"]
+        assert database_artifact_state(database_path) == writer_complete_artifacts
+        release_writer_connection.set()
+        writer_thread.join(30)
+        assert not writer_thread.is_alive()
+        assert writer_errors == []
+    finally:
+        finish_writer.set()
+        release_writer_connection.set()
+        writer_thread.join(30)
+        if window is not None:
+            close_main_window(window)
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_threaded_wal_direct_sql_heatmap_completes_without_source_writes(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    database_path = Path(tmp_path) / "threaded-live-heatmap.db"
+    original_database_path = qcodes.config.core.db_location
+    initial_row_written = threading.Event()
+    finish_writer = threading.Event()
+    writer_completed = threading.Event()
+    release_writer_connection = threading.Event()
+    writer_state = {}
+    writer_errors = []
+    window = None
+
+    def write_measurement():
+        writer_dataset = None
+        try:
+            initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+            experiment = load_or_create_experiment(
+                "threaded_live_heatmap",
+                sample_name="direct_sql_completion",
+                )
+            x_param = ManualParameter("x_param")
+            y_param = ManualParameter("y_param")
+            signal = ManualParameter("heat_signal")
+            measurement = Measurement(exp=experiment, name="direct_sql_completion")
+            measurement.register_parameter(x_param)
+            measurement.register_parameter(y_param)
+            measurement.register_parameter(signal, setpoints=(x_param, y_param))
+            with measurement.run(write_in_background=False) as datasaver:
+                writer_dataset = datasaver.dataset
+                datasaver.add_result(
+                    (x_param, 0.0),
+                    (y_param, 0.0),
+                    (signal, 10.0),
+                    )
+                datasaver.flush_data_to_database(block=True)
+                writer_state["run_id"] = writer_dataset.run_id
+                initial_row_written.set()
+                if not finish_writer.wait(30):
+                    raise TimeoutError("Test did not release the heatmap writer")
+                for x_value, y_value, signal_value in (
+                        (1.0, 0.0, 11.0),
+                        (0.0, 1.0, 12.0),
+                        (1.0, 1.0, 13.0),
+                        ):
+                    datasaver.add_result(
+                        (x_param, x_value),
+                        (y_param, y_value),
+                        (signal, signal_value),
+                        )
+            writer_completed.set()
+            if not release_writer_connection.wait(30):
+                raise TimeoutError("Test did not release the heatmap connection")
+        except BaseException as error:
+            writer_errors.append(error)
+            initial_row_written.set()
+            writer_completed.set()
+        finally:
+            if writer_dataset is not None:
+                writer_dataset.conn.close()
+
+    writer_thread = threading.Thread(target=write_measurement)
+    writer_thread.start()
+
+    try:
+        assert initial_row_written.wait(30)
+        assert writer_errors == []
+
+        window = main_window.MainWindow()
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.config.config["runtime_settings"]["max_full_heatmap_points"] = 1
+        window.close_database(status=False)
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        viewer_dataset = window.ds
+        assert viewer_dataset is not None
+        assert viewer_dataset.run_id == writer_state["run_id"]
+        assert viewer_dataset.running
+        assert viewer_dataset.number_of_results == 1
+
+        parameter = next(
+            candidate
+            for candidate in viewer_dataset.get_parameters()
+            if candidate.name == "heat_signal"
+            )
+        window.openPlot(params=[parameter], show=False)
+        heatmap = window.windows[-1]
+        wait_for(lambda: not getattr(heatmap.worker, "running", False))
+        heatmap.spinBox.setValue(60.0)
+        heatmap.monitor.stop()
+
+        assert not heatmap.worker.loaded_from_sql_heatmap
+        assert np.isfinite(np.asarray(heatmap.dataGrid)).sum() == 1
+        assert np.asarray(
+            cache_parameter_data(viewer_dataset.cache, "heat_signal")["heat_signal"]
+            ).size == 1
+
+        finish_writer.set()
+        assert writer_completed.wait(30)
+        assert writer_thread.is_alive()
+        assert writer_errors == []
+        artifacts_after_writer_completion = database_artifact_state(database_path)
+        assert artifacts_after_writer_completion[""] is not None
+        assert artifacts_after_writer_completion["-wal"] is not None
+        assert artifacts_after_writer_completion["-shm"] is not None
+
+        import qcodes.dataset.data_set as qcodes_data_set
+
+        def reject_qcodes_completion_write(*_args, **_kwargs):
+            raise AssertionError("qPlot must not call mark_run_complete")
+
+        monkeypatch.setattr(
+            qcodes_data_set,
+            "mark_run_complete",
+            reject_qcodes_completion_write,
+            )
+
+        heatmap.refreshWindow()
+        wait_for(
+            lambda: (
+                getattr(heatmap.worker, "loaded_from_sql_heatmap", False)
+                and heatmap._qplot_display_synchronized
+                and not getattr(heatmap.worker, "running", False)
+            )
+        )
+
+        assert heatmap.worker.dataset_completed is True
+        assert heatmap.worker.loaded_point_count == 4
+        assert viewer_dataset.completed
+        assert not viewer_dataset.running
+        assert heatmap._qplot_display_uses_direct_sql
+        assert not cache_parameter_is_synchronized(
+            viewer_dataset.cache,
+            "heat_signal",
+            )
+        assert np.asarray(
+            cache_parameter_data(viewer_dataset.cache, "heat_signal")["heat_signal"]
+            ).size == 1
+        np.testing.assert_array_equal(
+            np.sort(np.asarray(heatmap.dataGrid)[np.isfinite(heatmap.dataGrid)]),
+            [10.0, 11.0, 12.0, 13.0],
+            )
+        np.testing.assert_array_equal(
+            np.sort(np.asarray(heatmap.image.image).ravel()),
+            [10.0, 11.0, 12.0, 13.0],
+            )
+        assert database_artifact_state(database_path) == artifacts_after_writer_completion
+
+        wait_for(
+            lambda: (
+                not heatmap._heatmap_view_reload_timer.isActive()
+                and not getattr(heatmap.worker, "running", False)
+            ),
+            )
+        terminal_worker = heatmap.worker
+        heatmap.refreshWindow()
+        assert heatmap.worker is terminal_worker
+        assert not heatmap.monitor.isActive()
+        assert database_artifact_state(database_path) == artifacts_after_writer_completion
+
+        release_writer_connection.set()
+        writer_thread.join(30)
+        assert not writer_thread.is_alive()
+        assert writer_errors == []
+    finally:
+        finish_writer.set()
+        release_writer_connection.set()
+        writer_thread.join(30)
+        if window is not None:
+            close_main_window(window)
         qcodes.config.core.db_location = original_database_path

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -1,5 +1,7 @@
+import gc
 import hashlib
 import os
+import shutil
 import sqlite3
 import threading
 import time
@@ -124,6 +126,37 @@ def build_line_database(db_path, point_count, *, guid=None, journal_mode=None):
     return run_id, generated_guid, table_name
 
 
+def build_line_database_with_replayed_stale_wal(db_path):
+    """Create a completed QCoDeS run with a safely replayable old WAL.
+
+    The sidecars are copied while an unrelated raw SQLite writer owns them and
+    restored only after that writer closes. This gives Windows the same
+    unpaired-WAL replacement scenario as POSIX without trying to rename a file
+    that SQLite has open.
+    """
+
+    build_line_database(db_path, 1, journal_mode="WAL")
+    parked = {}
+    writer = sqlite3.connect(db_path)
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("UPDATE runs SET name = ?", ("stale_sidecar_run",))
+        writer.commit()
+        for suffix in ("-wal", "-shm"):
+            source = Path(f"{db_path}{suffix}")
+            assert source.is_file()
+            parked_path = Path(f"{db_path}.parked{suffix}")
+            shutil.copyfile(source, parked_path)
+            parked[suffix] = parked_path
+    finally:
+        writer.close()
+
+    for suffix, parked_path in parked.items():
+        shutil.copyfile(parked_path, f"{db_path}{suffix}")
+        parked_path.unlink()
+
+
 def dependent_parameter(dataset, dimensions):
     for param in dataset.get_parameters():
         if param.depends_on and len(param.depends_on_) == dimensions:
@@ -159,6 +192,37 @@ def database_artifact_state(database_path):
             hashlib.sha256(path.read_bytes()).hexdigest(),
             )
     return state
+
+
+def release_windows_database_locks(window, database_path, *extra_datasets):
+    """Release test-only SQLite handles before a Windows atomic replacement.
+
+    POSIX lets a test rename an open database while Windows correctly rejects
+    it. qPlot detects a replacement before reading these stale objects, so the
+    test can close their backing connections without changing the state under
+    test or marking their DatasetHandles closed ahead of the invalidation.
+    """
+
+    if os.name != "nt":
+        return
+
+    source_path = Path(database_path).resolve()
+    datasets = [getattr(window, "ds", None), *extra_datasets]
+    for dataset_key, handle in getattr(window, "dataset_holder", {}).items():
+        if Path(dataset_key.database_path).resolve() == source_path:
+            datasets.append(handle.dataset)
+
+    closed_connections = set()
+    for dataset in datasets:
+        connection = getattr(dataset, "conn", dataset)
+        close = getattr(connection, "close", None)
+        if not callable(close) or id(connection) in closed_connections:
+            continue
+        close()
+        closed_connections.add(id(connection))
+
+    qtw.QApplication.processEvents()
+    gc.collect()
 
 
 def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
@@ -330,6 +394,7 @@ def test_atomic_replacement_reloads_every_real_qcodes_runtime_object(
         window.refreshMain()
         assert window._database_refresh_pending
 
+        release_windows_database_locks(window, database_path)
         os.replace(replacement_path, database_path)
         replacement_artifacts = database_artifact_state(database_path)
         release_refresh.set()
@@ -402,119 +467,104 @@ def test_atomic_replacement_of_live_wal_uses_new_main_without_source_writes(
     original_database_path = qcodes.config.core.db_location
     database_path = Path(tmp_path) / "live-replaced.db"
     replacement_path = Path(tmp_path) / "replacement.db"
-    experiment = None
     window = None
 
     try:
-        initialise_or_create_database_at(str(database_path), journal_mode="WAL")
-        experiment = load_or_create_experiment(
-            "live_replacement",
-            sample_name="stale_sidecar",
+        build_line_database_with_replayed_stale_wal(database_path)
+        assert Path(f"{database_path}-wal").is_file()
+        assert Path(f"{database_path}-shm").is_file()
+
+        window = main_window.MainWindow()
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
         )
-        gate = ManualParameter("gate")
-        signal = ManualParameter("signal")
-        measurement = Measurement(exp=experiment, name="old_live_run")
-        measurement.register_parameter(gate)
-        measurement.register_parameter(signal, setpoints=(gate,))
+        window.monitor.stop()
+        assert window.ds is not None
+        old_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[old_parameter], show=False)
+        old_plot = window.windows[-1]
+        wait_for(lambda: not getattr(old_plot.worker, "running", False))
+        old_handle = window.dataset_holder[old_plot._dataset_key]
+        assert old_plot.axis_data["y"].size == 1
+        old_wal_identity = database_file_identity(f"{database_path}-wal")
+        assert old_wal_identity is not None
 
-        with measurement.run(write_in_background=False) as datasaver:
-            datasaver.add_result((gate, 0.0), (signal, 10.0))
-            datasaver.flush_data_to_database(block=True)
-            assert Path(f"{database_path}-wal").is_file()
-            assert Path(f"{database_path}-shm").is_file()
-
-            window = main_window.MainWindow()
-            window.startupDatabaseTimer.stop()
-            window.monitor.stop()
-            window.config.config["user_preference"]["confirm_close"] = False
-            window.config.config["user_preference"]["confirm_close_all"] = False
-            window.close_database(status=False)
-            assert window.load_file(str(database_path))
-            wait_for(
-                lambda: (
-                    not window._database_load_active
-                    and not window._database_detail_active
-                    and not window._database_expensive_detail_active
+        generate_database(
+            [
+                RunSpecification(
+                    1,
+                    "replacement_signal",
+                    "Replacement signal",
+                    "V",
+                    -1.0,
+                    1.0,
+                    4,
                 )
+            ],
+            replacement_path,
+        )
+        release_windows_database_locks(window, database_path)
+        os.replace(replacement_path, database_path)
+        replacement_artifacts = database_artifact_state(database_path)
+        assert replacement_artifacts["-wal"] is not None
+        assert replacement_artifacts["-shm"] is not None
+        assert database_file_identity(f"{database_path}-wal") == old_wal_identity
+
+        # Deliberately take a plot action before MainWindow's refresh timer
+        # can observe the replacement. It must start the replacement reload
+        # without opening the new main together with the old WAL.
+        window.show_error = lambda *_args, **_kwargs: None
+        direct_dataset_reads = []
+        original_loader = plot_actions_module.load_by_guid_read_only
+
+        def record_direct_dataset_read(*args, **kwargs):
+            direct_dataset_reads.append((args, kwargs))
+            return original_loader(*args, **kwargs)
+
+        with monkeypatch.context() as scoped_monkeypatch:
+            scoped_monkeypatch.setattr(
+                plot_actions_module,
+                "load_by_guid_read_only",
+                record_direct_dataset_read,
             )
-            window.monitor.stop()
-            assert window.ds is not None
-            old_parameter = dependent_parameter(window.ds, 1)
             window.openPlot(params=[old_parameter], show=False)
-            old_plot = window.windows[-1]
-            wait_for(lambda: not getattr(old_plot.worker, "running", False))
-            old_handle = window.dataset_holder[old_plot._dataset_key]
-            assert old_plot.axis_data["y"].size == 1
-            old_wal_identity = database_file_identity(f"{database_path}-wal")
-            assert old_wal_identity is not None
+            assert direct_dataset_reads == []
 
-            generate_database(
-                [
-                    RunSpecification(
-                        1,
-                        "replacement_signal",
-                        "Replacement signal",
-                        "V",
-                        -1.0,
-                        1.0,
-                        4,
-                    )
-                ],
-                replacement_path,
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_refresh_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
             )
-            os.replace(replacement_path, database_path)
-            replacement_artifacts = database_artifact_state(database_path)
-            assert replacement_artifacts["-wal"] is not None
-            assert replacement_artifacts["-shm"] is not None
-            assert database_file_identity(f"{database_path}-wal") == old_wal_identity
+        )
+        window.monitor.stop()
 
-            # Deliberately take a plot action before MainWindow's refresh timer
-            # can observe the replacement. It must start the replacement reload
-            # without opening the new main together with the old WAL.
-            window.show_error = lambda *_args, **_kwargs: None
-            direct_dataset_reads = []
-            original_loader = plot_actions_module.load_by_guid_read_only
-
-            def record_direct_dataset_read(*args, **kwargs):
-                direct_dataset_reads.append((args, kwargs))
-                return original_loader(*args, **kwargs)
-
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    plot_actions_module,
-                    "load_by_guid_read_only",
-                    record_direct_dataset_read,
-                )
-                window.openPlot(params=[old_parameter], show=False)
-                assert direct_dataset_reads == []
-
-            wait_for(
-                lambda: (
-                    not window._database_load_active
-                    and not window._database_refresh_active
-                    and not window._database_detail_active
-                    and not window._database_expensive_detail_active
-                )
-            )
-            window.monitor.stop()
-
-            metadata = next(iter(window.RunList.all_run_metadata().values()))
-            assert metadata["result_count"] == 4
-            assert old_plot not in window.windows
-            assert old_handle.closed
-            assert window.ds is not None
-            new_parameter = dependent_parameter(window.ds, 1)
-            window.openPlot(params=[new_parameter], show=False)
-            new_plot = window.windows[-1]
-            wait_for(lambda: not getattr(new_plot.worker, "running", False))
-            assert new_plot.axis_data["x"].size == 4
-            assert new_plot.axis_data["y"].size == 4
-            assert database_artifact_state(database_path) == replacement_artifacts
+        metadata = next(iter(window.RunList.all_run_metadata().values()))
+        assert metadata["result_count"] == 4
+        assert old_plot not in window.windows
+        assert old_handle.closed
+        assert window.ds is not None
+        new_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[new_parameter], show=False)
+        new_plot = window.windows[-1]
+        wait_for(lambda: not getattr(new_plot.worker, "running", False))
+        assert new_plot.axis_data["x"].size == 4
+        assert new_plot.axis_data["y"].size == 4
+        assert database_artifact_state(database_path) == replacement_artifacts
     finally:
         if window is not None:
             close_main_window(window)
-        if experiment is not None:
-            experiment.conn.close()
         qcodes.config.core.db_location = original_database_path
 
 
@@ -526,103 +576,88 @@ def test_existing_live_plot_refresh_quarantines_replaced_wal_before_worker_read(
     original_database_path = qcodes.config.core.db_location
     database_path = Path(tmp_path) / "live-refresh-replaced.db"
     replacement_path = Path(tmp_path) / "live-refresh-replacement.db"
-    experiment = None
     window = None
 
     try:
-        initialise_or_create_database_at(str(database_path), journal_mode="WAL")
-        experiment = load_or_create_experiment(
-            "live_refresh_replacement",
-            sample_name="stale_plot",
+        build_line_database_with_replayed_stale_wal(database_path)
+        assert Path(f"{database_path}-wal").is_file()
+
+        window = main_window.MainWindow()
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
         )
-        gate = ManualParameter("gate")
-        signal = ManualParameter("signal")
-        measurement = Measurement(exp=experiment, name="old_live_run")
-        measurement.register_parameter(gate)
-        measurement.register_parameter(signal, setpoints=(gate,))
+        window.monitor.stop()
+        old_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[old_parameter], show=False)
+        old_plot = window.windows[-1]
+        wait_for(lambda: not getattr(old_plot.worker, "running", False))
+        old_worker = old_plot.worker
+        old_handle = window.dataset_holder[old_plot._dataset_key]
 
-        with measurement.run(write_in_background=False) as datasaver:
-            datasaver.add_result((gate, 0.0), (signal, 10.0))
-            datasaver.flush_data_to_database(block=True)
-            assert Path(f"{database_path}-wal").is_file()
-
-            window = main_window.MainWindow()
-            window.startupDatabaseTimer.stop()
-            window.monitor.stop()
-            window.config.config["user_preference"]["confirm_close"] = False
-            window.config.config["user_preference"]["confirm_close_all"] = False
-            window.close_database(status=False)
-            assert window.load_file(str(database_path))
-            wait_for(
-                lambda: (
-                    not window._database_load_active
-                    and not window._database_detail_active
-                    and not window._database_expensive_detail_active
+        generate_database(
+            [
+                RunSpecification(
+                    1,
+                    "replacement_signal",
+                    "Replacement signal",
+                    "V",
+                    -1.0,
+                    1.0,
+                    4,
                 )
+            ],
+            replacement_path,
+        )
+        release_windows_database_locks(window, database_path)
+        os.replace(replacement_path, database_path)
+        replacement_artifacts = database_artifact_state(database_path)
+        assert replacement_artifacts["-wal"] is not None
+
+        worker_database_reads = []
+        original_prep = worker_module.load_param_data_from_db_prep
+        original_load = worker_module.load_param_data_from_db
+
+        def record_prep(*args, **kwargs):
+            worker_database_reads.append("prep")
+            return original_prep(*args, **kwargs)
+
+        def record_load(*args, **kwargs):
+            worker_database_reads.append("load")
+            return original_load(*args, **kwargs)
+
+        monkeypatch.setattr(worker_module, "load_param_data_from_db_prep", record_prep)
+        monkeypatch.setattr(worker_module, "load_param_data_from_db", record_load)
+        old_plot.refreshWindow(force=True)
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_refresh_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
             )
-            window.monitor.stop()
-            old_parameter = dependent_parameter(window.ds, 1)
-            window.openPlot(params=[old_parameter], show=False)
-            old_plot = window.windows[-1]
-            wait_for(lambda: not getattr(old_plot.worker, "running", False))
-            old_worker = old_plot.worker
-            old_handle = window.dataset_holder[old_plot._dataset_key]
+        )
+        window.monitor.stop()
 
-            generate_database(
-                [
-                    RunSpecification(
-                        1,
-                        "replacement_signal",
-                        "Replacement signal",
-                        "V",
-                        -1.0,
-                        1.0,
-                        4,
-                    )
-                ],
-                replacement_path,
-            )
-            os.replace(replacement_path, database_path)
-            replacement_artifacts = database_artifact_state(database_path)
-            assert replacement_artifacts["-wal"] is not None
-
-            worker_database_reads = []
-            original_prep = worker_module.load_param_data_from_db_prep
-            original_load = worker_module.load_param_data_from_db
-
-            def record_prep(*args, **kwargs):
-                worker_database_reads.append("prep")
-                return original_prep(*args, **kwargs)
-
-            def record_load(*args, **kwargs):
-                worker_database_reads.append("load")
-                return original_load(*args, **kwargs)
-
-            monkeypatch.setattr(worker_module, "load_param_data_from_db_prep", record_prep)
-            monkeypatch.setattr(worker_module, "load_param_data_from_db", record_load)
-            old_plot.refreshWindow(force=True)
-            wait_for(
-                lambda: (
-                    not window._database_load_active
-                    and not window._database_refresh_active
-                    and not window._database_detail_active
-                    and not window._database_expensive_detail_active
-                )
-            )
-            window.monitor.stop()
-
-            assert old_plot.worker is old_worker
-            assert worker_database_reads == []
-            assert old_plot not in window.windows
-            assert old_handle.closed
-            metadata = next(iter(window.RunList.all_run_metadata().values()))
-            assert metadata["result_count"] == 4
-            assert database_artifact_state(database_path) == replacement_artifacts
+        assert old_plot.worker is old_worker
+        assert worker_database_reads == []
+        assert old_plot not in window.windows
+        assert old_handle.closed
+        metadata = next(iter(window.RunList.all_run_metadata().values()))
+        assert metadata["result_count"] == 4
+        assert database_artifact_state(database_path) == replacement_artifacts
     finally:
         if window is not None:
             close_main_window(window)
-        if experiment is not None:
-            experiment.conn.close()
         qcodes.config.core.db_location = original_database_path
 
 
@@ -702,6 +737,7 @@ def test_replaced_background_plot_does_not_switch_current_database(
         assert source_plot._merged_trace_users == 1
         assert source_key in window.dataset_holder
 
+        release_windows_database_locks(window, database_a)
         os.replace(replacement_a, database_a)
         source_plot.refreshWindow(force=True)
         wait_for(
@@ -868,6 +904,7 @@ def test_loaded_path_test_database_generation_uses_replacement_reload(
         wait_for(lambda: not getattr(old_plot.worker, "running", False))
         old_handle = window.dataset_holder[old_plot._dataset_key]
 
+        release_windows_database_locks(window, database_path)
         generate_database(
             [replacement_specification],
             database_path,

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -24,6 +24,10 @@ from qcodes.parameters import ManualParameter
 import qplot.tools.worker as worker_module
 from qplot.configuration.config import config
 from qplot.datahandling import database as database_module
+from qplot.datahandling.file_identity import (
+    canonical_database_path,
+    logical_database_path,
+)
 from qplot.datahandling.qcodes_cache import (
     cache_parameter_data,
     cache_parameter_is_synchronized,
@@ -194,6 +198,25 @@ def database_artifact_state(database_path):
     return state
 
 
+def symlink_source_artifact_state(view_path, *target_paths):
+    """Record a symlink entry and every possible database target/sidecar."""
+
+    link_stat = view_path.lstat()
+    return {
+        "link": (
+            os.readlink(view_path),
+            link_stat.st_mode,
+            link_stat.st_size,
+            link_stat.st_mtime_ns,
+        ),
+        "targets": {
+            str(path): database_artifact_state(path)
+            for path in target_paths
+            if path.exists()
+        },
+    }
+
+
 def release_windows_database_locks(window, database_path, *extra_datasets):
     """Release test-only SQLite handles before a Windows atomic replacement.
 
@@ -211,11 +234,17 @@ def release_windows_database_locks(window, database_path, *extra_datasets):
     selected_key = getattr(window, "_selected_dataset_key", None)
     if (
             selected_key is not None
-            and Path(selected_key.database_path).resolve() == source_path
+            and (
+                Path(selected_key.database_path).resolve() == source_path
+                or Path(selected_key.resolved_database_path) == source_path
+            )
             ):
         datasets.append(getattr(window, "ds", None))
     for dataset_key, handle in getattr(window, "dataset_holder", {}).items():
-        if Path(dataset_key.database_path).resolve() == source_path:
+        if (
+                Path(dataset_key.database_path).resolve() == source_path
+                or Path(dataset_key.resolved_database_path) == source_path
+                ):
             datasets.append(handle.dataset)
 
     closed_connections = set()
@@ -465,6 +494,132 @@ def test_atomic_replacement_reloads_every_real_qcodes_runtime_object(
         qcodes.config.core.db_location = original_database_path
 
 
+@pytest.mark.parametrize("replacement_kind", ["symlink_entry", "target_file"])
+def test_symlinked_database_replacement_retires_the_accepted_instance(
+    tmp_path,
+    monkeypatch,
+    replacement_kind,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    target_a = Path(tmp_path) / "target-a.db"
+    target_b = Path(tmp_path) / "target-b.db"
+    view_path = Path(tmp_path) / "view.db"
+    next_link = Path(tmp_path) / "next-view.db"
+    _run_id, guid, _table_name = build_line_database(target_a, 3)
+    _new_run_id, new_guid, _new_table_name = build_line_database(
+        target_b,
+        4,
+        guid=guid,
+    )
+    assert new_guid == guid
+    try:
+        view_path.symlink_to(target_a)
+    except OSError as error:
+        pytest.skip(f"This platform cannot create the required symlink: {error}")
+
+    window = main_window.MainWindow()
+    original_load_file = window.load_file
+    replacement_loads = []
+
+    def record_load(*args, **kwargs):
+        replacement_loads.append((args, kwargs))
+        return original_load_file(*args, **kwargs)
+
+    try:
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        assert window.load_file(str(view_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        assert window.ds is not None
+        assert window.ds.number_of_results == 3
+
+        parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[parameter], show=False)
+        old_plot = window.windows[-1]
+        wait_for(lambda: not getattr(old_plot.worker, "running", False))
+        old_key = old_plot._dataset_key
+        old_handle = window.dataset_holder[old_key]
+        old_dataset = old_handle.dataset
+        assert old_key.database_path == logical_database_path(view_path)
+        assert old_key.resolved_database_path == canonical_database_path(target_a)
+        assert old_plot.axis_data["y"].size == 3
+
+        window.infoBox.preview.cache[guid] = [{"stale": True}]
+        window.infoBox._setpoint_summary_cache["stale"] = "old instance"
+        window.load_file = record_load
+
+        if replacement_kind == "symlink_entry":
+            next_link.symlink_to(target_b)
+            os.replace(next_link, view_path)
+            artifact_targets = (target_a, target_b)
+        else:
+            release_windows_database_locks(window, target_a)
+            os.replace(target_b, target_a)
+            artifact_targets = (target_a,)
+        replacement_artifacts = symlink_source_artifact_state(
+            view_path,
+            *artifact_targets,
+        )
+
+        window.refreshMain()
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_refresh_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+
+        metadata = next(iter(window.RunList.all_run_metadata().values()))
+        assert metadata["result_count"] == 4
+        assert window.ds is not None
+        assert window.ds.guid == guid
+        assert window.ds.number_of_results == 4
+        assert old_plot not in window.windows
+        assert old_handle.closed
+        assert old_key not in window.dataset_holder
+        with pytest.raises((sqlite3.ProgrammingError, RuntimeError)):
+            old_dataset.conn.cursor()
+        assert window.infoBox.preview.cache.get(guid) != [{"stale": True}]
+        assert "stale" not in window.infoBox._setpoint_summary_cache
+
+        new_key = window._current_dataset_key(guid)
+        assert new_key.database_path == logical_database_path(view_path)
+        assert new_key.resolved_database_path == canonical_database_path(view_path)
+        assert new_key != old_key
+        new_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[new_parameter], show=False)
+        new_plot = window.windows[-1]
+        wait_for(lambda: not getattr(new_plot.worker, "running", False))
+        assert new_plot.axis_data["x"].size == 4
+        assert new_plot.axis_data["y"].size == 4
+
+        qtw.QApplication.processEvents()
+        assert len(replacement_loads) == 1
+        assert replacement_loads[0][1] == {"force": True, "replacement": True}
+        assert symlink_source_artifact_state(
+            view_path,
+            *artifact_targets,
+        ) == replacement_artifacts
+    finally:
+        window.load_file = original_load_file
+        close_main_window(window)
+        qcodes.config.core.db_location = original_database_path
+
+
 def test_atomic_replacement_of_live_wal_uses_new_main_without_source_writes(
     tmp_path,
     monkeypatch,
@@ -679,6 +834,8 @@ def test_replaced_background_plot_does_not_switch_current_database(
     original_database_path = qcodes.config.core.db_location
     database_a = Path(tmp_path) / "source-a.db"
     replacement_a = Path(tmp_path) / "source-a-replacement.db"
+    source_view = Path(tmp_path) / "source-view.db"
+    replacement_view = Path(tmp_path) / "source-view-replacement.db"
     database_b = Path(tmp_path) / "source-b.db"
     _run_a, guid_a, _table_a = build_line_database(database_a, 3)
     _run_b, guid_b, _table_b = build_line_database(database_b, 2)
@@ -688,6 +845,10 @@ def test_replaced_background_plot_does_not_switch_current_database(
         guid=guid_a,
     )
     assert replacement_guid == guid_a
+    try:
+        source_view.symlink_to(database_a)
+    except OSError as error:
+        pytest.skip(f"This platform cannot create the required symlink: {error}")
 
     window = main_window.MainWindow()
     try:
@@ -697,7 +858,7 @@ def test_replaced_background_plot_does_not_switch_current_database(
         window.config.config["user_preference"]["confirm_close_all"] = False
         window.config.config["runtime_settings"]["del_grace_period"] = 0
         window.close_database(status=False)
-        assert window.load_file(str(database_a))
+        assert window.load_file(str(source_view))
         wait_for(
             lambda: (
                 not window._database_load_active
@@ -747,8 +908,14 @@ def test_replaced_background_plot_does_not_switch_current_database(
         assert source_plot._merged_trace_users == 1
         assert source_key in window.dataset_holder
 
-        release_windows_database_locks(window, database_a)
-        os.replace(replacement_a, database_a)
+        replacement_view.symlink_to(replacement_a)
+        os.replace(replacement_view, source_view)
+        replacement_artifacts = symlink_source_artifact_state(
+            source_view,
+            database_a,
+            replacement_a,
+            database_b,
+        )
         source_plot.refreshWindow(force=True)
         wait_for(
             lambda: (
@@ -767,6 +934,12 @@ def test_replaced_background_plot_does_not_switch_current_database(
         assert window._loaded_database_identity == database_file_identity(database_b)
         assert window.ds is not None
         assert window.ds.guid == guid_b
+        assert symlink_source_artifact_state(
+            source_view,
+            database_a,
+            replacement_a,
+            database_b,
+        ) == replacement_artifacts
     finally:
         close_main_window(window)
         qcodes.config.core.db_location = original_database_path

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -1,10 +1,13 @@
 import hashlib
+import os
+import sqlite3
 import threading
 import time
 from pathlib import Path
-from time import perf_counter
+from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import qcodes
 from PyQt6 import QtCore
 from PyQt6 import QtWidgets as qtw
@@ -18,18 +21,15 @@ from qcodes.parameters import ManualParameter
 
 import qplot.tools.worker as worker_module
 from qplot.configuration.config import config
+from qplot.datahandling import database as database_module
 from qplot.datahandling.qcodes_cache import (
     cache_parameter_data,
     cache_parameter_is_synchronized,
 )
-from qplot.datahandling.readonly import (
-    load_by_id_read_only,
-    set_qcodes_database_location,
-)
-from qplot.tools.worker import loader
+from qplot.testdata import RunSpecification, generate_database
+from qplot.windows import _plot_actions as plot_actions_module
 from qplot.windows import main as main_window
-from qplot.windows._dataset_handle import DatasetHandle, DatasetKey
-from qplot.windows._plotWin import plotWidget
+from qplot.windows._dataset_handle import database_file_identity
 
 
 def configure_temp_qplot(monkeypatch, tmp_path):
@@ -88,6 +88,42 @@ def build_synthetic_database(db_path):
     return line_run_id, heatmap_run_id
 
 
+def build_line_database(db_path, point_count, *, guid=None, journal_mode=None):
+    kwargs = {} if journal_mode is None else {"journal_mode": journal_mode}
+    initialise_or_create_database_at(str(db_path), **kwargs)
+    experiment = load_or_create_experiment(
+        f"qplot_replace_{db_path.stem}",
+        sample_name="replacement",
+    )
+    gate = ManualParameter("gate", label="Gate voltage", unit="V")
+    signal = ManualParameter("signal", label="Signal", unit="nA")
+    measurement = Measurement(exp=experiment, name="replaceable_run")
+    measurement.register_parameter(gate)
+    measurement.register_parameter(signal, setpoints=(gate,))
+    with measurement.run(write_in_background=False) as datasaver:
+        for index in range(point_count):
+            datasaver.add_result((gate, float(index)), (signal, float(index + 10)))
+        dataset = datasaver.dataset
+        run_id = dataset.run_id
+        generated_guid = dataset.guid
+        table_name = dataset.table_name
+    dataset.conn.close()
+
+    if guid is not None and guid != generated_guid:
+        connection = sqlite3.connect(db_path)
+        try:
+            connection.execute(
+                "UPDATE runs SET guid = ? WHERE run_id = ?",
+                (guid, run_id),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        generated_guid = guid
+
+    return run_id, generated_guid, table_name
+
+
 def dependent_parameter(dataset, dimensions):
     for param in dataset.get_parameters():
         if param.depends_on and len(param.depends_on_) == dimensions:
@@ -123,17 +159,6 @@ def database_artifact_state(database_path):
             hashlib.sha256(path.read_bytes()).hexdigest(),
             )
     return state
-
-
-def run_plot_worker_on_thread(worker):
-    errors = []
-    worker.emitter.errorOccurred.connect(errors.append)
-    thread = threading.Thread(target=worker.run)
-    thread.start()
-    thread.join(10)
-    qtw.QApplication.processEvents()
-    assert not thread.is_alive()
-    return errors
 
 
 def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
@@ -217,207 +242,665 @@ def test_main_window_opens_real_1d_and_2d_plots(tmp_path, monkeypatch):
         close_main_window(window)
 
 
-def test_threaded_live_run_completion_commits_final_rows_before_stopping_monitor(
+def test_atomic_replacement_reloads_every_real_qcodes_runtime_object(
     tmp_path,
     monkeypatch,
 ):
-    database_path = Path(tmp_path) / "threaded-live-run.db"
+    configure_temp_qplot(monkeypatch, tmp_path)
     original_database_path = qcodes.config.core.db_location
-    initial_row_written = threading.Event()
-    finish_writer = threading.Event()
-    writer_state = {}
-    writer_errors = []
-    viewer_dataset = None
+    database_path = Path(tmp_path) / "loaded.db"
+    replacement_path = Path(tmp_path) / "replacement.db"
+    _run_id, guid, table_name = build_line_database(database_path, 3)
+    _replacement_run_id, replacement_guid, replacement_table = build_line_database(
+        replacement_path,
+        4,
+        guid=guid,
+    )
+    assert replacement_guid == guid
+    assert replacement_table == table_name
 
-    def write_measurement():
-        try:
-            initialise_or_create_database_at(str(database_path), journal_mode="WAL")
-            experiment = load_or_create_experiment(
-                "threaded_live_run",
-                sample_name="completion_race",
-                )
-            gate = ManualParameter("gate")
-            signal = ManualParameter("signal")
-            measurement = Measurement(exp=experiment, name="completion_race")
-            measurement.register_parameter(gate)
-            measurement.register_parameter(signal, setpoints=(gate,))
-            with measurement.run(write_in_background=False) as datasaver:
-                datasaver.add_result((gate, 0.0), (signal, 10.0))
-                datasaver.flush_data_to_database(block=True)
-                writer_state["run_id"] = datasaver.dataset.run_id
-                initial_row_written.set()
-                if not finish_writer.wait(10):
-                    raise TimeoutError("Test did not release the measurement writer")
-                datasaver.add_result((gate, 1.0), (signal, 11.0))
-                datasaver.add_result((gate, 2.0), (signal, 12.0))
-            datasaver.dataset.conn.close()
-        except BaseException as error:
-            writer_errors.append(error)
-            initial_row_written.set()
+    window = main_window.MainWindow()
+    refresh_sql_finished = threading.Event()
+    release_refresh = threading.Event()
+    status_messages = []
+    original_show_status = window.show_status
+    original_get_run_status = database_module.get_run_status
+    replacement_loads = []
+    original_load_file = window.load_file
 
-    writer_thread = threading.Thread(target=write_measurement)
-    writer_thread.start()
+    def record_status(message, timeout=5000):
+        status_messages.append((message, timeout))
+        return original_show_status(message, timeout)
+
+    def block_completed_status(*args, **kwargs):
+        status = original_get_run_status(*args, **kwargs)
+        refresh_sql_finished.set()
+        if not release_refresh.wait(10):
+            raise TimeoutError("Test did not release the database refresh worker")
+        return status
+
+    def record_load(*args, **kwargs):
+        replacement_loads.append((args, kwargs))
+        return original_load_file(*args, **kwargs)
 
     try:
-        assert initial_row_written.wait(10)
-        assert writer_errors == []
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        window.show_status = record_status
 
-        set_qcodes_database_location(database_path)
-        viewer_dataset = load_by_id_read_only(writer_state["run_id"])
-        assert viewer_dataset.running
-        assert viewer_dataset.number_of_results == 1
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        assert window.ds is not None
+        assert window.ds.guid == guid
+        assert window.ds.number_of_results == 3
 
-        parameter = dependent_parameter(viewer_dataset, 1)
-        parameter._complete = False
-        parameters = {
-            candidate.name: candidate
-            for candidate in viewer_dataset.get_parameters()
-            }
-        parameters[parameter.name] = parameter
-        axes = {"x": parameter.depends_on_[0]}
+        parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[parameter], show=False)
+        old_plot = window.windows[-1]
+        wait_for(lambda: not getattr(old_plot.worker, "running", False))
+        old_key = old_plot._dataset_key
+        old_handle = window.dataset_holder[old_key]
+        old_dataset = old_handle.dataset
+        assert old_dataset.number_of_results == 3
+        assert old_key.database_identity == database_file_identity(database_path)
 
-        finish_writer.set()
-        writer_thread.join(10)
-        assert not writer_thread.is_alive()
-        assert writer_errors == []
-        assert viewer_dataset.running
-        # The source-preserving viewer connection is intentionally pinned to
-        # the WAL snapshot from when the run was opened. Plot workers must use
-        # fresh read-only snapshots to discover the committed final rows.
-        assert viewer_dataset.number_of_results == 1
-
-        writer_complete_artifacts = database_artifact_state(database_path)
-        assert set(writer_complete_artifacts) == {"", "-wal", "-shm", "-journal"}
-        assert writer_complete_artifacts[""] is not None
-
-        original_load = worker_module.load_param_data_from_db
-
-        def fail_final_load(*_args, **_kwargs):
-            raise RuntimeError("injected final-load failure")
+        stale_preview = [{"stale": True}]
+        window.infoBox.preview.cache[guid] = stale_preview
+        window.infoBox._setpoint_summary_cache["stale"] = "old instance"
+        window.RunList.watching = [SimpleNamespace(guid=guid)]
+        window.load_file = record_load
 
         monkeypatch.setattr(
-            worker_module,
-            "load_param_data_from_db",
-            fail_final_load,
+            database_module,
+            "get_run_status",
+            block_completed_status,
+        )
+        window.refreshMain()
+        assert refresh_sql_finished.wait(10)
+        window.refreshMain()
+        assert window._database_refresh_pending
+
+        os.replace(replacement_path, database_path)
+        replacement_artifacts = database_artifact_state(database_path)
+        release_refresh.set()
+
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_refresh_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+                and window._loaded_database_identity
+                == database_file_identity(database_path)
             )
-        failed_worker = loader(
-            viewer_dataset.cache,
-            parameter,
-            parameters,
-            axes,
-            )
-        failed_errors = run_plot_worker_on_thread(failed_worker)
+        )
+        window.monitor.stop()
 
-        assert len(failed_errors) == 1
-        assert "injected final-load failure" in str(failed_errors[0])
-        assert failed_worker.dataset_completed is True
-        assert viewer_dataset.running
-        assert not viewer_dataset.completed
-        assert not parameter._complete
+        runs = window.RunList.all_run_metadata()
+        replacement_metadata = next(
+            metadata for metadata in runs.values() if metadata["guid"] == guid
+        )
+        assert replacement_metadata["result_count"] == 4
+        assert window.infoBox.preview.run_metadata[guid]["result_count"] == 4
+        assert window.infoBox.preview.cache.get(guid) != stale_preview
+        assert "stale" not in window.infoBox._setpoint_summary_cache
+        assert old_plot not in window.windows
+        assert old_handle.closed
+        assert old_key not in window.dataset_holder
+        with pytest.raises((sqlite3.ProgrammingError, RuntimeError)):
+            old_dataset.conn.cursor()
 
-        class Monitor:
-            def __init__(self):
-                self.active = True
-                self.stop_count = 0
+        new_key = window._current_dataset_key(guid)
+        assert new_key != old_key
+        with pytest.raises(RuntimeError, match="replaced"):
+            window._dataset_for_key(old_key)
 
-            def stop(self):
-                self.active = False
-                self.stop_count += 1
+        assert window.ds is not None
+        assert window.ds.guid == guid
+        assert window.ds.number_of_results == 4
+        new_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[new_parameter], show=False)
+        new_plot = window.windows[-1]
+        wait_for(lambda: not getattr(new_plot.worker, "running", False))
+        new_handle = window.dataset_holder[new_plot._dataset_key]
+        assert new_handle is not old_handle
+        assert new_handle.database_identity == database_file_identity(database_path)
+        assert new_handle.dataset.number_of_results == 4
+        assert new_plot.axis_data["x"].size == 4
+        assert new_plot.axis_data["y"].size == 4
 
-        class SpinBox:
-            def value(self):
-                return 0.1
-
-        class EndWait:
-            def __init__(self):
-                self.count = 0
-
-            def emit(self):
-                self.count += 1
-
-        dataset_key = DatasetKey(database_path, viewer_dataset.guid)
-        window = plotWidget.__new__(plotWidget)
-        window._dataset_key = dataset_key
-        window._dataset_holder = {
-            dataset_key: DatasetHandle(viewer_dataset),
-            }
-        window._guid = viewer_dataset.guid
-        window.param = parameter
-        window.worker = failed_worker
-        window.monitor = Monitor()
-        window.spinBox = SpinBox()
-        window.end_wait = EndWait()
-        window._last_error_text = None
-        window.show_status = lambda *_args, **_kwargs: None
-        window.show_plot_state = lambda *_args, **_kwargs: None
-        window.hide_plot_state = lambda: None
-        window._set_param_axis_labels = lambda: None
-        monitor_restarts = []
-
-        def restart_monitor(interval):
-            monitor_restarts.append(interval)
-            window.monitor.active = True
-
-        window.monitorIntervalChanged = restart_monitor
-
-        assert plotWidget.refreshPlot(window, False, worker=failed_worker) is False
-        window.last_ds_len = viewer_dataset.number_of_results
-        retry_requests = []
-        window.load_data = lambda: retry_requests.append(True)
-
-        plotWidget.refreshWindow(window)
-
-        assert retry_requests == [True]
-        assert monitor_restarts == [0.1]
-        assert window.monitor.active
-
-        monkeypatch.setattr(
-            worker_module,
-            "load_param_data_from_db",
-            original_load,
-            )
-        successful_worker = loader(
-            viewer_dataset.cache,
-            parameter,
-            parameters,
-            axes,
-            )
-        successful_worker.started_at = perf_counter()
-        successful_worker.dataset_length_at_start = viewer_dataset.number_of_results
-        successful_errors = run_plot_worker_on_thread(successful_worker)
-
-        assert successful_errors == []
-        assert successful_worker.dataset_completed is True
-        assert viewer_dataset.running
-
-        window.worker = successful_worker
-        assert plotWidget.refreshPlot(window, True, worker=successful_worker) is True
-
-        np.testing.assert_array_equal(
-            cache_parameter_data(viewer_dataset.cache, parameter.name)["gate"],
-            [0.0, 1.0, 2.0],
-            )
-        np.testing.assert_array_equal(
-            cache_parameter_data(viewer_dataset.cache, parameter.name)["signal"],
-            [10.0, 11.0, 12.0],
-            )
-        np.testing.assert_array_equal(window.axis_data["x"], [0.0, 1.0, 2.0])
-        np.testing.assert_array_equal(window.axis_data["y"], [10.0, 11.0, 12.0])
-        assert viewer_dataset.completed
-        assert not viewer_dataset.running
-        assert parameter._complete
-
-        previous_restart_count = len(monitor_restarts)
-        plotWidget.refreshWindow(window)
-        assert len(monitor_restarts) == previous_restart_count
-        assert not window.monitor.active
-        assert retry_requests == [True]
-        assert database_artifact_state(database_path) == writer_complete_artifacts
+        qtw.QApplication.processEvents()
+        assert len(replacement_loads) == 1
+        assert replacement_loads[0][1] == {"force": True, "replacement": True}
+        assert any(
+            "Database was replaced and reloaded" in message
+            for message, _timeout in status_messages
+        )
+        assert database_artifact_state(database_path) == replacement_artifacts
     finally:
-        finish_writer.set()
-        writer_thread.join(10)
-        if viewer_dataset is not None:
-            viewer_dataset.conn.close()
+        release_refresh.set()
+        window.load_file = original_load_file
+        close_main_window(window)
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_atomic_replacement_of_live_wal_uses_new_main_without_source_writes(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    database_path = Path(tmp_path) / "live-replaced.db"
+    replacement_path = Path(tmp_path) / "replacement.db"
+    experiment = None
+    window = None
+
+    try:
+        initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+        experiment = load_or_create_experiment(
+            "live_replacement",
+            sample_name="stale_sidecar",
+        )
+        gate = ManualParameter("gate")
+        signal = ManualParameter("signal")
+        measurement = Measurement(exp=experiment, name="old_live_run")
+        measurement.register_parameter(gate)
+        measurement.register_parameter(signal, setpoints=(gate,))
+
+        with measurement.run(write_in_background=False) as datasaver:
+            datasaver.add_result((gate, 0.0), (signal, 10.0))
+            datasaver.flush_data_to_database(block=True)
+            assert Path(f"{database_path}-wal").is_file()
+            assert Path(f"{database_path}-shm").is_file()
+
+            window = main_window.MainWindow()
+            window.startupDatabaseTimer.stop()
+            window.monitor.stop()
+            window.config.config["user_preference"]["confirm_close"] = False
+            window.config.config["user_preference"]["confirm_close_all"] = False
+            window.close_database(status=False)
+            assert window.load_file(str(database_path))
+            wait_for(
+                lambda: (
+                    not window._database_load_active
+                    and not window._database_detail_active
+                    and not window._database_expensive_detail_active
+                )
+            )
+            window.monitor.stop()
+            assert window.ds is not None
+            old_parameter = dependent_parameter(window.ds, 1)
+            window.openPlot(params=[old_parameter], show=False)
+            old_plot = window.windows[-1]
+            wait_for(lambda: not getattr(old_plot.worker, "running", False))
+            old_handle = window.dataset_holder[old_plot._dataset_key]
+            assert old_plot.axis_data["y"].size == 1
+            old_wal_identity = database_file_identity(f"{database_path}-wal")
+            assert old_wal_identity is not None
+
+            generate_database(
+                [
+                    RunSpecification(
+                        1,
+                        "replacement_signal",
+                        "Replacement signal",
+                        "V",
+                        -1.0,
+                        1.0,
+                        4,
+                    )
+                ],
+                replacement_path,
+            )
+            os.replace(replacement_path, database_path)
+            replacement_artifacts = database_artifact_state(database_path)
+            assert replacement_artifacts["-wal"] is not None
+            assert replacement_artifacts["-shm"] is not None
+            assert database_file_identity(f"{database_path}-wal") == old_wal_identity
+
+            # Deliberately take a plot action before MainWindow's refresh timer
+            # can observe the replacement. It must start the replacement reload
+            # without opening the new main together with the old WAL.
+            window.show_error = lambda *_args, **_kwargs: None
+            direct_dataset_reads = []
+            original_loader = plot_actions_module.load_by_guid_read_only
+
+            def record_direct_dataset_read(*args, **kwargs):
+                direct_dataset_reads.append((args, kwargs))
+                return original_loader(*args, **kwargs)
+
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    plot_actions_module,
+                    "load_by_guid_read_only",
+                    record_direct_dataset_read,
+                )
+                window.openPlot(params=[old_parameter], show=False)
+                assert direct_dataset_reads == []
+
+            wait_for(
+                lambda: (
+                    not window._database_load_active
+                    and not window._database_refresh_active
+                    and not window._database_detail_active
+                    and not window._database_expensive_detail_active
+                )
+            )
+            window.monitor.stop()
+
+            metadata = next(iter(window.RunList.all_run_metadata().values()))
+            assert metadata["result_count"] == 4
+            assert old_plot not in window.windows
+            assert old_handle.closed
+            assert window.ds is not None
+            new_parameter = dependent_parameter(window.ds, 1)
+            window.openPlot(params=[new_parameter], show=False)
+            new_plot = window.windows[-1]
+            wait_for(lambda: not getattr(new_plot.worker, "running", False))
+            assert new_plot.axis_data["x"].size == 4
+            assert new_plot.axis_data["y"].size == 4
+            assert database_artifact_state(database_path) == replacement_artifacts
+    finally:
+        if window is not None:
+            close_main_window(window)
+        if experiment is not None:
+            experiment.conn.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_existing_live_plot_refresh_quarantines_replaced_wal_before_worker_read(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    database_path = Path(tmp_path) / "live-refresh-replaced.db"
+    replacement_path = Path(tmp_path) / "live-refresh-replacement.db"
+    experiment = None
+    window = None
+
+    try:
+        initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+        experiment = load_or_create_experiment(
+            "live_refresh_replacement",
+            sample_name="stale_plot",
+        )
+        gate = ManualParameter("gate")
+        signal = ManualParameter("signal")
+        measurement = Measurement(exp=experiment, name="old_live_run")
+        measurement.register_parameter(gate)
+        measurement.register_parameter(signal, setpoints=(gate,))
+
+        with measurement.run(write_in_background=False) as datasaver:
+            datasaver.add_result((gate, 0.0), (signal, 10.0))
+            datasaver.flush_data_to_database(block=True)
+            assert Path(f"{database_path}-wal").is_file()
+
+            window = main_window.MainWindow()
+            window.startupDatabaseTimer.stop()
+            window.monitor.stop()
+            window.config.config["user_preference"]["confirm_close"] = False
+            window.config.config["user_preference"]["confirm_close_all"] = False
+            window.close_database(status=False)
+            assert window.load_file(str(database_path))
+            wait_for(
+                lambda: (
+                    not window._database_load_active
+                    and not window._database_detail_active
+                    and not window._database_expensive_detail_active
+                )
+            )
+            window.monitor.stop()
+            old_parameter = dependent_parameter(window.ds, 1)
+            window.openPlot(params=[old_parameter], show=False)
+            old_plot = window.windows[-1]
+            wait_for(lambda: not getattr(old_plot.worker, "running", False))
+            old_worker = old_plot.worker
+            old_handle = window.dataset_holder[old_plot._dataset_key]
+
+            generate_database(
+                [
+                    RunSpecification(
+                        1,
+                        "replacement_signal",
+                        "Replacement signal",
+                        "V",
+                        -1.0,
+                        1.0,
+                        4,
+                    )
+                ],
+                replacement_path,
+            )
+            os.replace(replacement_path, database_path)
+            replacement_artifacts = database_artifact_state(database_path)
+            assert replacement_artifacts["-wal"] is not None
+
+            worker_database_reads = []
+            original_prep = worker_module.load_param_data_from_db_prep
+            original_load = worker_module.load_param_data_from_db
+
+            def record_prep(*args, **kwargs):
+                worker_database_reads.append("prep")
+                return original_prep(*args, **kwargs)
+
+            def record_load(*args, **kwargs):
+                worker_database_reads.append("load")
+                return original_load(*args, **kwargs)
+
+            monkeypatch.setattr(worker_module, "load_param_data_from_db_prep", record_prep)
+            monkeypatch.setattr(worker_module, "load_param_data_from_db", record_load)
+            old_plot.refreshWindow(force=True)
+            wait_for(
+                lambda: (
+                    not window._database_load_active
+                    and not window._database_refresh_active
+                    and not window._database_detail_active
+                    and not window._database_expensive_detail_active
+                )
+            )
+            window.monitor.stop()
+
+            assert old_plot.worker is old_worker
+            assert worker_database_reads == []
+            assert old_plot not in window.windows
+            assert old_handle.closed
+            metadata = next(iter(window.RunList.all_run_metadata().values()))
+            assert metadata["result_count"] == 4
+            assert database_artifact_state(database_path) == replacement_artifacts
+    finally:
+        if window is not None:
+            close_main_window(window)
+        if experiment is not None:
+            experiment.conn.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_replaced_background_plot_does_not_switch_current_database(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    database_a = Path(tmp_path) / "source-a.db"
+    replacement_a = Path(tmp_path) / "source-a-replacement.db"
+    database_b = Path(tmp_path) / "source-b.db"
+    _run_a, guid_a, _table_a = build_line_database(database_a, 3)
+    _run_b, guid_b, _table_b = build_line_database(database_b, 2)
+    _replacement_run, replacement_guid, _replacement_table = build_line_database(
+        replacement_a,
+        4,
+        guid=guid_a,
+    )
+    assert replacement_guid == guid_a
+
+    window = main_window.MainWindow()
+    try:
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.config.config["runtime_settings"]["del_grace_period"] = 0
+        window.close_database(status=False)
+        assert window.load_file(str(database_a))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        assert window.ds is not None
+        assert window.ds.guid == guid_a
+        source_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[source_parameter], show=False)
+        source_plot = window.windows[-1]
+        wait_for(lambda: not getattr(source_plot.worker, "running", False))
+
+        assert window.load_file(str(database_b))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        assert window.fileTextbox.text() == str(database_b)
+        assert window.ds is not None
+        assert window.ds.guid == guid_b
+        assert source_plot in window.windows
+
+        target_parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[target_parameter], show=False)
+        target_plot = window.windows[-1]
+        wait_for(lambda: not getattr(target_plot.worker, "running", False))
+
+        source_key = source_plot._dataset_key
+        source_handle = window.dataset_holder[source_key]
+        source_trace_key = source_plot._trace_key
+        assert window.add_trace_to_plot(
+            target_plot,
+            source_key,
+            source_parameter.name,
+            param=source_parameter,
+        )
+        wait_for(lambda: source_trace_key in target_plot.lines)
+        assert source_plot._closed
+        assert source_plot not in window.windows
+        assert source_plot._merged_trace_users == 1
+        assert source_key in window.dataset_holder
+
+        os.replace(replacement_a, database_a)
+        source_plot.refreshWindow(force=True)
+        wait_for(
+            lambda: (
+                source_trace_key not in target_plot.lines
+                and source_key not in window.dataset_holder
+            )
+        )
+
+        assert source_plot not in window.windows
+        assert source_handle.closed
+        assert source_plot._merged_trace_users == 0
+        assert not source_plot.monitor.isActive()
+        assert target_plot in window.windows
+        np.testing.assert_array_equal(target_plot.line.getData()[1], [10.0, 11.0])
+        assert window.fileTextbox.text() == str(database_b)
+        assert window._loaded_database_identity == database_file_identity(database_b)
+        assert window.ds is not None
+        assert window.ds.guid == guid_b
+    finally:
+        close_main_window(window)
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_live_wal_update_keeps_real_qcodes_instance_and_cached_handle(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    database_path = Path(tmp_path) / "live-wal.db"
+    initialise_or_create_database_at(str(database_path), journal_mode="WAL")
+    experiment = load_or_create_experiment("live_wal", sample_name="same_instance")
+    gate = ManualParameter("gate")
+    signal = ManualParameter("signal")
+    measurement = Measurement(exp=experiment, name="live_wal")
+    measurement.register_parameter(gate)
+    measurement.register_parameter(signal, setpoints=(gate,))
+
+    with measurement.run(write_in_background=False) as datasaver:
+        for index in range(3):
+            datasaver.add_result((gate, float(index)), (signal, float(index + 10)))
+        datasaver.flush_data_to_database(block=True)
+        guid = datasaver.dataset.guid
+
+        window = main_window.MainWindow()
+        try:
+            window.startupDatabaseTimer.stop()
+            window.monitor.stop()
+            window.config.config["user_preference"]["confirm_close"] = False
+            window.config.config["user_preference"]["confirm_close_all"] = False
+            window.close_database(status=False)
+            assert window.load_file(str(database_path))
+            wait_for(
+                lambda: (
+                    not window._database_load_active
+                    and not window._database_detail_active
+                    and not window._database_expensive_detail_active
+                )
+            )
+            window.monitor.stop()
+            assert window.RunList.watching
+            assert window.ds is not None
+            assert window.ds.number_of_results == 3
+
+            parameter = dependent_parameter(window.ds, 1)
+            window.openPlot(params=[parameter], show=False)
+            plot = window.windows[-1]
+            wait_for(lambda: not getattr(plot.worker, "running", False))
+            dataset_key = plot._dataset_key
+            handle = window.dataset_holder[dataset_key]
+            loaded_identity = window._loaded_database_identity
+
+            datasaver.add_result((gate, 3.0), (signal, 13.0))
+            datasaver.flush_data_to_database(block=True)
+            writer_artifacts = database_artifact_state(database_path)
+            assert database_file_identity(database_path) == loaded_identity
+
+            replacement_loads = []
+            original_load_file = window.load_file
+
+            def record_load(*args, **kwargs):
+                replacement_loads.append((args, kwargs))
+                return original_load_file(*args, **kwargs)
+
+            window.load_file = record_load
+            window.refreshMain()
+            wait_for(lambda: not window._database_refresh_active)
+            window.monitor.stop()
+
+            metadata = window.RunList.all_run_metadata()
+            run_metadata = next(
+                run for run in metadata.values() if run["guid"] == guid
+            )
+            assert run_metadata["result_count"] == 4
+            assert window._loaded_database_identity == loaded_identity
+            assert window._current_dataset_key(guid) == dataset_key
+            assert window.dataset_holder[dataset_key] is handle
+            assert not handle.closed
+            assert replacement_loads == []
+            assert database_artifact_state(database_path) == writer_artifacts
+        finally:
+            window.load_file = original_load_file
+            close_main_window(window)
+            qcodes.config.core.db_location = original_database_path
+
+
+def test_loaded_path_test_database_generation_uses_replacement_reload(
+    tmp_path,
+    monkeypatch,
+):
+    configure_temp_qplot(monkeypatch, tmp_path)
+    original_database_path = qcodes.config.core.db_location
+    database_path = Path(tmp_path) / "generated.db"
+    initial_specification = RunSpecification(
+        1,
+        "current",
+        "Current",
+        "nA",
+        -1.0,
+        1.0,
+        3,
+    )
+    replacement_specification = RunSpecification(
+        1,
+        "current",
+        "Current",
+        "nA",
+        -1.0,
+        1.0,
+        4,
+    )
+    generate_database([initial_specification], database_path)
+
+    window = main_window.MainWindow()
+    status_messages = []
+    original_show_status = window.show_status
+
+    def record_status(message, timeout=5000):
+        status_messages.append((message, timeout))
+        return original_show_status(message, timeout)
+
+    try:
+        window.startupDatabaseTimer.stop()
+        window.monitor.stop()
+        window.config.config["user_preference"]["confirm_close"] = False
+        window.config.config["user_preference"]["confirm_close_all"] = False
+        window.close_database(status=False)
+        window.show_status = record_status
+        assert window.load_file(str(database_path))
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+        assert window.ds is not None
+        assert window.ds.number_of_results == 3
+        parameter = dependent_parameter(window.ds, 1)
+        window.openPlot(params=[parameter], show=False)
+        old_plot = window.windows[-1]
+        wait_for(lambda: not getattr(old_plot.worker, "running", False))
+        old_handle = window.dataset_holder[old_plot._dataset_key]
+
+        generate_database(
+            [replacement_specification],
+            database_path,
+            overwrite=True,
+        )
+        generated_artifacts = database_artifact_state(database_path)
+        window.test_database_generation_finished(
+            str(database_path),
+            [replacement_specification],
+            None,
+        )
+        wait_for(
+            lambda: (
+                not window._database_load_active
+                and not window._database_detail_active
+                and not window._database_expensive_detail_active
+            )
+        )
+        window.monitor.stop()
+
+        assert old_handle.closed
+        assert old_plot not in window.windows
+        assert window.ds is not None
+        assert window.ds.number_of_results == 4
+        metadata = next(iter(window.RunList.all_run_metadata().values()))
+        assert metadata["result_count"] == 4
+        assert any(
+            "Database was replaced and reloaded" in message
+            for message, _timeout in status_messages
+        )
+        assert database_artifact_state(database_path) == generated_artifacts
+    finally:
+        close_main_window(window)
         qcodes.config.core.db_location = original_database_path
 
 

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -462,6 +462,27 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         self.assertEqual(window.statuses, [])
         self.assertEqual(window.plot_states, [])
 
+    def test_replaced_source_worker_cannot_publish_cache_or_display_state(self):
+        """A completed private snapshot is stale if its main file changed."""
+
+        window = self._window()
+        window._source_database_is_current = lambda: False
+        window.worker.read_data = True
+        cache_updates = []
+        old_update_cache = plot_refresh_module.update_cache_parameter_data
+        plot_refresh_module.update_cache_parameter_data = (
+            lambda *args: cache_updates.append(args)
+            )
+        try:
+            result = plotWidget.refreshPlot(window, True, worker=window.worker)
+        finally:
+            plot_refresh_module.update_cache_parameter_data = old_update_cache
+
+        self.assertFalse(result)
+        self.assertFalse(window.worker.running)
+        self.assertEqual(window.end_wait.emitted, 1)
+        self.assertEqual(cache_updates, [])
+
     def test_stale_worker_cannot_publish_display_synchronization(self):
         window = self._window()
         window._qplot_display_synchronized = False

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -142,6 +142,30 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
 
         self.assertEqual(window.load_calls, ["load"])
 
+    def test_terminal_success_drops_monitor_queued_refresh(self):
+        window = self._window(worker_running=False)
+        window.ds.running = False
+        window.last_ds_len = window.ds.number_of_results
+        window._qplot_display_synchronized = True
+        window._queue_pending_refresh()
+
+        plotWidget._run_pending_refresh(window)
+
+        self.assertFalse(window._refresh_pending)
+        self.assertEqual(window.load_calls, [])
+
+    def test_terminal_success_keeps_explicit_forced_refresh(self):
+        window = self._window(worker_running=False)
+        window.ds.running = False
+        window.last_ds_len = window.ds.number_of_results
+        window._qplot_display_synchronized = True
+        window._queue_pending_refresh(force=True)
+
+        plotWidget._run_pending_refresh(window)
+
+        self.assertFalse(window._refresh_pending)
+        self.assertEqual(window.load_calls, ["load"])
+
     def test_secondary_trace_restart_does_not_depend_on_dictionary_order(self):
         window = self._window(worker_running=False)
         window.ds.running = False
@@ -287,6 +311,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         class Dataset:
             cache = Cache()
             number_of_results = 42
+            running = False
 
         class Param:
             name = "signal"
@@ -319,6 +344,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         window._dataset_key = DatasetKey("database.db", "guid")
         window._dataset_holder = {window._dataset_key: DatasetHandle(Dataset())}
         window.param = Param()
+        window._qplot_display_synchronized = True
         window.param_dict = {"x": object(), "y": object(), "signal": object()}
         window.axis_dropdown = {"x": Combo("x"), "y": Combo("y")}
         window.config = Config()
@@ -357,6 +383,7 @@ class PlotWindowRefreshTestCase(unittest.TestCase):
         self.assertFalse(worker.force_sql_heatmap)
         self.assertEqual(worker.operations, ["operation"])
         self.assertEqual(window.worker, worker)
+        self.assertFalse(window._qplot_display_synchronized)
         self.assertIn("Loading data for signal", window.show_statuses[-1][0])
 
         error = RuntimeError("failed")
@@ -434,6 +461,35 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         self.assertEqual(cache_updates, [])
         self.assertEqual(window.statuses, [])
         self.assertEqual(window.plot_states, [])
+
+    def test_stale_worker_cannot_publish_display_synchronization(self):
+        window = self._window()
+        window._qplot_display_synchronized = False
+        stale_worker = self.Worker()
+        stale_worker.dataset_completed = True
+        stale_worker._qplot_display_commit_ready = True
+
+        self.assertFalse(window._mark_display_synchronized(stale_worker))
+        self.assertFalse(window._qplot_display_synchronized)
+
+    def test_cancelled_worker_cannot_publish_display_synchronization(self):
+        window = self._window()
+        window._qplot_display_synchronized = False
+        window.worker.dataset_completed = True
+        window.worker._qplot_display_commit_ready = True
+        window.worker.is_cancelled = lambda: True
+
+        self.assertFalse(window._mark_display_synchronized(window.worker))
+        self.assertFalse(window._qplot_display_synchronized)
+
+    def test_failed_worker_cannot_publish_display_synchronization(self):
+        window = self._window()
+        window._qplot_display_synchronized = False
+        window.worker.dataset_completed = True
+        window.worker._qplot_display_commit_ready = True
+
+        self.assertFalse(plotWidget.refreshPlot(window, False, worker=window.worker))
+        self.assertFalse(window._qplot_display_synchronized)
 
     def test_stale_failed_worker_cannot_show_error_overlay(self):
         window = self._window()

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -482,6 +483,58 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
         self.assertFalse(window.worker.running)
         self.assertEqual(window.end_wait.emitted, 1)
         self.assertEqual(cache_updates, [])
+
+    def test_retargeted_symlink_worker_cannot_publish_cache_or_display_state(self):
+        """A late plot callback must validate the logical source path."""
+
+        class ReplacementSignal:
+            def __init__(self):
+                self.paths = []
+
+            def emit(self, path):
+                self.paths.append(path)
+
+        class Monitor:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target_a = root / "target-a.db"
+            target_b = root / "target-b.db"
+            view_path = root / "view.db"
+            next_link = root / "next-view.db"
+            target_a.write_bytes(b"a")
+            target_b.write_bytes(b"b")
+            try:
+                view_path.symlink_to(target_a)
+                next_link.symlink_to(target_b)
+            except OSError as error:
+                self.skipTest(f"This platform cannot create symlinks: {error}")
+
+            window = self._window()
+            window._dataset_key = DatasetKey(view_path, "guid")
+            window.database_replaced = ReplacementSignal()
+            window.monitor = Monitor()
+            window.worker.read_data = True
+            cache_updates = []
+            os.replace(next_link, view_path)
+
+            with patch.object(
+                    plot_refresh_module,
+                    "update_cache_parameter_data",
+                    side_effect=lambda *args: cache_updates.append(args),
+                    ):
+                result = plotWidget.refreshPlot(window, True, worker=window.worker)
+
+            self.assertFalse(result)
+            self.assertFalse(window.worker.running)
+            self.assertEqual(cache_updates, [])
+            self.assertTrue(window.monitor.stopped)
+            self.assertEqual(window.database_replaced.paths, [str(view_path)])
 
     def test_stale_worker_cannot_publish_display_synchronization(self):
         window = self._window()

--- a/tests/windows/test_plot_window.py
+++ b/tests/windows/test_plot_window.py
@@ -534,7 +534,10 @@ class PlotWorkerCallbackTestCase(unittest.TestCase):
             self.assertFalse(window.worker.running)
             self.assertEqual(cache_updates, [])
             self.assertTrue(window.monitor.stopped)
-            self.assertEqual(window.database_replaced.paths, [str(view_path)])
+            self.assertEqual(
+                [os.path.normcase(path) for path in window.database_replaced.paths],
+                [os.path.normcase(str(view_path))],
+            )
 
     def test_stale_worker_cannot_publish_display_synchronization(self):
         window = self._window()

--- a/tests/windows/test_testdata_gui.py
+++ b/tests/windows/test_testdata_gui.py
@@ -178,6 +178,42 @@ def test_generation_completion_force_reloads_replaced_current_database(tmp_path)
         harness.deleteLater()
 
 
+def test_generation_releases_current_database_before_replacing_it(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_small_specification(csv_path)
+    harness.fileTextbox = type(
+        "Field",
+        (),
+        {"text": lambda _self: str(database_path)},
+    )()
+    harness._prepare_replaced_database_reload = Mock()
+    harness.load_file = Mock(return_value=True)
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+        ):
+            assert harness.generate_test_database_from_csv()
+
+        harness._prepare_replaced_database_reload.assert_called_once_with(
+            str(database_path)
+        )
+        harness.load_file.assert_called_once_with(str(database_path), force=True)
+    finally:
+        harness.deleteLater()
+
+
 def test_invalid_csv_is_reported_before_database_destination_prompt(tmp_path):
     harness = GuiHarness(tmp_path)
     csv_path = tmp_path / "invalid.csv"


### PR DESCRIPTION
## Summary

- separate global source-run completion from final cache synchronization per parameter and final display synchronization per plot
- keep open and retained hidden plots retrying their terminal read until their own cache and display commits succeed, including normal traces, merged sources, secondary lines, and direct-SQL heatmaps
- avoid QCoDeS public completion setters and all write-capable completion APIs
- detect atomic replacement of viewed database files, invalidate their runtime handles/plots/previews, and reload replacements safely
- distinguish the user-selected logical database path, the resolved path accepted at load time, and the immutable identity of that accepted file instance
- correctly invalidate old plots, hidden sources, merged traces, workers, previews, and DatasetHandles when a symlink entry is atomically retargeted or its target file is replaced
- release qPlot’s read-only handles before an explicitly requested same-path synthetic-database replacement, so that workflow also works on Windows
- propagate expected file identity through dataset, worker, SQLite, QCoDeS, and probe reads; quarantine ambiguous WAL sidecars for an observed replacement view without modifying the database or any sidecar
- use a Windows volume/file-index identity fallback when Python reports no usable inode, and reject replacement-sensitive loads when no stable identity is available
- retire retained merged traces sourced from a replaced background database without switching the main window away from its current database

## Root cause

QCoDeS 0.58 changes its in-memory completion flag before attempting the database write in `DataSet.completed = True`. Calling that setter from qPlot's worker thread could therefore leave a viewer dataset falsely terminal after SQLite rejected the cross-thread write. A shared terminal flag also allowed one plot to stop another plot's final synchronization.

Separately, atomically replacing a live WAL database can leave an old `-wal` beside the new main file. SQLite can then expose the stale WAL contents unless the replacement is recognized and read through a source-preserving quarantine path.

The residual symlink defect came from using `canonical_database_path()` for both user selection and instance identity. Once `view.db` was retargeted from target A to target B, resolving the displayed path reconstructed only target B; invalidation could no longer identify target-A plots and handles. The fix retains the logical path, accepted resolved path, and stable file identity as distinct state and always invalidates from the saved old instance.

The Windows failures were test setup attempting to atomically replace a file or move a WAL while SQLite still had it open. The regressions now preserve replayable stale sidecars while closing the deliberately external writer first, and release only test-held qPlot connections before simulated external replacement.

## Regression coverage

Real QCoDeS WAL integrations cover two visible dependent plots plus a retained hidden merged source, staggered terminal loads, cache/display failure retries, direct-SQL heatmaps, monitor quiescence, stale-worker rejection, atomic replacement before plot actions/refreshes, and unchanged database/WAL/SHM/journal metadata.

Real QCoDeS/PyQt replacement regressions cover symlink-entry retargeting and replacement of a symlink target with the same GUID and newer rows. They verify that old plots and hidden sources close, merged traces are removed, old handles are closed and evicted, selected/run-list data move to the replacement exactly once, late database/detail/plot callbacks cannot republish old data, background database replacement does not change the selected database, and source database plus sidecar artifacts remain byte-for-byte unchanged.

Lower-level tests cover replacement identity races, WAL gaps/reappearance, repeated replacement, probe-process handoff, Windows file-index identity, and explicit refusal when stable identity is unavailable. GUI coverage verifies same-path synthetic generation releases the current view before replacement.

## Validation

- `.venv-mac/bin/python -m pytest` — 637 tests collected and completed without failures
- focused replacement and read-only suites — passed
- `.venv-mac/bin/python -m ruff check .` — passed
- configured `.venv-mac/bin/python -m mypy` — passed (62 source files)
- offscreen `.venv-mac/bin/python -m qplot` startup smoke test — passed