### PR TITLE
Honor staged storage polling

### DIFF
--- a/src/qplot/datahandling/readSQL.py
+++ b/src/qplot/datahandling/readSQL.py
@@ -1,10 +1,16 @@
 import json
 import math
 import os
+from typing import Literal, NamedTuple
 
 from qcodes.dataset.sqlite.database import get_DB_location
 
 from qplot.datahandling.readonly import qcodes_read_only_connection
+
+
+class _StorageSize(NamedTuple):
+    bytes: int | None
+    accuracy: Literal["exact", "estimated", "unavailable"]
 
 
 def _install_cancel_progress_handler(conn, cancelled_callback):
@@ -410,22 +416,40 @@ def _add_run_detail_fields(
     if include_storage_bytes:
         table_name = metadata.get("result_table_name")
         if storage_bytes_by_table is not None:
-            metadata["storage_bytes"] = storage_bytes_by_table.get(table_name)
-            metadata["storage_bytes_estimated"] = False
+            storage_bytes = storage_bytes_by_table.get(table_name)
+            storage_size = _StorageSize(
+                storage_bytes,
+                "exact" if storage_bytes is not None else "unavailable",
+                )
         else:
-            metadata["storage_bytes"] = _table_storage_bytes(
+            storage_size = _table_storage_bytes(
                 cursor,
                 table_name,
                 result_count=metadata.get("result_count"),
                 )
-            metadata["storage_bytes_estimated"] = False
+        _add_storage_size_fields(metadata, storage_size)
     elif include_storage_estimate:
-        metadata["storage_bytes"] = _estimated_table_storage_bytes(
+        storage_bytes = _estimated_table_storage_bytes(
             cursor,
             metadata.get("result_table_name"),
             result_count=metadata.get("result_count"),
             )
-        metadata["storage_bytes_estimated"] = True
+        _add_storage_size_fields(
+            metadata,
+            _StorageSize(
+                storage_bytes,
+                "estimated" if storage_bytes is not None else "unavailable",
+                ),
+            )
+
+
+def _add_storage_size_fields(metadata, storage_size):
+    metadata["storage_bytes"] = storage_size.bytes
+    metadata["storage_bytes_estimated"] = {
+        "exact": False,
+        "estimated": True,
+        "unavailable": None,
+        }[storage_size.accuracy]
 
 
 def _add_observed_shape_fields(cursor, metadata):
@@ -864,25 +888,30 @@ def _sqlite_identifier(name):
 
 def _table_storage_bytes(cursor, table_name, result_count=None):
     if not table_name:
-        return None
+        return _StorageSize(None, "unavailable")
 
     try:
         cursor.execute("SELECT SUM(pgsize) FROM dbstat WHERE name = ?", (table_name, ))
-        value = cursor.fetchone()[0]
-    except Exception:
-        return _estimated_table_storage_bytes(
-            cursor,
-            table_name,
-            result_count=result_count,
-            )
+        row = cursor.fetchone()
+        value = row[0] if row else None
+        if value is not None:
+            return _StorageSize(int(value), "exact")
+    except Exception as err:
+        if _sql_was_interrupted(err):
+            raise
 
-    if value is None:
-        return _estimated_table_storage_bytes(
-            cursor,
-            table_name,
-            result_count=result_count,
-            )
-    return int(value)
+    estimated_bytes = _estimated_table_storage_bytes(
+        cursor,
+        table_name,
+        result_count=result_count,
+        )
+    if estimated_bytes is None:
+        return _StorageSize(None, "unavailable")
+    return _StorageSize(estimated_bytes, "estimated")
+
+
+def _sql_was_interrupted(error):
+    return "interrupted" in str(error).lower()
 
 
 def _run_storage_tables(cursor, run_ids):
@@ -928,7 +957,9 @@ def _table_storage_bytes_by_name(cursor, table_names):
             """,
             tuple(table_names),
             )
-    except Exception:
+    except Exception as err:
+        if _sql_was_interrupted(err):
+            raise
         return {}
 
     sizes = {}
@@ -1020,16 +1051,21 @@ def get_run_status(
         if value is None:
             return {}
 
-        is_completed = bool(value[1])
         status = {
             "completed_timestamp": value[0],
             "is_completed": value[1],
             "result_count": _result_count(cursor, value[2]),
             "database_modified_timestamp": _database_modified_timestamp(cursor),
             }
-        if include_storage_bytes or is_completed:
-            status["storage_bytes"] = _table_storage_bytes(cursor, value[2])
-            status["storage_bytes_estimated"] = False
+        if include_storage_bytes:
+            _add_storage_size_fields(
+                status,
+                _table_storage_bytes(
+                    cursor,
+                    value[2],
+                    result_count=status["result_count"],
+                    ),
+                )
         for index, column in enumerate(optional_columns, start=5):
             status[column] = value[index]
 

--- a/tests/datahandling/test_read_sql.py
+++ b/tests/datahandling/test_read_sql.py
@@ -3,11 +3,49 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from unittest.mock import Mock, patch
 
 from qplot.datahandling import readSQL
 
 
 class RunSizeTestCase(unittest.TestCase):
+    def _read_only_sqlite_connection(self, database_path):
+        return sqlite3.connect(f"file:{database_path}?mode=ro", uri=True)
+
+    def _create_completed_status_database(self, database_path, row_count=4):
+        conn = sqlite3.connect(database_path)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE runs (
+                    guid TEXT,
+                    completed_timestamp REAL,
+                    is_completed INTEGER,
+                    result_table_name TEXT,
+                    run_description TEXT,
+                    parameters TEXT
+                )
+                """
+                )
+            conn.execute("CREATE TABLE results_1 (x REAL, signal REAL)")
+            conn.executemany(
+                "INSERT INTO results_1 VALUES (?, ?)",
+                ((index, index + 1) for index in range(row_count)),
+                )
+            run_description = json.dumps({
+                "interdependencies_": {
+                    "dependencies": {"signal": ["x"]},
+                    },
+                "shapes": {"signal": [row_count]},
+                })
+            conn.execute(
+                "INSERT INTO runs VALUES (?, 123, 1, ?, ?, ?)",
+                ("completed-guid", "results_1", run_description, "x,signal"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
     def test_cancel_progress_handler_interrupts_a_running_sql_statement(self):
         conn = sqlite3.connect(":memory:")
         callback_count = 0
@@ -37,6 +75,179 @@ class RunSizeTestCase(unittest.TestCase):
                 readSQL._install_cancel_progress_handler(conn, lambda: True)
         finally:
             conn.close()
+
+    def test_completed_status_excludes_every_storage_query_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "completed.db")
+            self._create_completed_status_database(database_path)
+            statements = []
+
+            def trace_connection(connection):
+                if connection is not None:
+                    connection.set_trace_callback(statements.append)
+
+            with (
+                patch.object(
+                    readSQL,
+                    "qcodes_read_only_connection",
+                    side_effect=self._read_only_sqlite_connection,
+                    ),
+                patch.object(
+                    readSQL,
+                    "_table_storage_bytes",
+                    side_effect=AssertionError("storage helper must not run"),
+                    ) as storage_size,
+                ):
+                status = readSQL.get_run_status(
+                    "completed-guid",
+                    database_path=database_path,
+                    include_storage_bytes=False,
+                    connection_callback=trace_connection,
+                    )
+
+        storage_size.assert_not_called()
+        self.assertTrue(status["is_completed"])
+        self.assertNotIn("storage_bytes", status)
+        self.assertNotIn("storage_bytes_estimated", status)
+        self.assertFalse(any("DBSTAT" in sql.upper() for sql in statements))
+        self.assertFalse(any(
+            "TABLE_INFO(\"RESULTS_1\")" in sql.upper()
+            for sql in statements
+            ))
+
+    def test_status_includes_storage_calculation_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "completed.db")
+            self._create_completed_status_database(database_path)
+            expected = readSQL._StorageSize(4096, "exact")
+            with (
+                patch.object(
+                    readSQL,
+                    "qcodes_read_only_connection",
+                    side_effect=self._read_only_sqlite_connection,
+                    ),
+                patch.object(
+                    readSQL,
+                    "_table_storage_bytes",
+                    return_value=expected,
+                    ) as storage_size,
+                ):
+                status = readSQL.get_run_status(
+                    "completed-guid",
+                    database_path=database_path,
+                    include_storage_bytes=True,
+                    )
+
+        storage_size.assert_called_once()
+        self.assertEqual(storage_size.call_args.args[1], "results_1")
+        self.assertEqual(storage_size.call_args.kwargs["result_count"], 4)
+        self.assertEqual(status["storage_bytes"], 4096)
+        self.assertFalse(status["storage_bytes_estimated"])
+
+    def test_successful_dbstat_storage_size_is_exact(self):
+        cursor = Mock()
+        cursor.fetchone.return_value = (8192, )
+
+        storage_size = readSQL._table_storage_bytes(cursor, "results_1")
+        metadata = {}
+        readSQL._add_storage_size_fields(metadata, storage_size)
+
+        self.assertEqual(storage_size, readSQL._StorageSize(8192, "exact"))
+        self.assertEqual(metadata, {
+            "storage_bytes": 8192,
+            "storage_bytes_estimated": False,
+            })
+        cursor.execute.assert_called_once_with(
+            "SELECT SUM(pgsize) FROM dbstat WHERE name = ?",
+            ("results_1", ),
+            )
+
+    def test_missing_and_failing_dbstat_storage_sizes_are_estimated(self):
+        for dbstat_failure in (None, sqlite3.OperationalError("no such table: dbstat")):
+            with self.subTest(dbstat_failure=dbstat_failure):
+                cursor = Mock()
+                if dbstat_failure is None:
+                    cursor.fetchone.return_value = (None, )
+                else:
+                    cursor.execute.side_effect = [dbstat_failure, None]
+                cursor.fetchall.return_value = [
+                    (0, "signal", "REAL", 0, None, 0),
+                    ]
+
+                storage_size = readSQL._table_storage_bytes(
+                    cursor,
+                    "results_1",
+                    result_count=10,
+                    )
+                metadata = {}
+                readSQL._add_storage_size_fields(metadata, storage_size)
+
+                self.assertEqual(
+                    storage_size,
+                    readSQL._StorageSize(110, "estimated"),
+                    )
+                self.assertEqual(metadata, {
+                    "storage_bytes": 110,
+                    "storage_bytes_estimated": True,
+                    })
+
+    def test_unavailable_storage_sizes_have_consistent_metadata(self):
+        cursor = Mock()
+        cursor.execute.side_effect = [
+            sqlite3.OperationalError("no such table: dbstat"),
+            None,
+            ]
+        cursor.fetchall.return_value = []
+
+        storage_size = readSQL._table_storage_bytes(
+            cursor,
+            "missing_results",
+            result_count=10,
+            )
+        metadata = {}
+        readSQL._add_storage_size_fields(metadata, storage_size)
+
+        self.assertEqual(storage_size, readSQL._StorageSize(None, "unavailable"))
+        self.assertEqual(metadata, {
+            "storage_bytes": None,
+            "storage_bytes_estimated": None,
+            })
+
+    def test_interrupted_exact_storage_query_is_not_converted_to_an_estimate(self):
+        cursor = Mock()
+        cursor.execute.side_effect = sqlite3.OperationalError("interrupted")
+
+        with self.assertRaisesRegex(sqlite3.OperationalError, "interrupted"):
+            readSQL._table_storage_bytes(cursor, "results_1", result_count=10)
+
+    def test_large_completed_status_does_not_scan_storage(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "large.db")
+            self._create_completed_status_database(database_path, row_count=50_000)
+            statements = []
+
+            def trace_connection(connection):
+                if connection is not None:
+                    connection.set_trace_callback(statements.append)
+
+            with patch.object(
+                    readSQL,
+                    "qcodes_read_only_connection",
+                    side_effect=self._read_only_sqlite_connection,
+                    ):
+                status = readSQL.get_run_status(
+                    "completed-guid",
+                    database_path=database_path,
+                    include_storage_bytes=False,
+                    connection_callback=trace_connection,
+                    )
+
+        self.assertEqual(status["result_count"], 50_000)
+        self.assertFalse(any("DBSTAT" in sql.upper() for sql in statements))
+        self.assertFalse(any(
+            "TABLE_INFO(\"RESULTS_1\")" in sql.upper()
+            for sql in statements
+            ))
 
     def test_has_finished_returns_optional_timestamp_scalar(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -341,6 +552,7 @@ class RunSizeTestCase(unittest.TestCase):
 
             self.assertEqual(runs[1]["result_count"], 4)
             self.assertEqual(runs[1]["storage_bytes"], 116)
+            self.assertTrue(runs[1]["storage_bytes_estimated"])
             self.assertFalse(any("DBSTAT" in statement.upper() for statement in statements))
             self.assertFalse(any("SUM(" in statement.upper() for statement in statements))
         finally:

--- a/tests/widgets/test_run_list.py
+++ b/tests/widgets/test_run_list.py
@@ -874,6 +874,47 @@ class RunListTooltipTestCase(unittest.TestCase):
         finally:
             treeWidgets.isfile = old_isfile
 
+    def test_update_runs_replaces_prompt_estimate_with_later_exact_size(self):
+        old_isfile = treeWidgets.isfile
+        treeWidgets.isfile = lambda _: False
+
+        try:
+            run_list = treeWidgets.RunList()
+            run_list.addRuns({
+                1: {
+                    "run_timestamp": 100.0,
+                    "completed_timestamp": 110.0,
+                    "is_completed": True,
+                    "guid": "run-guid",
+                    "sweep_parameters": ["x"],
+                    "measure_parameters": ["signal"],
+                    },
+                })
+
+            estimated = run_list.updateRuns({
+                1: {
+                    "guid": "run-guid",
+                    "storage_bytes": 1024,
+                    "storage_bytes_estimated": True,
+                    },
+                })
+            exact = run_list.updateRuns({
+                1: {
+                    "guid": "run-guid",
+                    "storage_bytes": 4096,
+                    "storage_bytes_estimated": False,
+                    },
+                })
+
+            item = run_list.topLevelItem(0)
+            self.assertEqual(estimated[1]["storage_bytes"], 1024)
+            self.assertTrue(estimated[1]["storage_bytes_estimated"])
+            self.assertEqual(exact[1]["storage_bytes"], 4096)
+            self.assertFalse(exact[1]["storage_bytes_estimated"])
+            self.assertEqual(item.text(run_list.cols.index("Size")), "4.0 KB")
+        finally:
+            treeWidgets.isfile = old_isfile
+
     def test_check_watching_reports_finished_interrupted_run(self):
         old_isfile = treeWidgets.isfile
         old_get_run_status = treeWidgets.get_run_status

--- a/tests/windows/test_main_window.py
+++ b/tests/windows/test_main_window.py
@@ -3737,7 +3737,7 @@ class DatabaseRefreshWorkerTestCase(unittest.TestCase):
 
         def get_status(guid, **kwargs):
             seen_status_calls.append((guid, kwargs))
-            return {"result_count": 12}
+            return {"is_completed": True, "result_count": 12}
 
         worker = database_module.DatabaseRefreshWorker(
             4,
@@ -3782,8 +3782,8 @@ class DatabaseRefreshWorkerTestCase(unittest.TestCase):
             "example.db",
             {11: {"guid": "guid-11"}},
             {
-                "guid-1": {"result_count": 12},
-                "guid-2": {"result_count": 12},
+                "guid-1": {"is_completed": True, "result_count": 12},
+                "guid-2": {"is_completed": True, "result_count": 12},
                 },
             None,
             )])
@@ -4130,6 +4130,7 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
                             "guid": "guid-2",
                             "result_count": 20,
                             "storage_bytes": 1000,
+                            "storage_bytes_estimated": True,
                             }
                         }
                 elif run_id == 1:
