### PR TITLE
Harden database paths, configuration persistence, and read-only loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ files = [
     "src/qplot/datahandling/__init__.py",
     "src/qplot/datahandling/LoadFromDB.py",
     "src/qplot/datahandling/dimensions.py",
+    "src/qplot/datahandling/qcodes_compat.py",
     "src/qplot/datahandling/qcodes_cache.py",
     "src/qplot/datahandling/readSQL.py",
     "src/qplot/datahandling/readonly.py",

--- a/src/qplot/configuration/config.py
+++ b/src/qplot/configuration/config.py
@@ -325,9 +325,19 @@ class config:
         # Confirm reset worked
         self.validate(config)
         
-        # Save reset to file
+        # Save reset to file. Keep the last persisted configuration
+        # authoritative if any part of the atomic write fails.
+        had_previous_config = hasattr(self, "config")
+        previous_config = getattr(self, "config", {})
         self.config = config
-        self.save_config(self.default_file)
+        try:
+            self.save_config(self.default_file)
+        except Exception:
+            if had_previous_config:
+                self.config = previous_config
+            else:
+                del self.config
+            raise
 
 
     def validate(self, candidate):

--- a/src/qplot/datahandling/qcodes_compat.py
+++ b/src/qplot/datahandling/qcodes_compat.py
@@ -1,0 +1,14 @@
+"""Compatibility helpers for QCoDeS dataset implementation details."""
+
+from qcodes.dataset.data_set import DataSet
+
+
+def result_owns_supplied_connection(result: object) -> bool:
+    """Return whether QCoDeS transferred a supplied connection to ``result``.
+
+    QCoDeS' database-backed ``DataSet`` owns the connection passed to its
+    loader. Other dataset protocol implementations, including ``DataSetInMem``,
+    do not. Keep this implementation-specific type knowledge in one place.
+    """
+
+    return isinstance(result, DataSet)

--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -13,6 +13,7 @@ from qplot.datahandling.file_identity import (
     DatabaseFileIdentity,
     database_file_identity,
 )
+from qplot.datahandling.qcodes_compat import result_owns_supplied_connection
 
 SQLITE_READ_ONLY_CACHE_KIB = 16 * 1024
 WAL_SNAPSHOT_ATTEMPTS = 5
@@ -209,11 +210,14 @@ def load_by_guid_read_only(
         database_path,
         expected_database_identity=expected_database_identity,
     )
+    connection_transferred = False
     try:
-        return load_by_guid(guid, conn=conn)
-    except Exception:
-        conn.close()
-        raise
+        result = load_by_guid(guid, conn=conn)
+        connection_transferred = result_owns_supplied_connection(result)
+        return result
+    finally:
+        if not connection_transferred:
+            conn.close()
 
 
 def load_by_id_read_only(
@@ -229,11 +233,14 @@ def load_by_id_read_only(
         database_path,
         expected_database_identity=expected_database_identity,
     )
+    connection_transferred = False
     try:
-        return load_by_id(run_id, conn=conn)
-    except Exception:
-        conn.close()
-        raise
+        result = load_by_id(run_id, conn=conn)
+        connection_transferred = result_owns_supplied_connection(result)
+        return result
+    finally:
+        if not connection_transferred:
+            conn.close()
 
 
 def _resolved_database_path(database_path):

--- a/src/qplot/testdata.py
+++ b/src/qplot/testdata.py
@@ -94,6 +94,8 @@ _MINIMUM_FREQUENCY = 0.5
 _MAXIMUM_FREQUENCY = 4.0
 _SINUSOID_COMPONENT_COUNT = 2
 _RESULT_CHUNK_POINTS = 10_000
+_TEMPORARY_DATABASE_PREFIX = ".qplot-testdata-"
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 
 
 class SpecificationError(ValueError):
@@ -353,6 +355,38 @@ def _raise_if_cancelled(cancelled_callback):
         raise GenerationCancelled("Test-database generation was cancelled")
 
 
+def _qcodes_uri_name(database_path):
+    """Return one URI-encoded path layer for QCoDeS' ``file:`` prefix."""
+    database_uri = Path(database_path).absolute().as_uri()
+    return database_uri.removeprefix("file:")
+
+
+def _connect_writable_exact_path(database_path):
+    """Open an exact generator-owned path with QCoDeS' writable connector."""
+    return connect(_qcodes_uri_name(database_path))
+
+
+def _owned_temporary_artifacts(temporary_path):
+    yield temporary_path
+    for suffix in _SQLITE_SIDECAR_SUFFIXES:
+        yield Path(f"{temporary_path}{suffix}")
+
+
+def _remove_owned_temporary_artifacts(temporary_path):
+    """Remove only the generator-owned database and its possible sidecars."""
+    failures = []
+    for artifact_path in _owned_temporary_artifacts(temporary_path):
+        try:
+            artifact_path.unlink(missing_ok=True)
+        except OSError as error:
+            failures.append((artifact_path, error))
+    if failures:
+        failed_paths = ", ".join(str(path) for path, _error in failures)
+        raise OSError(
+            f"Could not remove generator-owned temporary files: {failed_paths}"
+        ) from failures[0][1]
+
+
 def _result_chunks(point_count):
     for start in range(0, point_count, _RESULT_CHUNK_POINTS):
         yield slice(start, min(start + _RESULT_CHUNK_POINTS, point_count))
@@ -503,7 +537,6 @@ def _publish_database(temporary_path, database_path, overwrite):
             "Could not atomically publish the generated database without "
             "overwriting an existing file"
         ) from error
-    temporary_path.unlink()
 
 
 def generate_database(
@@ -527,16 +560,6 @@ def generate_database(
         )
 
     database_path.parent.mkdir(parents=True, exist_ok=True)
-    temporary_handle = tempfile.NamedTemporaryFile(
-        prefix=f".{database_path.stem}-",
-        suffix=".db",
-        dir=database_path.parent,
-        delete=False,
-    )
-    temporary_path = Path(temporary_handle.name)
-    temporary_handle.close()
-    temporary_path.unlink()
-
     random_generator = rng if rng is not None else np.random.default_rng()
     total_runs = len(specifications)
     total_points = sum(specification.point_count for specification in specifications)
@@ -545,63 +568,76 @@ def generate_database(
         f"Test database generation started: {database_path} "
         f"({total_runs} runs, {total_points} points)."
     )
+    temporary_path = None
     try:
-        connection = connect(temporary_path)
         try:
-            experiment = new_experiment(
-                "qplot_test_database",
-                sample_name="synthetic",
-                conn=connection,
+            temporary_handle = tempfile.NamedTemporaryFile(
+                prefix=_TEMPORARY_DATABASE_PREFIX,
+                suffix=".db",
+                dir=database_path.parent,
+                delete=False,
             )
-            for run_number, specification in enumerate(specifications, start=1):
-                run_started = perf_counter()
-                _timestamped_message(
-                    f"Run started: run_{run_number} ({run_number}/{total_runs}, "
-                    f"{specification.dimensions}D, {specification.point_count} points)."
-                )
-                try:
-                    points_written = _write_run(
-                        experiment,
-                        run_number,
-                        specification,
-                        random_generator,
-                        cancelled_callback=cancelled_callback,
-                    )
-                    if points_written != specification.point_count:
-                        raise RuntimeError(
-                            f"run_{run_number} persisted {points_written} of "
-                            f"{specification.point_count} expected result rows"
-                        )
-                except GenerationCancelled:
-                    _timestamped_message(
-                        f"Run stopped (cancelled): run_{run_number} "
-                        f"after {perf_counter() - run_started:.2f} s."
-                    )
-                    raise
-                except Exception as error:
-                    _timestamped_message(
-                        f"Run stopped (failed): run_{run_number} after "
-                        f"{perf_counter() - run_started:.2f} s "
-                        f"({type(error).__name__}: {error})."
-                    )
-                    raise
-                _timestamped_message(
-                    f"Run stopped (completed): run_{run_number} in "
-                    f"{perf_counter() - run_started:.2f} s."
-                )
+            temporary_path = Path(temporary_handle.name)
+            temporary_handle.close()
             _raise_if_cancelled(cancelled_callback)
+            connection = _connect_writable_exact_path(temporary_path)
+            try:
+                experiment = new_experiment(
+                    "qplot_test_database",
+                    sample_name="synthetic",
+                    conn=connection,
+                )
+                for run_number, specification in enumerate(specifications, start=1):
+                    run_started = perf_counter()
+                    _timestamped_message(
+                        f"Run started: run_{run_number} ({run_number}/{total_runs}, "
+                        f"{specification.dimensions}D, "
+                        f"{specification.point_count} points)."
+                    )
+                    try:
+                        points_written = _write_run(
+                            experiment,
+                            run_number,
+                            specification,
+                            random_generator,
+                            cancelled_callback=cancelled_callback,
+                        )
+                        if points_written != specification.point_count:
+                            raise RuntimeError(
+                                f"run_{run_number} persisted {points_written} of "
+                                f"{specification.point_count} expected result rows"
+                            )
+                    except GenerationCancelled:
+                        _timestamped_message(
+                            f"Run stopped (cancelled): run_{run_number} "
+                            f"after {perf_counter() - run_started:.2f} s."
+                        )
+                        raise
+                    except Exception as error:
+                        _timestamped_message(
+                            f"Run stopped (failed): run_{run_number} after "
+                            f"{perf_counter() - run_started:.2f} s "
+                            f"({type(error).__name__}: {error})."
+                        )
+                        raise
+                    _timestamped_message(
+                        f"Run stopped (completed): run_{run_number} in "
+                        f"{perf_counter() - run_started:.2f} s."
+                    )
+                _raise_if_cancelled(cancelled_callback)
+            finally:
+                connection.close()
+            _publish_database(temporary_path, database_path, overwrite)
         finally:
-            connection.close()
-        _publish_database(temporary_path, database_path, overwrite)
+            if temporary_path is not None:
+                _remove_owned_temporary_artifacts(temporary_path)
     except GenerationCancelled:
-        temporary_path.unlink(missing_ok=True)
         _timestamped_message(
             "Test database generation stopped (cancelled) after "
             f"{perf_counter() - generation_started:.2f} s: {database_path}."
         )
         raise
     except Exception as error:
-        temporary_path.unlink(missing_ok=True)
         _timestamped_message(
             "Test database generation stopped (failed) after "
             f"{perf_counter() - generation_started:.2f} s: {database_path} "

--- a/src/qplot/windows/_config_persistence.py
+++ b/src/qplot/windows/_config_persistence.py
@@ -1,0 +1,123 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from PyQt6 import QtWidgets as qtw
+
+from qplot.diagnostics import log_exception
+
+
+def set_widget_value_without_signals(
+        widget: Any,
+        setter: Callable[[Any], None],
+        value: Any,
+        ) -> None:
+    """Set a Qt control value while preserving its signal-blocking state."""
+
+    signals_were_blocked = widget.blockSignals(True)
+    try:
+        setter(value)
+    finally:
+        widget.blockSignals(signals_were_blocked)
+
+
+def persist_config_action(
+        owner: Any,
+        operation: Callable[[], None],
+        description: str,
+        rollback: Callable[[], None] | None = None,
+        ) -> bool:
+    """Run one config write, rolling back GUI state and reporting one error."""
+
+    try:
+        operation()
+    except Exception as error:
+        log_exception(
+            f"Persisting {description} failed",
+            error,
+            __name__,
+            )
+        if rollback is not None:
+            try:
+                rollback()
+            except Exception as rollback_error:
+                log_exception(
+                    f"Rolling back {description} controls failed",
+                    rollback_error,
+                    __name__,
+                    )
+        _show_config_error(owner, description, error)
+        return False
+
+    return True
+
+
+def persist_config_value(
+        owner: Any,
+        config: Any,
+        key: str,
+        value: Any,
+        description: str,
+        rollback: Callable[[], None] | None = None,
+        ) -> bool:
+    """Persist one config value through the shared GUI failure policy."""
+
+    return persist_config_action(
+        owner,
+        lambda: config.update(key, value),
+        description,
+        rollback,
+        )
+
+
+def persist_config_values(
+        owner: Any,
+        config: Any,
+        values: Mapping[str, Any],
+        description: str,
+        rollback: Callable[[], None] | None = None,
+        ) -> bool:
+    """Persist related config values as one atomic GUI action."""
+
+    updates = dict(values)
+    return persist_config_action(
+        owner,
+        lambda: config.update_many(updates),
+        description,
+        rollback,
+        )
+
+
+def _show_config_error(owner: Any, description: str, error: Exception) -> None:
+    title = "Settings Not Saved"
+    message = (
+        f"Could not save {description}. Your previous setting is still active. "
+        "Check that the qPlot configuration folder is writable, then try again."
+        )
+    show_error = getattr(owner, "show_error", None)
+    if callable(show_error):
+        try:
+            show_error(title, message, str(error))
+        except Exception as notification_error:
+            log_exception(
+                "Showing the configuration error failed",
+                notification_error,
+                __name__,
+                )
+        return
+
+    if not isinstance(owner, qtw.QWidget):
+        return
+
+    try:
+        box = qtw.QMessageBox(owner)
+        box.setIcon(qtw.QMessageBox.Icon.Warning)
+        box.setWindowTitle(title)
+        box.setText(message)
+        box.setDetailedText(str(error))
+        box.exec()
+    except Exception as notification_error:
+        log_exception(
+            "Showing the configuration error failed",
+            notification_error,
+            __name__,
+            )

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -37,6 +37,7 @@ from qplot.testdata import (
     write_example_csv,
 )
 
+from ._config_persistence import persist_config_value, persist_config_values
 from ._dataset_handle import (
     canonical_database_path,
     database_file_identity,
@@ -879,10 +880,19 @@ class DatabaseActionsMixin:
         )
 
         if os.path.isdir(foldername):
-            self.config.update("file.default_load_path", foldername)
-            self.show_status(f"Default load folder set to {foldername}", 5000)
+            if persist_config_value(
+                    self,
+                    self.config,
+                    "file.default_load_path",
+                    foldername,
+                    "the default database folder",
+                    ):
+                self.show_status(f"Default load folder set to {foldername}", 5000)
+                return True
+            return False
         else:
             self.show_status("Default load folder unchanged.", 3000)
+            return False
 
 
     @QtCore.pyqtSlot(str)
@@ -960,11 +970,19 @@ class DatabaseActionsMixin:
             current_paths = []
 
         if current_paths == paths:
-            return
+            return True
 
-        self.config.config.setdefault("file", {})["recent_file_paths"] = paths
-        self.config.save_config(self.config.default_file)
+        if not persist_config_value(
+                self,
+                self.config,
+                "file.recent_file_paths",
+                paths,
+                "the recent database list",
+                ):
+            return False
+
         self.refresh_recent_database_menu()
+        return True
 
 
     def remember_loaded_database(self, filename):
@@ -977,13 +995,33 @@ class DatabaseActionsMixin:
             current_last_file = self.config.get("file.last_file_path")
         except KeyError:
             current_last_file = None
-
         try:
-            if current_last_file != abspath:
-                self.config.update("file.last_file_path", abspath)
-            self.remember_recent_database(abspath)
-        except Exception as err:
-            log_exception("Remember database path failed", err, __name__)
+            current_paths = list(self.config.get("file.recent_file_paths"))
+        except KeyError:
+            current_paths = []
+
+        paths = [path for path in self.recent_database_paths() if path != abspath]
+        paths.insert(0, abspath)
+        paths = paths[:10]
+
+        updates = {}
+        if current_last_file != abspath:
+            updates["file.last_file_path"] = abspath
+        if current_paths != paths:
+            updates["file.recent_file_paths"] = paths
+        if not updates:
+            return True
+
+        if not persist_config_values(
+                self,
+                self.config,
+                updates,
+                "the last and recent database paths",
+                ):
+            return False
+
+        self.refresh_recent_database_menu()
+        return True
 
 
     def refresh_recent_database_menu(self):

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -181,11 +181,12 @@ class TestDatabaseGenerationSignals(QtCore.QObject):
 class TestDatabaseGenerationWorker(QtCore.QRunnable):
     """Generate a test database without blocking the GUI thread."""
 
-    def __init__(self, specifications, database_path):
+    def __init__(self, specifications, database_path, overwrite=False):
         super().__init__()
         self.signals = TestDatabaseGenerationSignals()
         self.specifications = list(specifications)
         self.database_path = str(database_path)
+        self.overwrite = overwrite
         self._cancelled = threading.Event()
 
     def cancel(self):
@@ -198,7 +199,7 @@ class TestDatabaseGenerationWorker(QtCore.QRunnable):
             generate_database(
                 self.specifications,
                 self.database_path,
-                overwrite=True,
+                overwrite=self.overwrite,
                 cancelled_callback=self._cancelled.is_set,
             )
         except GenerationCancelled:
@@ -410,6 +411,7 @@ class DatabaseActionsMixin:
             "Save Test Database",
             suggested_path,
             "QCoDeS Database (*.db)",
+            options=qtw.QFileDialog.Option.DontConfirmOverwrite,
         )[0]
         if not database_path:
             self.show_status("Test database generation cancelled.", 3000)
@@ -417,6 +419,20 @@ class DatabaseActionsMixin:
         if not database_path.lower().endswith(".db"):
             database_path += ".db"
         database_path = os.path.abspath(database_path)
+        overwrite = os.path.exists(database_path)
+        if overwrite:
+            reply = qtw.QMessageBox.question(
+                self,
+                "Replace Test Database?",
+                f"{database_path} already exists.\n\nReplace it with the "
+                "generated test database?",
+                qtw.QMessageBox.StandardButton.Yes
+                | qtw.QMessageBox.StandardButton.No,
+                qtw.QMessageBox.StandardButton.No,
+            )
+            if reply != qtw.QMessageBox.StandardButton.Yes:
+                self.show_status("Test database generation cancelled.", 3000)
+                return False
 
         file_textbox = getattr(self, "fileTextbox", None)
         current_database = file_textbox.text() if file_textbox is not None else ""
@@ -441,7 +457,11 @@ class DatabaseActionsMixin:
         action = getattr(self, "generateTestDatabaseAction", None)
         if action is not None:
             action.setEnabled(False)
-        worker = TestDatabaseGenerationWorker(specifications, database_path)
+        worker = TestDatabaseGenerationWorker(
+            specifications,
+            database_path,
+            overwrite=overwrite,
+        )
         self._test_database_generation_worker = worker
         worker.signals.finished.connect(self.test_database_generation_finished)
         self.show_status(

--- a/src/qplot/windows/_plot2d_colorbar_dialog.py
+++ b/src/qplot/windows/_plot2d_colorbar_dialog.py
@@ -15,6 +15,7 @@ from ._colorbar import (
     _ColorbarColormapTableItem,
     _config_value,
 )
+from ._config_persistence import persist_config_value
 
 if TYPE_CHECKING:
     class _ColorbarScaleDialogBase:
@@ -360,10 +361,19 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
         """
         config_obj = self.__dict__.get("config")
         if config_obj is not None:
-            config_obj.update(key, bool(enabled))
+            if not persist_config_value(
+                    self,
+                    config_obj,
+                    key,
+                    bool(enabled),
+                    "the color-map filter",
+                    self._sync_colorbar_filter_controls,
+                    ):
+                return False
 
         self._populate_colorbar_colormap_table()
         self._sync_colorbar_scale_controls()
+        return True
 
     def _set_colorbar_subtype_filter_setting(self, group, subtype, enabled):
         """
@@ -595,14 +605,31 @@ class ColorbarScaleDialogMixin(_ColorbarScaleDialogBase):
                 show_status("Unknown color map.", 5000)
             return False
 
+        config_obj = self.__dict__.get("config")
+        if config_obj is not None:
+            previous_name = _config_value(
+                config_obj,
+                "user_preference.bar_colour",
+                self.__dict__.get("_colorbar_colormap_name", "viridis"),
+                )
+
+            def rollback():
+                self._select_colorbar_colormap(previous_name)
+
+            if not persist_config_value(
+                    self,
+                    config_obj,
+                    "user_preference.bar_colour",
+                    name,
+                    "the color map",
+                    rollback,
+                    ):
+                return False
+
         self._colorbar_colormap_name = name
         bar = self.__dict__.get("bar")
         if bar is not None:
             bar.setColorMap(self._colorbar_colormap(name))
-
-        config_obj = self.__dict__.get("config")
-        if config_obj is not None:
-            config_obj.update("user_preference.bar_colour", name)
 
         return True
 

--- a/src/qplot/windows/_plotWin.py
+++ b/src/qplot/windows/_plotWin.py
@@ -17,6 +17,7 @@ from ._commands import (
     create_action,
     toolbar_toggle_command_spec,
 )
+from ._config_persistence import persist_config_value
 from ._dataset_handle import DatasetKey, TraceKey
 from ._dragdrop import (
     preview_drop_is_compatible,
@@ -1056,21 +1057,68 @@ class plotWidget(
             return False
 
         main_window = main_window_for(self)
-        target_config = getattr(main_window, "config", self.config)
-        if target_config is not self.config:
-            self.config = target_config
+        main_config = getattr(main_window, "config", None)
+        target_config = self.config
+        if main_config is self.config:
+            target_config = main_config
 
         try:
             current_mode = target_config.get(MOUSE_MODE_KEY)
         except KeyError:
-            current_mode = None
+            current_mode = "pan"
+
+        def rollback():
+            if hasattr(self, "vb"):
+                self.vb.setLeftButtonAction(current_mode)
+
+            mouse_mode_action = self.__dict__.get("mouseModeAction")
+            menu = (
+                mouse_mode_action.menu()
+                if mouse_mode_action is not None
+                else None
+                )
+            if menu is None:
+                return
+            mode_actions = getattr(
+                self.__dict__.get("vbMenu"),
+                "mouseModes",
+                menu.actions(),
+                )
+            blocked_states = [
+                mode_action.blockSignals(True)
+                for mode_action in mode_actions
+                ]
+            try:
+                for mode_action, action_mode in zip(
+                        mode_actions,
+                        ("pan", "rect"),
+                        strict=False,
+                        ):
+                    mode_action.setChecked(action_mode == current_mode)
+            finally:
+                for mode_action, signals_were_blocked in zip(
+                        mode_actions,
+                        blocked_states,
+                        strict=True,
+                        ):
+                    mode_action.blockSignals(signals_were_blocked)
 
         if current_mode != mode:
-            target_config.update(MOUSE_MODE_KEY, mode)
+            error_owner = main_window if main_config is target_config else self
+            if not persist_config_value(
+                    error_owner,
+                    target_config,
+                    MOUSE_MODE_KEY,
+                    mode,
+                    "the mouse mode",
+                    rollback,
+                    ):
+                return False
 
         if (
                 main_window is not None
                 and main_window is not self
+                and main_config is target_config
                 and hasattr(main_window, "apply_current_settings")
                 ):
             main_window.apply_current_settings()
@@ -1084,8 +1132,13 @@ class plotWidget(
         if menu is None:
             return
 
+        mode_actions = getattr(
+            self.__dict__.get("vbMenu"),
+            "mouseModes",
+            menu.actions(),
+            )
         for action, mode in zip(
-                getattr(menu, "mouseModes", ()),
+                mode_actions,
                 ("pan", "rect"),
                 strict=False,
                 ):

--- a/src/qplot/windows/_preferences.py
+++ b/src/qplot/windows/_preferences.py
@@ -10,6 +10,7 @@ from PyQt6 import (
 )
 
 from ._commands import create_action
+from ._config_persistence import persist_config_values
 from ._window_controls import (
     CONFIRM_CLOSE_ALL_KEY,
     CONFIRM_QUIT_KEY,
@@ -320,40 +321,63 @@ class PreferencesDialog(qtw.QDialog):
         Loads preference values into the dialog widgets.
 
         """
-        theme_index = self.themeCombo.findData(values["user_preference.theme"])
-        self.themeCombo.setCurrentIndex(max(theme_index, 0))
+        widgets = (
+            self.themeCombo,
+            self.previewSizeSpin,
+            self.mouseModeCombo,
+            self.copyPlotImageResolutionCombo,
+            self.defaultLoadPathEdit,
+            self.refreshRateSpin,
+            self.confirmCloseAllCheck,
+            self.confirmQuitCheck,
+            self.maxThreadsSpin,
+            self.maxFullHeatmapPointsSpin,
+            self.delGracePeriodSpin,
+            self.cloudSyncTimeoutSpin,
+            )
+        blocked_states = [widget.blockSignals(True) for widget in widgets]
+        try:
+            theme_index = self.themeCombo.findData(values["user_preference.theme"])
+            self.themeCombo.setCurrentIndex(max(theme_index, 0))
 
-        self.previewSizeSpin.setValue(int(values["GUI.preview_size"]))
-        mouse_mode_index = self.mouseModeCombo.findData(values[MOUSE_MODE_KEY])
-        self.mouseModeCombo.setCurrentIndex(max(mouse_mode_index, 0))
-        copy_resolution_index = self.copyPlotImageResolutionCombo.findData(
-            values[COPY_PLOT_IMAGE_RESOLUTION_KEY]
-            )
-        self.copyPlotImageResolutionCombo.setCurrentIndex(
-            max(copy_resolution_index, 0)
-            )
-        self.defaultLoadPathEdit.setText(str(values["file.default_load_path"]))
-        self.refreshRateSpin.setValue(
-            float(values["user_preference.default_refresh_rate"])
-            )
-        self.confirmCloseAllCheck.setChecked(
-            bool(values[CONFIRM_CLOSE_ALL_KEY])
-            )
-        self.confirmQuitCheck.setChecked(
-            bool(values[CONFIRM_QUIT_KEY])
-            )
-        self.maxThreadsSpin.setValue(
-            int(values["runtime_settings.max_threads"])
-            )
-        self.maxFullHeatmapPointsSpin.setValue(
-            int(values["runtime_settings.max_full_heatmap_points"])
-            )
-        self.delGracePeriodSpin.setValue(
-            float(values["runtime_settings.del_grace_period"])
-            )
-        self.cloudSyncTimeoutSpin.setValue(
-            float(values["runtime_settings.cloud_sync_timeout"])
-            )
+            self.previewSizeSpin.setValue(int(values["GUI.preview_size"]))
+            mouse_mode_index = self.mouseModeCombo.findData(values[MOUSE_MODE_KEY])
+            self.mouseModeCombo.setCurrentIndex(max(mouse_mode_index, 0))
+            copy_resolution_index = self.copyPlotImageResolutionCombo.findData(
+                values[COPY_PLOT_IMAGE_RESOLUTION_KEY]
+                )
+            self.copyPlotImageResolutionCombo.setCurrentIndex(
+                max(copy_resolution_index, 0)
+                )
+            self.defaultLoadPathEdit.setText(str(values["file.default_load_path"]))
+            self.refreshRateSpin.setValue(
+                float(values["user_preference.default_refresh_rate"])
+                )
+            self.confirmCloseAllCheck.setChecked(
+                bool(values[CONFIRM_CLOSE_ALL_KEY])
+                )
+            self.confirmQuitCheck.setChecked(
+                bool(values[CONFIRM_QUIT_KEY])
+                )
+            self.maxThreadsSpin.setValue(
+                int(values["runtime_settings.max_threads"])
+                )
+            self.maxFullHeatmapPointsSpin.setValue(
+                int(values["runtime_settings.max_full_heatmap_points"])
+                )
+            self.delGracePeriodSpin.setValue(
+                float(values["runtime_settings.del_grace_period"])
+                )
+            self.cloudSyncTimeoutSpin.setValue(
+                float(values["runtime_settings.cloud_sync_timeout"])
+                )
+        finally:
+            for widget, signals_were_blocked in zip(
+                    widgets,
+                    blocked_states,
+                    strict=True,
+                    ):
+                widget.blockSignals(signals_were_blocked)
 
     def preference_values(self):
         """
@@ -403,20 +427,18 @@ class PreferencesDialog(qtw.QDialog):
         Persists the dialog values and emits preferencesApplied on success.
 
         """
-        try:
-            changed_values = {
-                key: value
-                for key, value in self.preference_values().items()
-                if self.config.get(key) != value
-                }
-            if changed_values:
-                self.config.update_many(changed_values)
-        except Exception as err:
-            qtw.QMessageBox.critical(
+        changed_values = {
+            key: value
+            for key, value in self.preference_values().items()
+            if self.config.get(key) != value
+            }
+        if changed_values and not persist_config_values(
                 self,
-                "Preferences Not Saved",
-                f"Could not save preferences:\n{err}",
-                )
+                self.config,
+                changed_values,
+                "the preferences",
+                self.load_from_config,
+                ):
             return False
 
         self.preferencesApplied.emit()

--- a/src/qplot/windows/_run_controls.py
+++ b/src/qplot/windows/_run_controls.py
@@ -9,6 +9,10 @@ from PyQt6 import (
 from PyQt6.QtGui import QIntValidator
 
 from ._commands import create_action, plot_measurement_command_spec
+from ._config_persistence import (
+    persist_config_value,
+    set_widget_value_without_signals,
+)
 from ._help import show_quick_start
 from ._widgets import (
     RunList,
@@ -380,7 +384,9 @@ class RunControlsMixin:
         Updates the refresh interval for checking for new runs in database.
 
         """
-        self._save_refresh_interval(interval)
+        if not self._save_refresh_interval(interval):
+            self._sync_empty_state()
+            return
         self._apply_refresh_interval(interval)
         self._sync_empty_state()
 
@@ -390,7 +396,29 @@ class RunControlsMixin:
         Persists the Auto-plot checkbox state.
 
         """
-        self.config.update(AUTO_PLOT_KEY, bool(checked))
+        try:
+            previous_checked = bool(self.config.get(AUTO_PLOT_KEY))
+        except (AttributeError, KeyError):
+            previous_checked = not bool(checked)
+
+        def rollback():
+            checkbox = getattr(self, "autoPlotBox", None)
+            if checkbox is not None:
+                set_widget_value_without_signals(
+                    checkbox,
+                    checkbox.setChecked,
+                    previous_checked,
+                    )
+
+        if not persist_config_value(
+                self,
+                self.config,
+                AUTO_PLOT_KEY,
+                bool(checked),
+                "the Auto-plot preference",
+                rollback,
+                ):
+            return
         if checked:
             self._auto_plot_current_running_run()
 
@@ -440,8 +468,26 @@ class RunControlsMixin:
         except (KeyError, TypeError, ValueError):
             current_interval = None
 
-        if current_interval != interval:
-            self.config.update("user_preference.default_refresh_rate", interval)
+        if current_interval == interval:
+            return True
+
+        def rollback():
+            spin_box = getattr(self, "spinBox", None)
+            if spin_box is not None and current_interval is not None:
+                set_widget_value_without_signals(
+                    spin_box,
+                    spin_box.setValue,
+                    current_interval,
+                    )
+
+        return persist_config_value(
+            self,
+            self.config,
+            "user_preference.default_refresh_rate",
+            interval,
+            "the refresh interval",
+            rollback,
+            )
 
     @QtCore.pyqtSlot(str)
     def update_run_id(self, text):

--- a/src/qplot/windows/_window_controls.py
+++ b/src/qplot/windows/_window_controls.py
@@ -2,6 +2,10 @@ from PyQt6 import QtGui
 from PyQt6 import QtWidgets as qtw
 
 from ._commands import create_action
+from ._config_persistence import (
+    persist_config_value,
+    set_widget_value_without_signals,
+)
 
 CONFIRM_CLOSE_ALL_KEY = "user_preference.confirm_close_all"
 CONFIRM_QUIT_KEY = "user_preference.confirm_close"
@@ -98,9 +102,23 @@ def add_config_checkbox_action(window, menu, text, key, status_tip):
         action.blockSignals(False)
 
     sync_checked()
-    action.toggled.connect(
-        lambda checked: window.config.update(key, checked)
-        )
+
+    def persist_checked(checked):
+        previous_checked = config_bool(window.config, key, default=True)
+        persist_config_value(
+            window,
+            window.config,
+            key,
+            checked,
+            "the confirmation preference",
+            lambda: set_widget_value_without_signals(
+                action,
+                action.setChecked,
+                previous_checked,
+                ),
+            )
+
+    action.toggled.connect(persist_checked)
     menu.aboutToShow.connect(sync_checked)
     menu.addAction(action)
     return action
@@ -140,7 +158,13 @@ def ask_confirmation_with_dont_ask_again(
 
     reply = box.exec()
     if reply == qtw.QMessageBox.StandardButton.Yes and dont_ask_again.isChecked():
-        window.config.update(config_key, False)
+        persist_config_value(
+            window,
+            window.config,
+            config_key,
+            False,
+            "the close-confirmation preference",
+            )
     return reply
 
 

--- a/src/qplot/windows/main.py
+++ b/src/qplot/windows/main.py
@@ -32,6 +32,11 @@ from qplot.datahandling.database import (
 from qplot.diagnostics import log_user_error
 
 from ._commands import create_action
+from ._config_persistence import (
+    persist_config_action,
+    persist_config_value,
+    set_widget_value_without_signals,
+)
 from ._database_actions import DatabaseActionsMixin, TestDatabaseGenerationWorker
 from ._dataset_handle import DatasetHandle, DatasetKey
 from ._help import add_help_menu
@@ -669,21 +674,49 @@ class MainWindow(
 
         """
         if self.config.get("user_preference.theme") == theme: #already selected
-            action.setChecked(True)
+            set_widget_value_without_signals(action, action.setChecked, True)
             self.show_status(f"{theme.title()} theme already selected.", 3000)
-            return
-        for QActions in getattr(self, "themes", []): # Untick other options
-            if QActions != action:
-                QActions.setChecked(False)
-                
-        # Update config.jon
-        self.config.update("user_preference.theme", theme)
+            return True
+
+        def sync_theme_actions():
+            current_theme = self.config.get("user_preference.theme")
+            actions = list(getattr(self, "themes", []))
+            if action not in actions:
+                actions.append(action)
+            blocked_states = [
+                theme_action.blockSignals(True)
+                for theme_action in actions
+                ]
+            try:
+                for theme_action in actions:
+                    action_theme = theme_action.text().replace("&", "").lower()
+                    theme_action.setChecked(action_theme == current_theme)
+            finally:
+                for theme_action, signals_were_blocked in zip(
+                        actions,
+                        blocked_states,
+                        strict=True,
+                        ):
+                    theme_action.blockSignals(signals_were_blocked)
+
+        if not persist_config_value(
+                self,
+                self.config,
+                "user_preference.theme",
+                theme,
+                "the theme preference",
+                sync_theme_actions,
+                ):
+            return False
+
+        sync_theme_actions()
         
         # Update all windows.
         self.setStyleSheet(self.config.theme.main)
         for win in self.windows:
             win.update_theme(self.config)
         self.show_status(f"Theme changed to {theme}.", 2000)
+        return True
 
 
     def change_preview_size(self, preview_size):
@@ -693,10 +726,12 @@ class MainWindow(
         """
         preview_size = int(preview_size)
         if preview_size == self.preview_size:
-            return
+            return True
+
+        if not self._save_preview_size(preview_size):
+            return False
 
         self.preview_size = preview_size
-        self._save_preview_size(preview_size)
         if hasattr(self, "infoBox"):
             self.infoBox.set_preview_size(preview_size)
             prioritize_previews = getattr(self, "_prioritize_preview_runs", None)
@@ -705,6 +740,7 @@ class MainWindow(
             if hasattr(self, "runInfoSplitter"):
                 self.runInfoSplitter.setSizes([380, self._details_pane_height()])
         self.show_status(f"Preview size set to {preview_size} px.", 3000)
+        return True
 
 
     @QtCore.pyqtSlot()
@@ -725,11 +761,18 @@ class MainWindow(
             self.show_status("Settings reset cancelled.", 3000)
             return
 
+        if not persist_config_action(
+                self,
+                self.config.reset_to_defaults,
+                "the default settings",
+                ):
+            return False
+
         self.close_plot_windows(confirm=False, status=False)
-        self.config.reset_to_defaults()
         self.apply_current_settings()
         self.close_database(status=False)
         self.show_status("Settings reset to defaults.", 5000)
+        return True
 
 
     def show_preferences_dialog(self):
@@ -795,10 +838,30 @@ class MainWindow(
 
 
     def _save_preview_size(self, preview_size):
-        gui_config = self.config.config.setdefault("GUI", {})
-        if "preview_size" not in gui_config:
-            gui_config["preview_size"] = self.preview_size
-        self.config.update("GUI.preview_size", int(preview_size))
+        previous_size = self._configured_preview_size()
+
+        def rollback():
+            actions = list(getattr(self, "previewSizeActions", []))
+            blocked_states = [action.blockSignals(True) for action in actions]
+            try:
+                for action in actions:
+                    action.setChecked(action.data() == previous_size)
+            finally:
+                for action, signals_were_blocked in zip(
+                        actions,
+                        blocked_states,
+                        strict=True,
+                        ):
+                    action.blockSignals(signals_were_blocked)
+
+        return persist_config_value(
+            self,
+            self.config,
+            "GUI.preview_size",
+            int(preview_size),
+            "the preview size",
+            rollback,
+            )
 
 
 ###############################################################################

--- a/tests/datahandling/test_readonly.py
+++ b/tests/datahandling/test_readonly.py
@@ -13,11 +13,13 @@ from qcodes.dataset import (
     initialise_or_create_database_at,
     load_or_create_experiment,
 )
+from qcodes.dataset.data_set_in_memory import DataSetInMem
 from qcodes.dataset.sqlite.connection import AtomicConnection
 from qcodes.parameters import ManualParameter
 
 from qplot._repair import repair
 from qplot.datahandling import file_identity as file_identity_module
+from qplot.datahandling import readonly as readonly_module
 from qplot.datahandling.database import database_access_error, database_info_rows
 from qplot.datahandling.file_identity import database_file_identity
 from qplot.datahandling.readonly import (
@@ -33,6 +35,7 @@ from qplot.datahandling.readonly import (
 )
 from qplot.datahandling.readSQL import get_runs_via_sql
 from qplot.testdata import RunSpecification, generate_database
+from qplot.windows._dataset_handle import DatasetHandle
 
 
 def test_windows_file_index_is_used_when_stat_inode_is_zero(monkeypatch):
@@ -125,6 +128,65 @@ def _create_default_wal_run(database_path):
     return run_id, guid, table_name
 
 
+def _open_active_wal(database_path):
+    writer = sqlite3.connect(database_path)
+    assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+    writer.execute("PRAGMA wal_autocheckpoint = 0")
+    writer.execute("CREATE TABLE qplot_wal_marker (value INTEGER)")
+    writer.execute("INSERT INTO qplot_wal_marker VALUES (1)")
+    writer.commit()
+    assert Path(f"{database_path}-wal").is_file()
+    assert Path(f"{database_path}-shm").is_file()
+    return writer
+
+
+def _load_read_only(loader_kind, run_id, guid, database_path):
+    if loader_kind == "guid":
+        return load_by_guid_read_only(guid, database_path)
+    if loader_kind == "run_id":
+        return load_by_id_read_only(run_id, database_path)
+    raise AssertionError(f"Unexpected loader kind: {loader_kind}")
+
+
+def _track_explicit_qcodes_connections(monkeypatch):
+    real_open = readonly_module.qcodes_read_only_connection
+    records = []
+
+    def tracked_open(*args, **kwargs):
+        conn = real_open(*args, **kwargs)
+        opened_path = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+        source_path = Path(conn.path_to_dbfile).resolve()
+        snapshot_directory = (
+            opened_path.parent if opened_path != source_path else None
+        )
+        record = SimpleNamespace(
+            connection=conn,
+            close_count=0,
+            snapshot_directory=snapshot_directory,
+        )
+        original_close = conn.close
+
+        def tracked_close():
+            record.close_count += 1
+            return original_close()
+
+        conn.close = tracked_close
+        records.append(record)
+        return conn
+
+    monkeypatch.setattr(
+        readonly_module,
+        "qcodes_read_only_connection",
+        tracked_open,
+    )
+    return records
+
+
+def _assert_connection_closed(conn):
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        conn.execute("SELECT 1")
+
+
 def test_sqlite_read_only_connection_rejects_writes(tmp_path):
     database_path = tmp_path / "plain.db"
     writable = sqlite3.connect(database_path)
@@ -156,6 +218,193 @@ def test_qcodes_read_only_connection_rejects_writes(tmp_path):
             conn.execute("CREATE TABLE qplot_read_only_probe (value INTEGER)")
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize("loader_kind", ["guid", "run_id"])
+def test_database_dataset_owns_connection_until_dataset_handle_closes(
+    tmp_path,
+    monkeypatch,
+    loader_kind,
+):
+    database_path = tmp_path / "owned-active-wal.db"
+    original_database_path = qcodes.config.core.db_location
+    writer = None
+    try:
+        run_id, guid, _table_name = _create_default_wal_run(database_path)
+        writer = _open_active_wal(database_path)
+        source_state = _directory_state(tmp_path)
+        records = _track_explicit_qcodes_connections(monkeypatch)
+
+        dataset = _load_read_only(loader_kind, run_id, guid, database_path)
+
+        assert len(records) == 1
+        record = records[0]
+        assert dataset.conn is record.connection
+        assert record.close_count == 0
+        assert record.connection.execute("SELECT COUNT(*) FROM runs").fetchone() == (1,)
+        assert record.snapshot_directory is not None
+        assert record.snapshot_directory.is_dir()
+
+        handle = DatasetHandle(dataset)
+        assert handle.close()
+        assert record.close_count == 1
+        _assert_connection_closed(record.connection)
+        assert not record.snapshot_directory.exists()
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writer is not None:
+            writer.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+@pytest.mark.parametrize("loader_kind", ["guid", "run_id"])
+def test_missing_result_table_closes_non_owning_dataset_connection(
+    tmp_path,
+    monkeypatch,
+    loader_kind,
+):
+    database_path = tmp_path / "missing-table-active-wal.db"
+    original_database_path = qcodes.config.core.db_location
+    writer = None
+    try:
+        run_id, guid, table_name = _create_default_wal_run(database_path)
+        writer = _open_active_wal(database_path)
+        escaped_table_name = table_name.replace('"', '""')
+        writer.execute(f'DROP TABLE "{escaped_table_name}"')
+        writer.commit()
+        source_state = _directory_state(tmp_path)
+        records = _track_explicit_qcodes_connections(monkeypatch)
+
+        dataset = _load_read_only(loader_kind, run_id, guid, database_path)
+
+        assert isinstance(dataset, DataSetInMem)
+        assert len(records) == 1
+        record = records[0]
+        assert record.close_count == 1
+        _assert_connection_closed(record.connection)
+        assert record.snapshot_directory is not None
+        assert not record.snapshot_directory.exists()
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writer is not None:
+            writer.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+@pytest.mark.parametrize("loader_kind", ["guid", "run_id"])
+def test_exported_netcdf_closes_non_owning_dataset_connection(
+    tmp_path,
+    monkeypatch,
+    loader_kind,
+):
+    pytest.importorskip("xarray")
+    pytest.importorskip("h5netcdf")
+    database_path = tmp_path / "exported.db"
+    original_database_path = qcodes.config.core.db_location
+    writable_dataset = None
+    try:
+        run_id, guid = _create_qcodes_run(database_path)
+        writable_dataset = qcodes.dataset.load_by_id(run_id)
+        writable_dataset.export(export_type="netcdf", path=tmp_path)
+        writable_dataset.conn.close()
+        writable_dataset = None
+        monkeypatch.setattr(
+            qcodes.config.dataset,
+            "load_from_exported_file",
+            True,
+        )
+        source_state = _directory_state(tmp_path)
+        records = _track_explicit_qcodes_connections(monkeypatch)
+
+        dataset = _load_read_only(loader_kind, run_id, guid, database_path)
+
+        assert isinstance(dataset, DataSetInMem)
+        assert dataset.guid == guid
+        assert len(records) == 1
+        record = records[0]
+        assert record.close_count == 1
+        _assert_connection_closed(record.connection)
+        assert record.snapshot_directory is None
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writable_dataset is not None:
+            writable_dataset.conn.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+def test_repeated_in_memory_loads_release_connections_and_wal_snapshots(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "repeated-in-memory-active-wal.db"
+    original_database_path = qcodes.config.core.db_location
+    writer = None
+    try:
+        run_id, guid, table_name = _create_default_wal_run(database_path)
+        writer = _open_active_wal(database_path)
+        escaped_table_name = table_name.replace('"', '""')
+        writer.execute(f'DROP TABLE "{escaped_table_name}"')
+        writer.commit()
+        source_state = _directory_state(tmp_path)
+        records = _track_explicit_qcodes_connections(monkeypatch)
+
+        for index in range(30):
+            loader_kind = "guid" if index % 2 == 0 else "run_id"
+            dataset = _load_read_only(loader_kind, run_id, guid, database_path)
+            assert isinstance(dataset, DataSetInMem)
+            assert len(records) == index + 1
+            record = records[-1]
+            assert record.close_count == 1
+            _assert_connection_closed(record.connection)
+            assert record.snapshot_directory is not None
+            assert not record.snapshot_directory.exists()
+            assert all(item.close_count == 1 for item in records)
+
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writer is not None:
+            writer.close()
+        qcodes.config.core.db_location = original_database_path
+
+
+@pytest.mark.parametrize(
+    ("loader_kind", "qcodes_loader_name"),
+    [("guid", "load_by_guid"), ("run_id", "load_by_id")],
+)
+def test_loader_exception_closes_connection_and_wal_snapshot(
+    tmp_path,
+    monkeypatch,
+    loader_kind,
+    qcodes_loader_name,
+):
+    database_path = tmp_path / "loader-error-active-wal.db"
+    original_database_path = qcodes.config.core.db_location
+    writer = None
+    try:
+        run_id, guid, _table_name = _create_default_wal_run(database_path)
+        writer = _open_active_wal(database_path)
+        source_state = _directory_state(tmp_path)
+        records = _track_explicit_qcodes_connections(monkeypatch)
+
+        def fail_loader(*_args, **_kwargs):
+            raise RuntimeError("loader failed")
+
+        monkeypatch.setattr(readonly_module, qcodes_loader_name, fail_loader)
+
+        with pytest.raises(RuntimeError, match="loader failed"):
+            _load_read_only(loader_kind, run_id, guid, database_path)
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.close_count == 1
+        _assert_connection_closed(record.connection)
+        assert record.snapshot_directory is not None
+        assert not record.snapshot_directory.exists()
+        assert _directory_state(tmp_path) == source_state
+    finally:
+        if writer is not None:
+            writer.close()
+        qcodes.config.core.db_location = original_database_path
 
 
 @pytest.mark.parametrize(
@@ -272,14 +521,23 @@ def test_completed_default_wal_database_opens_from_read_only_directory(
             )
         assert list(runs) == [run_id]
 
-        def load_dataset():
-            dataset = load_by_guid_read_only(guid, database_path)
+        def load_dataset(loader_kind):
+            dataset = _load_read_only(
+                loader_kind,
+                run_id,
+                guid,
+                database_path,
+            )
             try:
                 return dataset.run_id
             finally:
                 dataset.conn.close()
 
-        assert _run_without_source_changes(tmp_path, load_dataset) == run_id
+        for loader_kind in ("guid", "run_id"):
+            assert _run_without_source_changes(
+                tmp_path,
+                lambda loader_kind=loader_kind: load_dataset(loader_kind),
+            ) == run_id
         assert _run_without_source_changes(tmp_path, repair) is None
         assert _run_without_source_changes(
             tmp_path,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
@@ -114,6 +115,120 @@ class TemporaryConfigTestCase(unittest.TestCase):
             )
         self.assertEqual(cfg.get("user_preference.theme"), "light")
         self.assertEqual(list(Path(config.default_path).glob("*.tmp")), [])
+
+    def test_atomic_write_failures_preserve_memory_and_disk_and_allow_retry(self):
+        cfg = config()
+        real_fdopen = os.fdopen
+
+        class FlushFailure:
+            def __init__(self, file_object):
+                self.file_object = file_object
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                self.file_object.close()
+
+            def write(self, value):
+                return self.file_object.write(value)
+
+            def flush(self):
+                raise OSError("simulated flush failure")
+
+            def fileno(self):
+                return self.file_object.fileno()
+
+        def failing_fdopen(*args, **kwargs):
+            return FlushFailure(real_fdopen(*args, **kwargs))
+
+        failures = {
+            "temporary-file creation": patch(
+                "qplot.configuration.config.tempfile.mkstemp",
+                side_effect=OSError("simulated temporary-file failure"),
+                ),
+            "writing": patch(
+                "qplot.configuration.config.json.dump",
+                side_effect=OSError("simulated write failure"),
+                ),
+            "flushing": patch(
+                "qplot.configuration.config.os.fdopen",
+                side_effect=failing_fdopen,
+                ),
+            "fsync": patch(
+                "qplot.configuration.config.os.fsync",
+                side_effect=OSError("simulated fsync failure"),
+                ),
+            "chmod": patch(
+                "qplot.configuration.config.os.chmod",
+                side_effect=OSError("simulated chmod failure"),
+                ),
+            "replace": patch(
+                "qplot.configuration.config.os.replace",
+                side_effect=OSError("simulated replace failure"),
+                ),
+            }
+
+        for stage, failure in failures.items():
+            with self.subTest(stage=stage):
+                cfg.update("user_preference.theme", "light")
+                previous_config = deepcopy(cfg.config)
+                previous_contents = Path(config.default_file).read_text(
+                    encoding="utf-8"
+                    )
+
+                with failure, self.assertRaises(OSError):
+                    cfg.update("user_preference.theme", "dark")
+
+                self.assertEqual(cfg.config, previous_config)
+                self.assertEqual(
+                    Path(config.default_file).read_text(encoding="utf-8"),
+                    previous_contents,
+                    )
+                self.assertEqual(
+                    config().get("user_preference.theme"),
+                    "light",
+                    )
+                self.assertEqual(
+                    list(Path(config.default_path).glob(".config.json.*.tmp")),
+                    [],
+                    )
+
+                cfg.update("user_preference.theme", "dark")
+                self.assertEqual(
+                    config().get("user_preference.theme"),
+                    "dark",
+                    )
+
+    def test_reset_to_defaults_failure_restores_complete_previous_config(self):
+        cfg = config()
+        cfg.update_many({
+            "user_preference.theme": "dark",
+            "GUI.preview_size": 350,
+            "file.last_file_path": "/previous/database.db",
+            })
+        previous_config = deepcopy(cfg.config)
+        previous_contents = Path(config.default_file).read_text(encoding="utf-8")
+
+        with (
+            patch(
+                "qplot.configuration.config.os.replace",
+                side_effect=OSError("simulated reset failure"),
+                ),
+            self.assertRaisesRegex(OSError, "simulated reset failure"),
+            ):
+            cfg.reset_to_defaults()
+
+        self.assertEqual(cfg.config, previous_config)
+        self.assertEqual(
+            Path(config.default_file).read_text(encoding="utf-8"),
+            previous_contents,
+            )
+
+        cfg.reset_to_defaults()
+
+        self.assertEqual(cfg.get("user_preference.theme"), "light")
+        self.assertEqual(config().get("GUI.preview_size"), 200)
 
     def test_config_cli_set_value_converts_values(self):
         with redirect_stdout(io.StringIO()):

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -1,11 +1,15 @@
 import csv
+import os
 import re
+import sqlite3
+from pathlib import Path
 
 import numpy as np
 import pytest
 import qcodes as qc
 from qcodes.dataset import initialise_or_create_database_at, load_by_id
 from qcodes.dataset.measurements import DataSaver
+from qcodes.dataset.sqlite.connection import AtomicConnection
 
 from qplot import testdata as testdata_module
 from qplot.testdata import (
@@ -26,6 +30,40 @@ def write_specification(path, rows):
         writer = csv.writer(handle)
         writer.writerow(CSV_COLUMNS)
         writer.writerows(rows)
+
+
+def small_specification():
+    return testdata_module.RunSpecification(
+        1,
+        "current",
+        "Current",
+        "nA",
+        -1.0,
+        1.0,
+        5,
+    )
+
+
+def assert_generated_database(database_path):
+    assert database_path.is_file()
+    connection = sqlite3.connect(database_path)
+    try:
+        assert connection.execute("SELECT name FROM runs").fetchall() == [("run_1",)]
+    finally:
+        connection.close()
+
+
+def owned_temporary_artifacts(directory):
+    return sorted(
+        path
+        for path in directory.iterdir()
+        if path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+    )
+
+
+def create_all_temporary_sidecars(temporary_path):
+    for suffix in testdata_module._SQLITE_SIDECAR_SUFFIXES:
+        Path(f"{temporary_path}{suffix}").write_bytes(suffix.encode("ascii"))
 
 
 def test_example_csv_is_ready_to_generate(tmp_path):
@@ -365,7 +403,7 @@ def test_cancellation_during_batched_run_removes_temporary_database(
         )
 
     assert not database_path.exists()
-    assert list(tmp_path.glob(".runs-*.db")) == []
+    assert owned_temporary_artifacts(tmp_path) == []
     output = capsys.readouterr().out
     assert "Run stopped (cancelled): run_1" in output
     assert "Test database generation stopped (cancelled)" in output
@@ -392,7 +430,7 @@ def test_generation_failure_reports_timestamped_stop_and_removes_temporary_datab
         generate_database_from_csv(csv_path, database_path)
 
     assert not database_path.exists()
-    assert list(tmp_path.glob(".runs-*.db")) == []
+    assert owned_temporary_artifacts(tmp_path) == []
     output = capsys.readouterr().out
     assert "Run stopped (failed): run_1" in output
     assert "RuntimeError: deliberate failure" in output
@@ -416,7 +454,7 @@ def test_generation_rejects_silently_missing_result_rows(
         generate_database_from_csv(csv_path, database_path)
 
     assert not database_path.exists()
-    assert list(tmp_path.glob(".runs-*.db")) == []
+    assert owned_temporary_artifacts(tmp_path) == []
 
 
 def test_generate_database_requires_explicit_overwrite(tmp_path):
@@ -460,4 +498,272 @@ def test_no_overwrite_publish_does_not_clobber_concurrently_created_file(
         generate_database_from_csv(csv_path, database_path)
 
     assert database_path.read_bytes() == b"concurrent owner"
-    assert list(tmp_path.glob(".runs-*.db")) == []
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+_RESERVED_PATH_COMPONENTS = (
+    pytest.param("hash#scan", id="hash"),
+    pytest.param("question?scan", id="question"),
+    pytest.param("percent%scan", id="literal-percent"),
+    pytest.param("escape%3fscan", id="literal-percent-3f"),
+    pytest.param("escape%23scan", id="literal-percent-23"),
+    pytest.param("space scan", id="space"),
+    pytest.param("unicode-測定", id="unicode"),
+)
+
+
+@pytest.mark.parametrize("component", _RESERVED_PATH_COMPONENTS)
+@pytest.mark.parametrize("location", ("filename", "parent"))
+def test_generate_database_publishes_exact_reserved_path(
+    tmp_path,
+    component,
+    location,
+):
+    if os.name == "nt" and "?" in component:
+        pytest.skip("Windows does not support '?' in filesystem path components")
+
+    if location == "filename":
+        database_path = tmp_path / f"{component}.db"
+    else:
+        output_directory = tmp_path / component
+        output_directory.mkdir()
+        database_path = output_directory / "runs.db"
+
+    generated_path = testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+    )
+
+    assert generated_path == database_path
+    assert_generated_database(database_path)
+    assert owned_temporary_artifacts(database_path.parent) == []
+
+
+def test_qcodes_uri_name_has_exactly_one_encoding_layer(tmp_path):
+    database_path = (
+        tmp_path
+        / "parent # ? % %3f %23 space 測定"
+        / "out # ? % %3f %23 space Δ.db"
+    )
+
+    uri_name = testdata_module._qcodes_uri_name(database_path)
+
+    assert f"file:{uri_name}" == database_path.absolute().as_uri()
+    assert "%23" in uri_name
+    assert "%3F" in uri_name
+    assert "%25" in uri_name
+    assert "%253f" in uri_name
+    assert "%2523" in uri_name
+    assert "%20" in uri_name
+    assert "%E6%B8%AC%E5%AE%9A" in uri_name
+
+
+@pytest.mark.parametrize(
+    ("exact_name", "historical_name"),
+    (
+        pytest.param("exact#scan.db", "exact", id="fragment-truncation"),
+        pytest.param("exact?scan.db", "exact", id="query-truncation"),
+        pytest.param("exact%3fscan.db", "exact?scan.db", id="decoded-question"),
+        pytest.param("exact%23scan.db", "exact#scan.db", id="decoded-hash"),
+    ),
+)
+def test_exact_writable_connection_preserves_historical_sentinel(
+    tmp_path,
+    exact_name,
+    historical_name,
+):
+    if os.name == "nt" and "?" in (exact_name + historical_name):
+        pytest.skip("Windows does not support '?' in filesystem path components")
+
+    exact_path = tmp_path / exact_name
+    historical_path = tmp_path / historical_name
+    sentinel = sqlite3.connect(historical_path)
+    try:
+        sentinel.execute("CREATE TABLE sentinel(value TEXT)")
+        sentinel.execute("INSERT INTO sentinel VALUES ('unchanged')")
+        sentinel.commit()
+    finally:
+        sentinel.close()
+    before = historical_path.read_bytes()
+
+    connection = testdata_module._connect_writable_exact_path(exact_path)
+    try:
+        assert isinstance(connection, AtomicConnection)
+        assert connection.path_to_dbfile == str(exact_path.resolve())
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'runs'"
+        ).fetchone() == ("runs",)
+        assert connection.execute("PRAGMA user_version").fetchone()[0] > 0
+        expected_array = np.array([1.25, 2.5])
+        connection.execute("CREATE TABLE converter_probe(payload array)")
+        connection.execute("INSERT INTO converter_probe VALUES (?)", (expected_array,))
+        converted_array = connection.execute(
+            "SELECT payload FROM converter_probe"
+        ).fetchone()[0]
+        np.testing.assert_array_equal(converted_array, expected_array)
+    finally:
+        connection.close()
+
+    assert exact_path.is_file()
+    assert historical_path.read_bytes() == before
+
+
+def test_generator_does_not_modify_historically_truncated_sentinel(tmp_path):
+    database_path = tmp_path / "out#scan.db"
+    historical_path = tmp_path / ".out"
+    sentinel = sqlite3.connect(historical_path)
+    try:
+        sentinel.execute("CREATE TABLE sentinel(value TEXT)")
+        sentinel.execute("INSERT INTO sentinel VALUES ('unchanged')")
+        sentinel.commit()
+    finally:
+        sentinel.close()
+    before = historical_path.read_bytes()
+
+    testdata_module.generate_database([small_specification()], database_path)
+
+    assert_generated_database(database_path)
+    assert historical_path.read_bytes() == before
+
+
+def test_connection_failure_removes_all_owned_temporary_sidecars(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "parent#scan" / "out%23scan.db"
+    temporary_paths = []
+
+    def fail_connection(temporary_path):
+        temporary_path = Path(temporary_path)
+        temporary_paths.append(temporary_path)
+        create_all_temporary_sidecars(temporary_path)
+        raise RuntimeError("injected connection failure")
+
+    monkeypatch.setattr(
+        testdata_module,
+        "_connect_writable_exact_path",
+        fail_connection,
+    )
+
+    with pytest.raises(RuntimeError, match="injected connection failure"):
+        testdata_module.generate_database([small_specification()], database_path)
+
+    assert len(temporary_paths) == 1
+    assert temporary_paths[0].name.startswith(
+        testdata_module._TEMPORARY_DATABASE_PREFIX
+    )
+    assert "out" not in temporary_paths[0].name
+    assert not database_path.exists()
+    assert owned_temporary_artifacts(database_path.parent) == []
+
+
+def test_generation_failure_removes_all_owned_temporary_sidecars(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "runs.db"
+    temporary_paths = []
+    original_connect = testdata_module._connect_writable_exact_path
+
+    def record_connection(temporary_path):
+        temporary_paths.append(Path(temporary_path))
+        return original_connect(temporary_path)
+
+    def fail_generation(*_args, **_kwargs):
+        create_all_temporary_sidecars(temporary_paths[0])
+        raise RuntimeError("injected generation failure")
+
+    monkeypatch.setattr(
+        testdata_module,
+        "_connect_writable_exact_path",
+        record_connection,
+    )
+    monkeypatch.setattr(testdata_module, "_write_run", fail_generation)
+
+    with pytest.raises(RuntimeError, match="injected generation failure"):
+        testdata_module.generate_database([small_specification()], database_path)
+
+    assert not database_path.exists()
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_publication_failure_removes_all_owned_temporary_sidecars(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "runs.db"
+
+    def fail_publication(temporary_path, _database_path, _overwrite):
+        create_all_temporary_sidecars(temporary_path)
+        raise RuntimeError("injected publication failure")
+
+    monkeypatch.setattr(testdata_module, "_publish_database", fail_publication)
+
+    with pytest.raises(RuntimeError, match="injected publication failure"):
+        testdata_module.generate_database([small_specification()], database_path)
+
+    assert not database_path.exists()
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_cancellation_removes_all_owned_temporary_sidecars(tmp_path):
+    database_path = tmp_path / "runs.db"
+
+    def cancel_with_sidecars():
+        temporary_path = owned_temporary_artifacts(tmp_path)[0]
+        create_all_temporary_sidecars(temporary_path)
+        return True
+
+    with pytest.raises(GenerationCancelled):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            cancelled_callback=cancel_with_sidecars,
+        )
+
+    assert not database_path.exists()
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_overwrite_publish_replaces_concurrently_created_file(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "runs.db"
+    original_write_run = testdata_module._write_run
+
+    def write_run_after_competitor_arrives(*args, **kwargs):
+        points_written = original_write_run(*args, **kwargs)
+        database_path.write_bytes(b"concurrent owner")
+        return points_written
+
+    monkeypatch.setattr(
+        testdata_module,
+        "_write_run",
+        write_run_after_competitor_arrives,
+    )
+
+    testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+        overwrite=True,
+    )
+
+    assert_generated_database(database_path)
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_cli_generates_exact_reserved_output_path(tmp_path):
+    csv_path = tmp_path / "runs.csv"
+    output_directory = tmp_path / "CLI # %3f space 測定"
+    output_directory.mkdir()
+    database_path = output_directory / "out#%23 space 測定.db"
+    write_specification(
+        csv_path,
+        [("1", "current", "Current", "nA", "-1", "1", "5", "", "", "")],
+    )
+
+    assert main([str(csv_path), str(database_path)]) == 0
+
+    assert_generated_database(database_path)
+    assert owned_temporary_artifacts(output_directory) == []

--- a/tests/windows/test_config_transactions.py
+++ b/tests/windows/test_config_transactions.py
@@ -1,0 +1,664 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pyqtgraph as pg
+from PyQt6 import QtCore, QtGui
+from PyQt6 import QtWidgets as qtw
+
+from qplot.configuration.config import config
+from qplot.windows import main as main_window
+from qplot.windows._database_actions import DatabaseActionsMixin
+from qplot.windows._plot2d_colorbar_dialog import ColorbarScaleDialogMixin
+from qplot.windows._plotWin import plotWidget
+from qplot.windows._preferences import PreferencesDialog
+from qplot.windows._run_controls import AUTO_PLOT_KEY, RunControlsMixin
+from qplot.windows._window_controls import (
+    CONFIRM_CLOSE_ALL_KEY,
+    add_config_checkbox_action,
+    ask_confirmation_with_dont_ask_again,
+)
+from qplot.windows.plot2d import plot2d
+
+
+class TransactionalGuiTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.old_default_path = config.default_path
+        self.old_default_file = config.default_file
+        config.default_path = str(Path(self.temp_dir.name) / ".qplot")
+        config.default_file = str(Path(config.default_path) / config.config_file_name)
+        self.config = config()
+
+    def tearDown(self):
+        config.default_path = self.old_default_path
+        config.default_file = self.old_default_file
+        self.temp_dir.cleanup()
+
+    def disk_value(self, key):
+        return config().get(key)
+
+    @staticmethod
+    def failing_save(config_object):
+        return patch.object(
+            config_object,
+            "save_config",
+            side_effect=OSError("simulated config write failure"),
+            )
+
+    def test_refresh_interval_rolls_back_widget_and_exact_timer_state(self):
+        class Harness:
+            monitorIntervalChanged = RunControlsMixin.monitorIntervalChanged
+            _save_refresh_interval = RunControlsMixin._save_refresh_interval
+            _apply_refresh_interval = RunControlsMixin._apply_refresh_interval
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.spinBox = qtw.QDoubleSpinBox()
+                self.spinBox.setValue(1.0)
+                self.monitor = QtCore.QTimer()
+                self.errors = []
+                self.empty_state_syncs = 0
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def _sync_empty_state(self):
+                self.empty_state_syncs += 1
+
+        harness = Harness(self.config)
+        observed_values = []
+        harness.spinBox.valueChanged.connect(
+            lambda value: harness.monitorIntervalChanged(value)
+            )
+        harness.spinBox.valueChanged.connect(observed_values.append)
+        harness.monitor.start(1000)
+
+        try:
+            with self.failing_save(self.config):
+                harness.spinBox.setValue(2.0)
+
+            self.assertEqual(harness.spinBox.value(), 1.0)
+            self.assertTrue(harness.monitor.isActive())
+            self.assertEqual(harness.monitor.interval(), 1000)
+            self.assertEqual(self.config.get("user_preference.default_refresh_rate"), 1.0)
+            self.assertEqual(self.disk_value("user_preference.default_refresh_rate"), 1.0)
+            self.assertEqual(observed_values, [2.0])
+            self.assertEqual(len(harness.errors), 1)
+
+            harness.spinBox.setValue(2.0)
+            self.assertEqual(harness.monitor.interval(), 2000)
+            self.assertTrue(harness.monitor.isActive())
+            self.assertEqual(self.disk_value("user_preference.default_refresh_rate"), 2.0)
+
+            with self.failing_save(self.config):
+                harness.spinBox.setValue(0.0)
+            self.assertEqual(harness.spinBox.value(), 2.0)
+            self.assertTrue(harness.monitor.isActive())
+            self.assertEqual(harness.monitor.interval(), 2000)
+            self.assertEqual(len(harness.errors), 2)
+
+            harness.spinBox.setValue(0.0)
+            self.assertFalse(harness.monitor.isActive())
+            inactive_interval = harness.monitor.interval()
+
+            with self.failing_save(self.config):
+                harness.spinBox.setValue(1.0)
+            self.assertEqual(harness.spinBox.value(), 0.0)
+            self.assertFalse(harness.monitor.isActive())
+            self.assertEqual(harness.monitor.interval(), inactive_interval)
+            self.assertEqual(self.disk_value("user_preference.default_refresh_rate"), 0.0)
+            self.assertEqual(len(harness.errors), 3)
+        finally:
+            harness.monitor.stop()
+            harness.spinBox.deleteLater()
+
+    def test_auto_plot_rolls_back_without_runtime_action_and_retry_succeeds(self):
+        class Harness:
+            _auto_plot_changed = RunControlsMixin._auto_plot_changed
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.autoPlotBox = qtw.QCheckBox()
+                self.errors = []
+                self.auto_plot_calls = 0
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def _auto_plot_current_running_run(self):
+                self.auto_plot_calls += 1
+
+        harness = Harness(self.config)
+        toggles = []
+        harness.autoPlotBox.toggled.connect(
+            lambda checked: harness._auto_plot_changed(checked)
+            )
+        harness.autoPlotBox.toggled.connect(toggles.append)
+
+        try:
+            with self.failing_save(self.config):
+                harness.autoPlotBox.setChecked(True)
+
+            self.assertFalse(harness.autoPlotBox.isChecked())
+            self.assertFalse(self.config.get(AUTO_PLOT_KEY))
+            self.assertFalse(self.disk_value(AUTO_PLOT_KEY))
+            self.assertEqual(harness.auto_plot_calls, 0)
+            self.assertEqual(toggles, [True])
+            self.assertEqual(len(harness.errors), 1)
+
+            harness.autoPlotBox.setChecked(True)
+            self.assertTrue(harness.autoPlotBox.isChecked())
+            self.assertTrue(self.config.get(AUTO_PLOT_KEY))
+            self.assertTrue(self.disk_value(AUTO_PLOT_KEY))
+            self.assertEqual(harness.auto_plot_calls, 1)
+        finally:
+            harness.autoPlotBox.deleteLater()
+
+    def test_theme_and_preview_runtime_commit_only_after_persistence(self):
+        class ThemeHarness:
+            change_theme = main_window.MainWindow.change_theme
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.windows = []
+                self.styles = ["previous stylesheet"]
+                self.statuses = []
+                self.errors = []
+
+            def setStyleSheet(self, stylesheet):
+                self.styles.append(stylesheet)
+
+            def show_status(self, *args):
+                self.statuses.append(args)
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+        theme_harness = ThemeHarness(self.config)
+        group = QtGui.QActionGroup(None)
+        light_action = group.addAction(QtGui.QAction("Light"))
+        dark_action = group.addAction(QtGui.QAction("Dark"))
+        for action in (light_action, dark_action):
+            action.setCheckable(True)
+        light_action.setChecked(True)
+        theme_harness.themes = [light_action, dark_action]
+        theme_calls = []
+        dark_action.triggered.connect(
+            lambda: (
+                theme_calls.append("dark"),
+                theme_harness.change_theme("dark", dark_action),
+                )
+            )
+
+        with self.failing_save(self.config):
+            dark_action.trigger()
+
+        self.assertEqual(theme_calls, ["dark"])
+        self.assertTrue(light_action.isChecked())
+        self.assertFalse(dark_action.isChecked())
+        self.assertEqual(theme_harness.styles, ["previous stylesheet"])
+        self.assertEqual(self.config.get("user_preference.theme"), "light")
+        self.assertEqual(self.disk_value("user_preference.theme"), "light")
+        self.assertEqual(len(theme_harness.errors), 1)
+
+        dark_action.trigger()
+        self.assertTrue(dark_action.isChecked())
+        self.assertEqual(self.disk_value("user_preference.theme"), "dark")
+        self.assertEqual(theme_harness.styles[-1], self.config.theme.main)
+
+        class InfoBox:
+            def __init__(self):
+                self.preview_size = 200
+
+            def set_preview_size(self, value):
+                self.preview_size = value
+
+        class PreviewHarness:
+            change_preview_size = main_window.MainWindow.change_preview_size
+            _save_preview_size = main_window.MainWindow._save_preview_size
+            _configured_preview_size = RunControlsMixin._configured_preview_size
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.preview_size = 200
+                self.infoBox = InfoBox()
+                self.errors = []
+                self.statuses = []
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def show_status(self, *args):
+                self.statuses.append(args)
+
+            def _prioritize_preview_runs(self):
+                pass
+
+        preview_harness = PreviewHarness(self.config)
+        preview_group = QtGui.QActionGroup(None)
+        preview_200 = preview_group.addAction(QtGui.QAction("200 px"))
+        preview_300 = preview_group.addAction(QtGui.QAction("300 px"))
+        for action, value in ((preview_200, 200), (preview_300, 300)):
+            action.setCheckable(True)
+            action.setData(value)
+        preview_200.setChecked(True)
+        preview_harness.previewSizeActions = [preview_200, preview_300]
+        preview_calls = []
+        preview_300.triggered.connect(
+            lambda: (
+                preview_calls.append(300),
+                preview_harness.change_preview_size(300),
+                )
+            )
+
+        with self.failing_save(self.config):
+            preview_300.trigger()
+
+        self.assertEqual(preview_calls, [300])
+        self.assertTrue(preview_200.isChecked())
+        self.assertFalse(preview_300.isChecked())
+        self.assertEqual(preview_harness.preview_size, 200)
+        self.assertEqual(preview_harness.infoBox.preview_size, 200)
+        self.assertEqual(self.config.get("GUI.preview_size"), 200)
+        self.assertEqual(self.disk_value("GUI.preview_size"), 200)
+        self.assertEqual(len(preview_harness.errors), 1)
+
+        preview_300.trigger()
+        self.assertEqual(preview_harness.preview_size, 300)
+        self.assertEqual(preview_harness.infoBox.preview_size, 300)
+        self.assertEqual(self.disk_value("GUI.preview_size"), 300)
+
+    def test_confirmation_actions_rollback_without_recursion_or_duplicate_error(self):
+        window = qtw.QMainWindow()
+        window.config = self.config
+        errors = []
+        window.show_error = lambda *args: errors.append(args)
+        menu = qtw.QMenu(window)
+        action = add_config_checkbox_action(
+            window,
+            menu,
+            "Confirm",
+            CONFIRM_CLOSE_ALL_KEY,
+            "Confirm closes",
+            )
+        toggles = []
+        action.toggled.connect(toggles.append)
+
+        try:
+            with self.failing_save(self.config):
+                action.setChecked(False)
+
+            self.assertTrue(action.isChecked())
+            self.assertTrue(self.config.get(CONFIRM_CLOSE_ALL_KEY))
+            self.assertTrue(self.disk_value(CONFIRM_CLOSE_ALL_KEY))
+            self.assertEqual(toggles, [False])
+            self.assertEqual(len(errors), 1)
+
+            action.setChecked(False)
+            self.assertFalse(action.isChecked())
+            self.assertFalse(self.disk_value(CONFIRM_CLOSE_ALL_KEY))
+
+            self.config.update(CONFIRM_CLOSE_ALL_KEY, True)
+
+            def accept_and_disable(box):
+                box.checkBox().setChecked(True)
+                return qtw.QMessageBox.StandardButton.Yes
+
+            with (
+                patch.object(qtw.QMessageBox, "exec", accept_and_disable),
+                self.failing_save(self.config),
+                ):
+                reply = ask_confirmation_with_dont_ask_again(
+                    window,
+                    "Confirm",
+                    "Continue?",
+                    CONFIRM_CLOSE_ALL_KEY,
+                    )
+
+            self.assertEqual(reply, qtw.QMessageBox.StandardButton.Yes)
+            self.assertTrue(self.config.get(CONFIRM_CLOSE_ALL_KEY))
+            self.assertTrue(self.disk_value(CONFIRM_CLOSE_ALL_KEY))
+            self.assertEqual(len(errors), 2)
+        finally:
+            window.deleteLater()
+
+    def test_mouse_mode_rolls_back_menu_and_viewbox_then_retries(self):
+        class MouseHarness(qtw.QMainWindow):
+            change_mouse_mode = plotWidget.change_mouse_mode
+            apply_mouse_mode_preference = plotWidget.apply_mouse_mode_preference
+            _configured_mouse_mode = plotWidget._configured_mouse_mode
+            _connect_mouse_mode_menu_to_preferences = (
+                plotWidget._connect_mouse_mode_menu_to_preferences
+                )
+
+            def __init__(self, config_object):
+                super().__init__()
+                self.config = config_object
+                self.vb = pg.ViewBox()
+                self.vbMenu = self.vb.menu
+                self.mouseModeAction = next(
+                    action for action in self.vb.menu.actions()
+                    if action.text() == "Mouse Mode"
+                    )
+                self.errors = []
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+        window = MouseHarness(self.config)
+        window.apply_mouse_mode_preference()
+        window._connect_mouse_mode_menu_to_preferences()
+        pan_action, rect_action = window.vbMenu.mouseModes
+        triggers = []
+        rect_action.triggered.connect(lambda: triggers.append("rect"))
+
+        try:
+            with self.failing_save(self.config):
+                rect_action.trigger()
+
+            self.assertEqual(triggers, ["rect"])
+            self.assertTrue(pan_action.isChecked())
+            self.assertFalse(rect_action.isChecked())
+            self.assertEqual(
+                window.vb.getState(copy=False)["mouseMode"],
+                pg.ViewBox.PanMode,
+                )
+            self.assertEqual(self.config.get("user_preference.mouse_mode"), "pan")
+            self.assertEqual(self.disk_value("user_preference.mouse_mode"), "pan")
+            self.assertEqual(len(window.errors), 1)
+
+            rect_action.trigger()
+            self.assertTrue(rect_action.isChecked())
+            self.assertEqual(
+                window.vb.getState(copy=False)["mouseMode"],
+                pg.ViewBox.RectMode,
+                )
+            self.assertEqual(self.disk_value("user_preference.mouse_mode"), "rect")
+        finally:
+            window.vb.deleteLater()
+            window.deleteLater()
+
+    def test_color_map_filter_and_selection_roll_back_then_retry(self):
+        class FilterHarness(qtw.QMainWindow):
+            _set_colorbar_filter_setting = (
+                ColorbarScaleDialogMixin._set_colorbar_filter_setting
+                )
+            _colorbar_include_local_changed = (
+                ColorbarScaleDialogMixin._colorbar_include_local_changed
+                )
+            _sync_colorbar_filter_controls = (
+                ColorbarScaleDialogMixin._sync_colorbar_filter_controls
+                )
+
+            def __init__(self, config_object):
+                super().__init__()
+                self.config = config_object
+                self.colorbar_include_cet_check = qtw.QCheckBox()
+                self.colorbar_include_matplotlib_check = qtw.QCheckBox()
+                self.colorbar_include_local_check = qtw.QCheckBox()
+                self.colorbar_include_custom_check = qtw.QCheckBox()
+                self.colorbar_cet_subtype_checks = {}
+                self.colorbar_matplotlib_subtype_checks = {}
+                for widget in (
+                        self.colorbar_include_cet_check,
+                        self.colorbar_include_matplotlib_check,
+                        self.colorbar_include_local_check,
+                        self.colorbar_include_custom_check,
+                        ):
+                    widget.setChecked(True)
+                self.errors = []
+                self.rebuilds = 0
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def _populate_colorbar_colormap_table(self):
+                self.rebuilds += 1
+
+            def _sync_colorbar_scale_controls(self):
+                self._sync_colorbar_filter_controls()
+
+        window = FilterHarness(self.config)
+        toggles = []
+        window.colorbar_include_local_check.toggled.connect(
+            window._colorbar_include_local_changed
+            )
+        window.colorbar_include_local_check.toggled.connect(toggles.append)
+
+        try:
+            with self.failing_save(self.config):
+                window.colorbar_include_local_check.setChecked(False)
+
+            self.assertTrue(window.colorbar_include_local_check.isChecked())
+            self.assertTrue(
+                self.config.get("user_preference.bar_colour_include_local")
+                )
+            self.assertTrue(
+                self.disk_value("user_preference.bar_colour_include_local")
+                )
+            self.assertEqual(toggles, [False])
+            self.assertEqual(window.rebuilds, 0)
+            self.assertEqual(len(window.errors), 1)
+
+            window.colorbar_include_local_check.setChecked(False)
+            self.assertFalse(window.colorbar_include_local_check.isChecked())
+            self.assertFalse(
+                self.disk_value("user_preference.bar_colour_include_local")
+                )
+            self.assertEqual(window.rebuilds, 1)
+        finally:
+            window.deleteLater()
+
+        class Colorbar:
+            def __init__(self):
+                self.color_map = "previous color map"
+
+            def setColorMap(self, color_map):
+                self.color_map = color_map
+
+        plot = plot2d.__new__(plot2d)
+        qtw.QMainWindow.__init__(plot)
+        plot.config = self.config
+        plot.bar = Colorbar()
+        plot._colorbar_colormap_name = "viridis"
+        plot.colorbar_colormap_table = None
+        plot_errors = []
+        plot.show_error = lambda *args: plot_errors.append(args)
+
+        try:
+            with self.failing_save(self.config):
+                self.assertFalse(plot.setColorbarColorMap("Purples"))
+
+            self.assertEqual(plot._colorbar_colormap_name, "viridis")
+            self.assertEqual(plot.bar.color_map, "previous color map")
+            self.assertEqual(self.config.get("user_preference.bar_colour"), "viridis")
+            self.assertEqual(self.disk_value("user_preference.bar_colour"), "viridis")
+            self.assertEqual(len(plot_errors), 1)
+
+            self.assertTrue(plot.setColorbarColorMap("Purples"))
+            self.assertEqual(plot._colorbar_colormap_name, "Purples")
+            self.assertIsInstance(plot.bar.color_map, pg.ColorMap)
+            self.assertEqual(self.disk_value("user_preference.bar_colour"), "Purples")
+        finally:
+            plot.deleteLater()
+
+    def test_default_recent_and_last_database_paths_are_atomic(self):
+        class Harness:
+            change_default_file = DatabaseActionsMixin.change_default_file
+            recent_database_paths = DatabaseActionsMixin.recent_database_paths
+            remember_recent_database = DatabaseActionsMixin.remember_recent_database
+            remember_loaded_database = DatabaseActionsMixin.remember_loaded_database
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.errors = []
+                self.statuses = []
+                self.menu_refreshes = 0
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def show_status(self, *args):
+                self.statuses.append(args)
+
+            def refresh_recent_database_menu(self):
+                self.menu_refreshes += 1
+
+        harness = Harness(self.config)
+        folder = self.temp_dir.name
+
+        with (
+            patch.object(qtw.QFileDialog, "getExistingDirectory", return_value=folder),
+            self.failing_save(self.config),
+            ):
+            self.assertFalse(harness.change_default_file())
+
+        self.assertEqual(self.config.get("file.default_load_path"), "")
+        self.assertEqual(self.disk_value("file.default_load_path"), "")
+        self.assertEqual(len(harness.errors), 1)
+
+        with patch.object(qtw.QFileDialog, "getExistingDirectory", return_value=folder):
+            self.assertTrue(harness.change_default_file())
+        self.assertEqual(self.disk_value("file.default_load_path"), folder)
+
+        recent_path = os.path.abspath("recent.db")
+        with self.failing_save(self.config):
+            self.assertFalse(harness.remember_recent_database(recent_path))
+        self.assertEqual(self.config.get("file.recent_file_paths"), [])
+        self.assertEqual(self.disk_value("file.recent_file_paths"), [])
+        self.assertEqual(harness.menu_refreshes, 0)
+        self.assertEqual(len(harness.errors), 2)
+
+        self.assertTrue(harness.remember_recent_database(recent_path))
+        self.assertEqual(self.disk_value("file.recent_file_paths"), [recent_path])
+        self.assertEqual(harness.menu_refreshes, 1)
+
+        previous_last = os.path.abspath("previous.db")
+        self.config.update_many({
+            "file.last_file_path": previous_last,
+            "file.recent_file_paths": [previous_last, recent_path],
+            })
+        new_path = os.path.abspath("new.db")
+        with (
+            patch.object(self.config, "update_many", wraps=self.config.update_many) as update,
+            self.failing_save(self.config),
+            ):
+            self.assertFalse(harness.remember_loaded_database(new_path))
+            self.assertEqual(update.call_count, 1)
+            self.assertEqual(
+                set(update.call_args.args[0]),
+                {"file.last_file_path", "file.recent_file_paths"},
+                )
+
+        self.assertEqual(self.config.get("file.last_file_path"), previous_last)
+        self.assertEqual(
+            self.config.get("file.recent_file_paths"),
+            [previous_last, recent_path],
+            )
+        self.assertEqual(self.disk_value("file.last_file_path"), previous_last)
+        self.assertEqual(len(harness.errors), 3)
+
+        self.assertTrue(harness.remember_loaded_database(new_path))
+        self.assertEqual(self.disk_value("file.last_file_path"), new_path)
+        self.assertEqual(
+            self.disk_value("file.recent_file_paths"),
+            [new_path, previous_last, recent_path],
+            )
+
+    def test_gui_reset_waits_for_persistence_and_can_retry(self):
+        self.config.update("user_preference.theme", "dark")
+
+        class Harness:
+            restore_default_settings = main_window.MainWindow.restore_default_settings
+
+            def __init__(self, config_object):
+                self.config = config_object
+                self.errors = []
+                self.closed_plots = 0
+                self.applied = 0
+                self.closed_database = 0
+                self.statuses = []
+
+            def show_error(self, *args):
+                self.errors.append(args)
+
+            def show_status(self, *args):
+                self.statuses.append(args)
+
+            def close_plot_windows(self, **_kwargs):
+                self.closed_plots += 1
+
+            def apply_current_settings(self):
+                self.applied += 1
+
+            def close_database(self, **_kwargs):
+                self.closed_database += 1
+
+        harness = Harness(self.config)
+        with (
+            patch.object(
+                qtw.QMessageBox,
+                "question",
+                return_value=qtw.QMessageBox.StandardButton.Yes,
+                ),
+            self.failing_save(self.config),
+            ):
+            self.assertFalse(harness.restore_default_settings())
+
+        self.assertEqual(self.config.get("user_preference.theme"), "dark")
+        self.assertEqual(self.disk_value("user_preference.theme"), "dark")
+        self.assertEqual(harness.closed_plots, 0)
+        self.assertEqual(harness.applied, 0)
+        self.assertEqual(harness.closed_database, 0)
+        self.assertEqual(len(harness.errors), 1)
+
+        with patch.object(
+                qtw.QMessageBox,
+                "question",
+                return_value=qtw.QMessageBox.StandardButton.Yes,
+                ):
+            self.assertTrue(harness.restore_default_settings())
+
+        self.assertEqual(self.disk_value("user_preference.theme"), "light")
+        self.assertEqual(harness.closed_plots, 1)
+        self.assertEqual(harness.applied, 1)
+        self.assertEqual(harness.closed_database, 1)
+
+    def test_preferences_failure_rolls_back_widgets_and_success_still_applies(self):
+        dialog = PreferencesDialog(self.config)
+        notifications = []
+        applied = []
+        dialog.preferencesApplied.connect(lambda: applied.append(True))
+        dialog.themeCombo.setCurrentIndex(dialog.themeCombo.findData("dark"))
+        dialog.previewSizeSpin.setValue(300)
+
+        try:
+            with (
+                patch.object(
+                    qtw.QMessageBox,
+                    "exec",
+                    lambda box: notifications.append(box.text()) or 0,
+                    ),
+                self.failing_save(self.config),
+                ):
+                self.assertFalse(dialog.apply_preferences())
+
+            self.assertEqual(dialog.themeCombo.currentData(), "light")
+            self.assertEqual(dialog.previewSizeSpin.value(), 200)
+            self.assertEqual(self.config.get("user_preference.theme"), "light")
+            self.assertEqual(self.disk_value("GUI.preview_size"), 200)
+            self.assertEqual(applied, [])
+            self.assertEqual(len(notifications), 1)
+            self.assertIn("previous setting is still active", notifications[0])
+
+            dialog.themeCombo.setCurrentIndex(dialog.themeCombo.findData("dark"))
+            dialog.previewSizeSpin.setValue(300)
+            self.assertTrue(dialog.apply_preferences())
+            self.assertEqual(self.disk_value("user_preference.theme"), "dark")
+            self.assertEqual(self.disk_value("GUI.preview_size"), 300)
+            self.assertEqual(applied, [True])
+        finally:
+            dialog.deleteLater()

--- a/tests/windows/test_plot_integration.py
+++ b/tests/windows/test_plot_integration.py
@@ -1034,7 +1034,9 @@ def test_loaded_path_test_database_generation_uses_replacement_reload(
 ):
     configure_temp_qplot(monkeypatch, tmp_path)
     original_database_path = qcodes.config.core.db_location
-    database_path = Path(tmp_path) / "generated.db"
+    output_directory = Path(tmp_path) / "loaded # %23 space 測定"
+    output_directory.mkdir()
+    database_path = output_directory / "generated#%3f 測定.db"
     initial_specification = RunSpecification(
         1,
         "current",

--- a/tests/windows/test_testdata_gui.py
+++ b/tests/windows/test_testdata_gui.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from PyQt6 import QtGui
 from PyQt6 import QtWidgets as qtw
 
+from qplot import testdata as testdata_module
 from qplot.testdata import CSV_COLUMNS, INSTRUCTION_FILE_NAMES
 from qplot.windows._database_actions import (
     DatabaseActionsMixin,
@@ -122,7 +123,9 @@ def test_reveal_file_uses_finder_selection_on_macos(tmp_path):
 def test_generate_database_from_csv_runs_in_worker_pool(tmp_path):
     harness = GuiHarness(tmp_path)
     csv_path = tmp_path / "runs.csv"
-    database_path = tmp_path / "runs.db"
+    output_directory = tmp_path / "GUI # %3f space 測定"
+    output_directory.mkdir()
+    database_path = output_directory / "out#%23 space 測定.db"
     write_small_specification(csv_path)
 
     try:
@@ -181,7 +184,10 @@ def test_generation_completion_force_reloads_replaced_current_database(tmp_path)
 def test_generation_releases_current_database_before_replacing_it(tmp_path):
     harness = GuiHarness(tmp_path)
     csv_path = tmp_path / "runs.csv"
-    database_path = tmp_path / "runs.db"
+    output_directory = tmp_path / "loaded # %23 測定"
+    output_directory.mkdir()
+    database_path = output_directory / "runs#%3f 測定.db"
+    database_path.write_bytes(b"old database")
     write_small_specification(csv_path)
     harness.fileTextbox = type(
         "Field",
@@ -203,6 +209,11 @@ def test_generation_releases_current_database_before_replacing_it(tmp_path):
                 "getSaveFileName",
                 return_value=(str(database_path), "QCoDeS Database (*.db)"),
             ),
+            patch.object(
+                qtw.QMessageBox,
+                "question",
+                return_value=qtw.QMessageBox.StandardButton.Yes,
+            ),
         ):
             assert harness.generate_test_database_from_csv()
 
@@ -210,6 +221,13 @@ def test_generation_releases_current_database_before_replacing_it(tmp_path):
             str(database_path)
         )
         harness.load_file.assert_called_once_with(str(database_path), force=True)
+        connection = sqlite3.connect(database_path)
+        try:
+            assert connection.execute("SELECT name FROM runs").fetchall() == [
+                ("run_1",)
+            ]
+        finally:
+            connection.close()
     finally:
         harness.deleteLater()
 
@@ -265,6 +283,83 @@ def test_generation_cancelled_before_first_run_removes_temporary_database(tmp_pa
             assert harness.generate_test_database_from_csv()
 
         assert not database_path.exists()
-        assert list(tmp_path.glob(".runs-*.db")) == []
+        assert not any(
+            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+            for path in tmp_path.iterdir()
+        )
+    finally:
+        harness.deleteLater()
+
+
+def test_generation_declined_overwrite_leaves_existing_output_unchanged(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    database_path.write_bytes(b"existing owner")
+    write_small_specification(csv_path)
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+            patch.object(
+                qtw.QMessageBox,
+                "question",
+                return_value=qtw.QMessageBox.StandardButton.No,
+            ) as question,
+        ):
+            assert not harness.generate_test_database_from_csv()
+
+        question.assert_called_once()
+        assert database_path.read_bytes() == b"existing owner"
+        assert harness._test_database_generation_worker is None
+        assert "cancelled" in harness.status_messages[-1][0].lower()
+    finally:
+        harness.deleteLater()
+
+
+def test_new_gui_output_does_not_clobber_publication_race(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    write_small_specification(csv_path)
+
+    class RacingThreadPool:
+        def start(self, worker):
+            assert not worker.overwrite
+            database_path.write_bytes(b"concurrent owner")
+            worker.run()
+
+    harness.testDatabaseGenerationThreadPool = RacingThreadPool()
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+        ):
+            assert harness.generate_test_database_from_csv()
+
+        assert database_path.read_bytes() == b"concurrent owner"
+        assert harness.errors[0][0] == "Test Database Generation Failed"
+        assert "already exists" in harness.errors[0][2]
+        assert not any(
+            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+            for path in tmp_path.iterdir()
+        )
     finally:
         harness.deleteLater()


### PR DESCRIPTION
## Summary

- Preserve exact user-selected synthetic database output paths, including URI-significant characters, while keeping temporary basenames and SQLite sidecar cleanup safe.
- Make explicit overwrite and loaded-database replacement race-safe.
- Add shared transactional persistence for configuration-backed GUI actions.
- Treat the last successfully persisted configuration as authoritative: persist before dependent runtime changes where possible, otherwise restore widgets and runtime state with signals blocked.
- Log the underlying persistence exception and show one actionable user-facing error without allowing exceptions to escape Qt callbacks.
- Make reset-to-defaults transactional and update last/recent database paths atomically.
- Preserve the successful Preferences dialog behavior.
- Make read-only GUID and run-ID loaders explicitly close caller-owned QCoDeS connections when the result is `DataSetInMem` or any other non-owning result.
- Retain database-backed `DataSet` connections until their `DatasetHandle` closes them, including private active-WAL snapshots.

## Root causes

QCoDeS prepends `file:` to database paths, so SQLite interpreted characters such as `#`, `?`, and `%` as URI syntax. Separately, several GUI slots updated controls or live runtime state before saving configuration, allowed write failures to escape Qt callbacks, or mutated configuration directly before an unprotected save. A failed reset could also leave memory and disk representing different configurations.

For read-only loading, qPlot supplies an explicit connection to QCoDeS. A database-backed `DataSet` assumes ownership of that connection, but `DataSetInMem` deliberately does not. The wrappers previously closed only when loading raised, leaving non-owning successful results to eventual garbage collection.

## Impact

Configuration-backed GUI actions now either commit widget state, runtime state, in-memory configuration, and on-disk configuration together, or keep all four at their previous values. Failed actions do not recurse or duplicate notifications, and a later successful retry works normally.

Covered actions include refresh interval and manual-refresh state, auto-plot, theme, preview size, close confirmations, mouse mode, color-map filters, recent/default/last database paths, reset-to-defaults, and Preferences.

Read-only loaders now transfer connection ownership only to QCoDeS's database-backed `DataSet` type. All non-owning results and all exception paths close immediately through the snapshot-aware connection close path, releasing SQLite descriptors and private WAL snapshot directories without changing the source database or its `-wal`, `-shm`, or `-journal` artifacts.

## Regression coverage

- Reserved and URI-significant synthetic database paths.
- Generation failure, overwrite, and replacement races.
- Configuration failures during temporary-file creation, writing, flushing/fsync, chmod where applicable, and `os.replace`.
- Exact timer interval and active/inactive rollback.
- Widget/runtime/memory/disk atomicity for all audited GUI actions.
- No escaped Qt exception, recursive signal, or duplicated notification.
- Preferences dialog regression behavior.
- GUID and run-ID ownership transfer for ordinary database-backed datasets.
- Missing raw-result-table and exported-NetCDF `DataSetInMem` loading.
- Thirty alternating GUID/run-ID in-memory loads without retained connections or snapshot directories.
- Loader exception cleanup, completed databases, active WAL snapshots, reserved-character paths, and unchanged source SQLite artifacts.

## Validation

- Focused read-only and dataset-handle tests: **34 passed**
- Complete suite: **685 passed**
- Ruff: **passed**
- mypy: **passed (63 source files)**
- qPlot smoke test: **launched successfully from the project virtual environment**