@@ -4161,7 +4162,14 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             ])
         self.assertEqual(batches, [
             (11, "details.db", {1: {"guid": "guid-1", "result_count": 10}}),
-            (11, "details.db", {2: {"guid": "guid-2", "result_count": 20, "storage_bytes": 1000}}),
+            (11, "details.db", {
+                2: {
+                    "guid": "guid-2",
+                    "result_count": 20,
+                    "storage_bytes": 1000,
+                    "storage_bytes_estimated": True,
+                    },
+                }),
             ])
         self.assertEqual(statuses, [
             (11, "Loading run details... 0/2"),
@@ -4199,7 +4207,11 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             self.assertTrue(callable(connection_callback))
             calls.append(("storage", database_path, run_ids, batch_size))
             if 1 in run_ids:
-                yield {1: {"guid": "guid-1", "storage_bytes": 2000}}
+                yield {1: {
+                    "guid": "guid-1",
+                    "storage_bytes": 2000,
+                    "storage_bytes_estimated": False,
+                    }}
 
         database_module.iter_run_shape_batches_via_sql = iter_shapes
         database_module.iter_run_storage_batches_via_sql = iter_storage
@@ -4229,7 +4241,13 @@ class DatabaseLoadWorkerTestCase(unittest.TestCase):
             ])
         self.assertEqual(batches, [
             (12, "details.db", {1: {"guid": "guid-1", "setpoint_shape": [10], "setpoint_count": 10}}),
-            (12, "details.db", {1: {"guid": "guid-1", "storage_bytes": 2000}}),
+            (12, "details.db", {
+                1: {
+                    "guid": "guid-1",
+                    "storage_bytes": 2000,
+                    "storage_bytes_estimated": False,
+                    },
+                }),
             ])
         self.assertEqual(statuses, [
             (12, "Loading setpoint shapes... 0/2"),


### PR DESCRIPTION
## Summary

- honor `include_storage_bytes=False` even after a watched run completes
- return explicit exact, estimated, or unavailable storage accuracy from the storage helper
- keep cheap estimates responsive while allowing expensive exact results to replace them
- preserve exact RunList values when later estimates arrive
- propagate interrupted exact storage scans instead of converting them into estimates

## Root cause

`get_run_status()` used `if include_storage_bytes or is_completed`, so completion polling performed a `dbstat` scan even though `DatabaseRefreshWorker` explicitly excluded storage. Separately, `_table_storage_bytes()` could fall back to a schema estimate while callers always labelled its result exact.

## Query behavior

Before this fix, a completed-run status request with `include_storage_bytes=False` still entered `_table_storage_bytes()`, issued a `dbstat` query, and could issue schema/count queries for a fallback estimate.

After this fix, that polling path performs no storage helper call, no `dbstat` query, and no storage-estimation query. Explicit storage requests still perform the calculation; cheap detail workers request estimates explicitly and expensive detail workers retain exact work.

## Validation

- focused readSQL/database-worker/RunList regressions: 16 passed
- complete test suite: 693 passed
- Ruff: passed
- mypy: passed (63 source files)
- qPlot runtime smoke launch from `.venv-mac`: passed
