### PR TITLE
Prevent stale SQLite sidecars during database publication

### DIFF
--- a/docs/demo-data.md
+++ b/docs/demo-data.md
@@ -70,7 +70,16 @@ frequencies along the two sweep axes, producing varied plane-wave patterns.
 The measured parameter name, label, unit, sweep ranges, and point counts are set
 in the CSV. Existing CSV or database files are not replaced unless
 `--overwrite` is supplied. Collection export also refuses to replace existing
-collection files without `--overwrite`.
+collection files without `--overwrite`. Even with `--overwrite`, database
+generation refuses publication if the destination changed while generation was
+running or if a `-wal`, `-shm`, or `-journal` sidecar is present. Close the
+application using that database, or choose another output path; qPlot never
+removes or modifies those destination sidecars. Every generated test database
+carries an internal publication marker, so a fresh qPlot process also treats
+any later WAL as unpaired and reads the generated main immutably. If a
+sidecar is detected after the atomic swap, qPlot restores the old main and
+retains an explicit `.qplot-publishing` safety guard until the owning SQLite
+application has resolved the sidecars.
 
 Run `qplot-generate-db --help` for the complete command reference.
 

--- a/src/qplot/datahandling/file_identity.py
+++ b/src/qplot/datahandling/file_identity.py
@@ -2,6 +2,7 @@
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TypeAlias
 
 DatabaseFileIdentity: TypeAlias = (
@@ -9,6 +10,9 @@ DatabaseFileIdentity: TypeAlias = (
     | tuple[str, int, int]
     | tuple[str, str, int]
 )
+DATABASE_PUBLICATION_GUARD_SUFFIX = ".qplot-publishing"
+QPLOT_GENERATED_DATABASE_APPLICATION_ID = 0x51504C54
+_SQLITE_APPLICATION_ID_OFFSET = 68
 
 
 def logical_database_path(database_path: str | os.PathLike[str]) -> str:
@@ -20,6 +24,27 @@ def logical_database_path(database_path: str | os.PathLike[str]) -> str:
 def canonical_database_path(database_path: str | os.PathLike[str]) -> str:
     """Return the currently resolved, platform-normalised database path."""
     return os.path.normcase(os.path.realpath(os.path.abspath(os.fspath(database_path))))
+
+
+def database_publication_guard_path(
+        database_path: str | os.PathLike[str],
+        ) -> Path:
+    """Return qPlot's path-local guard for an in-flight main-file replacement."""
+
+    return Path(f"{logical_database_path(database_path)}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+
+
+def database_has_qplot_generation_marker(
+        database_path: str | os.PathLike[str],
+        ) -> bool:
+    """Return whether the main header marks a qPlot-generated database."""
+    with open(database_path, "rb") as database_file:
+        database_file.seek(_SQLITE_APPLICATION_ID_OFFSET)
+        application_id = database_file.read(4)
+    return application_id == QPLOT_GENERATED_DATABASE_APPLICATION_ID.to_bytes(
+        4,
+        "big",
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -282,7 +282,8 @@ def _require_publication_complete(database_path):
         ) from error
     raise ReadOnlyDatabaseAccessError(
         "Test-database publication is still in progress or needs recovery. "
-        "Retry after generation finishes; qPlot did not open the database or "
+        "If generation has stopped, follow its recovery instructions before "
+        "removing the publication guard. qPlot did not open the database or "
         "its SQLite sidecars."
     )
 

--- a/src/qplot/datahandling/readonly.py
+++ b/src/qplot/datahandling/readonly.py
@@ -12,6 +12,8 @@ from qcodes.dataset.sqlite.database import connect, get_DB_debug, get_DB_locatio
 from qplot.datahandling.file_identity import (
     DatabaseFileIdentity,
     database_file_identity,
+    database_has_qplot_generation_marker,
+    database_publication_guard_path,
 )
 from qplot.datahandling.qcodes_compat import result_owns_supplied_connection
 
@@ -119,6 +121,17 @@ def _require_expected_database_instance(database_path, expected_database_identit
     )
 
 
+def _require_prepared_database_instance(database_path, prepared_database_identity):
+    """Bind publication-marker and WAL decisions to one main-file identity."""
+    if database_file_identity(database_path) == prepared_database_identity:
+        return
+    quarantine_wal_for_replaced_database(database_path)
+    raise DatabaseInstanceChangedError(
+        "The database was replaced while qPlot was selecting a read-only view. "
+        "Refresh to retry; qPlot did not combine the replacement with a prior WAL."
+    )
+
+
 def configure_read_only_sqlite_connection(conn):
     """Keep read-only SQLite scans from growing qPlot's memory footprint."""
     pragmas = (
@@ -156,11 +169,13 @@ def qcodes_read_only_connection(
         )
         conn = None
         try:
+            _require_publication_complete(source_path)
             conn = connect(
                 _qcodes_uri_path(target_path, immutable=immutable),
                 get_DB_debug(),
                 read_only=True,
                 )
+            _require_publication_complete(source_path)
             _require_expected_database_instance(
                 source_path,
                 expected_database_identity,
@@ -186,6 +201,13 @@ def qcodes_read_only_connection(
             conn.close()
             continue
 
+        try:
+            _require_publication_complete(source_path)
+        except Exception:
+            conn.close()
+            if snapshot is not None:
+                snapshot.cleanup()
+            raise
         conn.path_to_dbfile = str(source_path)
         if snapshot is not None:
             _attach_snapshot_cleanup(conn, snapshot)
@@ -247,6 +269,24 @@ def _resolved_database_path(database_path):
     return Path(database_path).resolve()
 
 
+def _require_publication_complete(database_path):
+    """Reject a view while qPlot is replacing the database main file."""
+    guard_path = database_publication_guard_path(database_path)
+    try:
+        guard_path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        raise ReadOnlyDatabaseAccessError(
+            f"Could not prove that database publication is complete: {error}"
+        ) from error
+    raise ReadOnlyDatabaseAccessError(
+        "Test-database publication is still in progress or needs recovery. "
+        "Retry after generation finishes; qPlot did not open the database or "
+        "its SQLite sidecars."
+    )
+
+
 def _sqlite_uri_path(database_path):
     """Return an absolute, URI-escaped SQLite path without the ``file:`` prefix."""
     return _resolved_database_path(database_path).as_uri().removeprefix("file:")
@@ -285,12 +325,14 @@ def sqlite_read_only_connection(
         )
         conn = None
         try:
+            _require_publication_complete(source_path)
             conn = sqlite3.connect(
                 sqlite_read_only_uri(target_path, immutable=immutable),
                 timeout=timeout,
                 uri=True,
                 **kwargs,
                 )
+            _require_publication_complete(source_path)
             _require_expected_database_instance(
                 source_path,
                 expected_database_identity,
@@ -316,6 +358,13 @@ def sqlite_read_only_connection(
             conn.close()
             continue
 
+        try:
+            _require_publication_complete(source_path)
+        except Exception:
+            conn.close()
+            if snapshot is not None:
+                snapshot.cleanup()
+            raise
         if snapshot is not None:
             attach_snapshot = getattr(conn, "attach_snapshot", None)
             if not callable(attach_snapshot):
@@ -324,7 +373,7 @@ def sqlite_read_only_connection(
                 raise TypeError(
                     "A custom SQLite connection factory used for a live WAL "
                     "database must provide attach_snapshot()."
-                    )
+                )
             attach_snapshot(snapshot)
         return configure_read_only_sqlite_connection(conn)
 
@@ -408,8 +457,9 @@ def _prepare_read_target(
         *,
         ignore_unpaired_wal=False,
         expected_database_identity=None,
-        ):
+    ):
     """Select immutable static access or make a stable private WAL snapshot."""
+    _require_publication_complete(database_path)
     if not database_path.is_file():
         raise FileNotFoundError(database_path)
 
@@ -417,14 +467,41 @@ def _prepare_read_target(
         database_path,
         expected_database_identity,
     )
+    prepared_database_identity = database_file_identity(database_path)
+    if prepared_database_identity is None:
+        raise FileNotFoundError(database_path)
+
+    try:
+        generation_marker = database_has_qplot_generation_marker(database_path)
+    except OSError as error:
+        raise ReadOnlyDatabaseAccessError(
+            f"Could not inspect the database publication marker: {error}"
+        ) from error
+    if generation_marker:
+        # The marker is embedded before qPlot publishes a generated main, so it
+        # survives CLI/API process boundaries. Quarantine the whole logical
+        # path before looking for a WAL: a stale WAL can appear, disappear, or
+        # be copied into a private snapshot between any two pathname checks.
+        # Immutable access to the marked main is the only source-preserving
+        # way to ensure no later first load combines it with an old WAL.
+        quarantine_wal_for_replaced_database(database_path)
+        ignore_unpaired_wal = True
 
     wal_path = _wal_path(database_path)
     if ignore_unpaired_wal or replacement_wal_is_quarantined(database_path):
+        _require_prepared_database_instance(
+            database_path,
+            prepared_database_identity,
+        )
         return database_path, True, None, True
     if not wal_path.exists():
         _require_expected_database_instance(
             database_path,
             expected_database_identity,
+        )
+        _require_prepared_database_instance(
+            database_path,
+            prepared_database_identity,
         )
         return database_path, True, None, False
 
@@ -440,6 +517,10 @@ def _prepare_read_target(
             _require_expected_database_instance(
                 database_path,
                 expected_database_identity,
+            )
+            _require_prepared_database_instance(
+                database_path,
+                prepared_database_identity,
             )
             return (
                 database_path,
@@ -467,6 +548,10 @@ def _prepare_read_target(
                 _require_expected_database_instance(
                     database_path,
                     expected_database_identity,
+                )
+                _require_prepared_database_instance(
+                    database_path,
+                    prepared_database_identity,
                 )
             except Exception:
                 snapshot.cleanup()

--- a/src/qplot/testdata.py
+++ b/src/qplot/testdata.py
@@ -739,9 +739,18 @@ def _restore_database_backup(backup_path, database_path):
     try:
         os.replace(backup_path, database_path)
     except OSError as error:
+        guard_path = database_publication_guard_path(database_path)
         raise OSError(
-            "Could not restore the previous database after an unsafe "
-            "publication race; the qPlot publication guard was left in place"
+            f"Cannot publish {database_path}: database active or SQLite "
+            "sidecars present. qPlot could not restore the previous database "
+            "main because the replacement path is still active. The selected "
+            f"path may contain the replacement; the prior main is retained at "
+            f"{backup_path} unless qPlot's final retry restored it. The safety "
+            f"guard {guard_path} remains. Close every application using the "
+            "database and have the owning SQLite/QCoDeS application resolve "
+            "all -wal, -shm, and -journal files before recovering the prior "
+            "main or removing only that guard. qPlot did not modify or remove "
+            "the SQLite sidecars."
         ) from error
 
 

--- a/src/qplot/testdata.py
+++ b/src/qplot/testdata.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import csv
+import errno
 import math
 import os
 import re
 import sqlite3
+import stat
 import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -20,6 +22,11 @@ import numpy as np
 from qcodes.dataset import Measurement, new_experiment
 from qcodes.dataset.sqlite.database import connect
 from qcodes.parameters import ManualParameter
+
+from qplot.datahandling.file_identity import (
+    QPLOT_GENERATED_DATABASE_APPLICATION_ID,
+    database_publication_guard_path,
+)
 
 CSV_COLUMNS = (
     "dimensions",
@@ -96,6 +103,18 @@ _SINUSOID_COMPONENT_COUNT = 2
 _RESULT_CHUNK_POINTS = 10_000
 _TEMPORARY_DATABASE_PREFIX = ".qplot-testdata-"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+_SQLITE_HEADER = b"SQLite format 3\x00"
+_SQLITE_ROLLBACK_JOURNAL_VERSIONS = b"\x01\x01"
+_REPLACEMENT_BUSY_ERRNOS = frozenset(
+    value
+    for value in (
+        errno.EACCES,
+        errno.EBUSY,
+        errno.EPERM,
+        getattr(errno, "ETXTBSY", None),
+    )
+    if value is not None
+)
 
 
 class SpecificationError(ValueError):
@@ -366,16 +385,20 @@ def _connect_writable_exact_path(database_path):
     return connect(_qcodes_uri_name(database_path))
 
 
-def _owned_temporary_artifacts(temporary_path):
-    yield temporary_path
+def _owned_temporary_artifacts(temporary_path, *, include_database=True):
+    if include_database:
+        yield temporary_path
     for suffix in _SQLITE_SIDECAR_SUFFIXES:
         yield Path(f"{temporary_path}{suffix}")
 
 
-def _remove_owned_temporary_artifacts(temporary_path):
+def _remove_owned_temporary_artifacts(temporary_path, *, include_database=True):
     """Remove only the generator-owned database and its possible sidecars."""
     failures = []
-    for artifact_path in _owned_temporary_artifacts(temporary_path):
+    for artifact_path in _owned_temporary_artifacts(
+            temporary_path,
+            include_database=include_database,
+            ):
         try:
             artifact_path.unlink(missing_ok=True)
         except OSError as error:
@@ -385,6 +408,82 @@ def _remove_owned_temporary_artifacts(temporary_path):
         raise OSError(
             f"Could not remove generator-owned temporary files: {failed_paths}"
         ) from failures[0][1]
+
+
+def _destination_entry_state(database_path):
+    """Return a race-sensitive identity for the selected directory entry."""
+    try:
+        status = database_path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise _unsafe_publication_error(database_path) from error
+    return (
+        status.st_dev,
+        status.st_ino,
+        status.st_mode,
+        status.st_size,
+        status.st_mtime_ns,
+        status.st_ctime_ns,
+    )
+
+
+def _destination_sidecars(database_path):
+    """Return every existing sidecar entry without following symlinks."""
+    sidecars = []
+    for suffix in _SQLITE_SIDECAR_SUFFIXES:
+        sidecar_path = Path(f"{database_path}{suffix}")
+        try:
+            sidecar_path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            # An inspection failure is not evidence that the entry is absent.
+            # Publication must therefore fail closed without touching it.
+            raise _unsafe_publication_error(database_path) from error
+        sidecars.append(sidecar_path)
+    return tuple(sidecars)
+
+
+def _unsafe_publication_error(database_path, sidecars=()):
+    details = ""
+    if sidecars:
+        details = " Detected: " + ", ".join(path.name for path in sidecars) + "."
+    return SpecificationError(
+        f"Cannot publish {database_path}: database active or SQLite sidecars "
+        "present. Close every application using this database and have the "
+        "owning SQLite/QCoDeS application resolve any -wal, -shm, or -journal "
+        f"files, then retry or choose another output path.{details} qPlot did "
+        "not change the destination database or its SQLite sidecars."
+    )
+
+
+def _ambiguous_sidecar_race_error(database_path, guard_path, sidecars):
+    if sidecars:
+        details = " Detected after replacement: " + ", ".join(
+            path.name for path in sidecars
+        ) + "."
+    else:
+        details = (
+            " A post-install safety check failed; a transient sidecar cannot "
+            "be ruled out."
+        )
+    return SpecificationError(
+        f"Cannot publish {database_path}: database active or SQLite sidecars "
+        f"present.{details} qPlot restored the "
+        "previous database main and did not change the sidecars, but cannot "
+        "prove which main they belong to. To prevent a stale main/WAL pairing, "
+        f"qPlot left the safety guard {guard_path}. Close every application "
+        "using the database, have the owning SQLite/QCoDeS application resolve "
+        "the sidecars, then remove only that .qplot-publishing guard and retry "
+        "or choose another output path."
+    )
+
+
+def _require_safe_destination_sidecars(database_path):
+    sidecars = _destination_sidecars(database_path)
+    if sidecars:
+        raise _unsafe_publication_error(database_path, sidecars)
 
 
 def _result_chunks(point_count):
@@ -518,25 +617,403 @@ def _write_run(
     return points_written
 
 
-def _publish_database(temporary_path, database_path, overwrite):
-    """Publish a generated database atomically with optional no-clobber."""
-    if overwrite:
-        os.replace(temporary_path, database_path)
-        return
+def _require_rollback_journal_database(database_path):
+    """Reject destinations that cannot be locked without creating sidecars."""
+    try:
+        status = database_path.lstat()
+        with database_path.open("rb") as handle:
+            header = handle.read(20)
+    except OSError as error:
+        raise _unsafe_publication_error(database_path) from error
+    if (
+            not stat.S_ISREG(status.st_mode)
+            or not header.startswith(_SQLITE_HEADER)
+            or header[18:20] != _SQLITE_ROLLBACK_JOURNAL_VERSIONS
+            ):
+        # A persistent WAL-mode main can have no sidecars while quiescent, but
+        # BEGIN EXCLUSIVE would create its WAL/SHM. Rejecting it is the only
+        # source-preserving choice; the user can choose a new output path.
+        raise _unsafe_publication_error(database_path)
+
+
+def _open_quiescent_destination(
+        database_path,
+        expected_destination_state,
+        lock_path,
+        ):
+    """Hold SQLite's own exclusive inode lock through a private alias."""
+    _require_safe_destination_sidecars(database_path)
+    if _destination_entry_state(database_path) != expected_destination_state:
+        raise _unsafe_publication_error(database_path)
+    _require_rollback_journal_database(lock_path)
+    connection = None
+    try:
+        connection = sqlite3.connect(
+            f"file:{_qcodes_uri_name(lock_path)}?mode=rw",
+            uri=True,
+            isolation_level=None,
+            timeout=0,
+        )
+        # The alias is a hardlink to the destination inode, so SQLite's
+        # VFS-specific EXCLUSIVE lock conflicts with real readers/writers. Its
+        # recovery and journal lookup, however, uses the private alias name.
+        # A destination -journal racing into this call is therefore never
+        # opened, recovered, modified, or deleted by qPlot; the recheck below
+        # observes it and rejects publication.
+        connection.execute("BEGIN EXCLUSIVE")
+    except sqlite3.Error as error:
+        if connection is not None:
+            connection.close()
+        raise _unsafe_publication_error(database_path) from error
 
     try:
-        # Both paths are in the same directory. Creating the destination hard
-        # link is atomic and fails if another process won the destination race.
-        os.link(temporary_path, database_path)
-    except FileExistsError as error:
-        raise SpecificationError(
-            f"{database_path} already exists; use --overwrite to replace it"
-        ) from error
+        _require_safe_destination_sidecars(database_path)
+        if _destination_entry_state(database_path) != expected_destination_state:
+            raise _unsafe_publication_error(database_path)
+    except Exception:
+        connection.close()
+        raise
+    return connection
+
+
+def _close_publication_connection(connection):
+    if connection is None:
+        return
+    try:
+        connection.rollback()
+    except sqlite3.Error:
+        pass
+    try:
+        connection.close()
+    except sqlite3.Error:
+        pass
+
+
+def _create_publication_guard(database_path):
+    """Create the qPlot-visible guard for the short replacement transaction."""
+    guard_path = database_publication_guard_path(database_path)
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(guard_path, flags, 0o600)
+    except OSError as error:
+        raise _unsafe_publication_error(database_path) from error
+    try:
+        os.close(descriptor)
+    except OSError as error:
+        # Ownership starts at os.open, not when this helper returns. Otherwise
+        # a reported close failure could strand an untracked guard and block
+        # every later read/retry.
+        try:
+            guard_path.unlink()
+        except OSError:
+            pass
+        raise _unsafe_publication_error(database_path) from error
+    return guard_path
+
+
+def _create_database_backup_link(database_path):
+    """Keep the old main inode available for a sidecar-race rollback."""
+    handle = tempfile.NamedTemporaryFile(
+        prefix=_TEMPORARY_DATABASE_PREFIX,
+        suffix=".backup",
+        dir=database_path.parent,
+        delete=False,
+    )
+    backup_path = Path(handle.name)
+    handle.close()
+    backup_path.unlink()
+    try:
+        # This private alias lets SQLite lock the old inode without consulting
+        # destination-named journals, and lets the publisher atomically restore
+        # that exact inode if a post-install safety check fails.
+        os.link(database_path, backup_path)
+    except OSError as error:
+        backup_path.unlink(missing_ok=True)
+        raise _unsafe_publication_error(database_path) from error
+    return backup_path
+
+
+def _restore_database_backup(backup_path, database_path):
+    """Atomically restore the old main without touching any sidecar."""
+    try:
+        os.replace(backup_path, database_path)
     except OSError as error:
         raise OSError(
-            "Could not atomically publish the generated database without "
-            "overwriting an existing file"
+            "Could not restore the previous database after an unsafe "
+            "publication race; the qPlot publication guard was left in place"
         ) from error
+
+
+def _replace_database_file(
+        temporary_path,
+        database_path,
+        expected_destination_state,
+        ):
+    """Replace a proven-quiescent main and roll back any sidecar race."""
+    guard_path = _create_publication_guard(database_path)
+    backup_path = None
+    connection = None
+    replacement_installed = False
+    guard_must_remain = False
+    ambiguous_sidecars = ()
+    try:
+        _require_safe_destination_sidecars(database_path)
+        if _destination_entry_state(database_path) != expected_destination_state:
+            raise _unsafe_publication_error(database_path)
+        _require_rollback_journal_database(database_path)
+        backup_path = _create_database_backup_link(database_path)
+        backup_state = _destination_entry_state(backup_path)
+        locked_destination_state = _destination_entry_state(database_path)
+        if (
+                backup_state is None
+                or locked_destination_state is None
+                or backup_state[:5] != expected_destination_state[:5]
+                or locked_destination_state != backup_state
+                or not os.path.samefile(database_path, backup_path)
+                ):
+            raise _unsafe_publication_error(database_path)
+
+        connection = _open_quiescent_destination(
+            database_path,
+            locked_destination_state,
+            backup_path,
+        )
+        # Windows does not permit replacing the main while this connection is
+        # open. Closing it is safe there because any competing SQLite handle
+        # likewise prevents os.replace. POSIX keeps the VFS lock across replace.
+        if os.name == "nt":
+            _close_publication_connection(connection)
+            connection = None
+
+        _require_safe_destination_sidecars(database_path)
+        if not os.path.samefile(database_path, backup_path):
+            raise _unsafe_publication_error(database_path)
+
+        try:
+            os.replace(temporary_path, database_path)
+        except OSError as error:
+            if error.errno in _REPLACEMENT_BUSY_ERRNOS:
+                raise _unsafe_publication_error(database_path) from error
+            raise
+        replacement_installed = True
+
+        try:
+            # This postcondition is essential: a non-cooperating filesystem
+            # actor can create a sidecar in the final check/replace syscall gap.
+            # qPlot readers see the guard throughout this interval. If a
+            # sidecar appeared, restore the byte-identical old inode and leave
+            # that externally owned sidecar exactly as it was created.
+            ambiguous_sidecars = _destination_sidecars(database_path)
+            if ambiguous_sidecars:
+                raise _unsafe_publication_error(
+                    database_path,
+                    ambiguous_sidecars,
+                )
+            backup_after_replace = _destination_entry_state(backup_path)
+            if (
+                    backup_after_replace is None
+                    or backup_after_replace[:5] != backup_state[:5]
+                    ):
+                raise _unsafe_publication_error(database_path)
+            ambiguous_sidecars = _destination_sidecars(database_path)
+            if ambiguous_sidecars:
+                raise _unsafe_publication_error(
+                    database_path,
+                    ambiguous_sidecars,
+                )
+        except Exception as error:
+            # Once a post-install postcondition fails, absence observed later
+            # cannot prove that a transient sidecar did not belong to the new
+            # main. Keep the guard even if rollback itself needs a retry.
+            guard_must_remain = True
+            _restore_database_backup(backup_path, database_path)
+            backup_path = None
+            replacement_installed = False
+            if not ambiguous_sidecars:
+                try:
+                    ambiguous_sidecars = _destination_sidecars(database_path)
+                except SpecificationError as inspection_error:
+                    # Inspection itself is unsafe, so retain the guard exactly
+                    # as for an observed sidecar. A fresh process must not guess.
+                    guard_must_remain = True
+                    raise _ambiguous_sidecar_race_error(
+                        database_path,
+                        guard_path,
+                        (),
+                    ) from inspection_error
+            # A sidecar observed after the swap could belong to either the old
+            # or new main. Even if none is visible now, a failed postcondition
+            # cannot rule out a transient one. The guard is therefore
+            # persistent recovery state, not a disposable generator temporary.
+            guard_must_remain = True
+            raise _ambiguous_sidecar_race_error(
+                database_path,
+                guard_path,
+                ambiguous_sidecars,
+            ) from error
+
+        # Keep SQLite's old-inode EXCLUSIVE lock through commit on POSIX. A
+        # cooperating old SQLite connection cannot create a stale sidecar in
+        # the check/unlink gap; on Windows, a handle overlapping os.replace
+        # makes that syscall fail. No portable filesystem syscall atomically
+        # conditions a main-file replace on three sibling paths, so the main's
+        # embedded replacement marker is the cross-process backstop: qPlot
+        # permanently quarantines WAL access for this identity even if a raw
+        # filesystem actor bypasses SQLite's lock after the last check.
+        try:
+            guard_path.unlink()
+        except OSError as error:
+            guard_must_remain = True
+            _restore_database_backup(backup_path, database_path)
+            backup_path = None
+            replacement_installed = False
+            try:
+                ambiguous_sidecars = _destination_sidecars(database_path)
+            except SpecificationError as inspection_error:
+                guard_must_remain = True
+                raise _ambiguous_sidecar_race_error(
+                    database_path,
+                    guard_path,
+                    (),
+                ) from inspection_error
+            raise _ambiguous_sidecar_race_error(
+                database_path,
+                guard_path,
+                ambiguous_sidecars,
+            ) from error
+        guard_path = None
+        _close_publication_connection(connection)
+        connection = None
+        replacement_installed = False
+
+        # Publication is now committed. Failure to remove this private name
+        # must not turn a completed replacement into a reported rejection.
+        try:
+            backup_path.unlink()
+        except OSError:
+            pass
+        else:
+            backup_path = None
+    finally:
+        _close_publication_connection(connection)
+        if replacement_installed and backup_path is not None:
+            guard_must_remain = True
+            try:
+                _restore_database_backup(backup_path, database_path)
+            except OSError:
+                # Keep both the backup and publication guard for manual recovery.
+                guard_must_remain = True
+            else:
+                backup_path = None
+                replacement_installed = False
+                try:
+                    guard_must_remain = (
+                        guard_must_remain
+                        or bool(_destination_sidecars(database_path))
+                    )
+                except SpecificationError:
+                    guard_must_remain = True
+        if backup_path is not None and not replacement_installed:
+            try:
+                backup_path.unlink()
+            except OSError:
+                pass
+        if (
+                guard_path is not None
+                and not guard_must_remain
+                and not replacement_installed
+                ):
+            try:
+                guard_path.unlink()
+            except OSError:
+                pass
+
+
+def _link_database_file(temporary_path, database_path):
+    """Publish a previously absent output with a guarded postcondition."""
+    guard_path = _create_publication_guard(database_path)
+    destination_linked = False
+    try:
+        _require_safe_destination_sidecars(database_path)
+        if _destination_entry_state(database_path) is not None:
+            raise SpecificationError(
+                f"{database_path} already exists; use --overwrite to replace it"
+            )
+        try:
+            # The hard link is an atomic no-clobber publish because the
+            # generator temporary lives in the destination directory.
+            os.link(temporary_path, database_path)
+        except FileExistsError as error:
+            raise SpecificationError(
+                f"{database_path} already exists; use --overwrite to replace it"
+            ) from error
+        except OSError as error:
+            raise OSError(
+                "Could not atomically publish the generated database without "
+                "overwriting an existing file"
+            ) from error
+        destination_linked = True
+
+        # An orphan sidecar can be copied into place in the link syscall gap.
+        # Since the old state was absence, rolling back only our own hard link
+        # restores it without touching the externally owned sidecar.
+        _require_safe_destination_sidecars(database_path)
+        guard_path.unlink()
+        guard_path = None
+        destination_linked = False
+    finally:
+        if destination_linked:
+            try:
+                owns_destination = os.path.samefile(
+                    temporary_path,
+                    database_path,
+                )
+            except OSError:
+                owns_destination = False
+            if owns_destination:
+                try:
+                    database_path.unlink()
+                except OSError as error:
+                    # Keep the guard: qPlot must not open a main whose rollback
+                    # could not be proved after a sidecar publication race.
+                    raise OSError(
+                        "Could not roll back an unsafe new database publication; "
+                        "the qPlot publication guard was left in place"
+                    ) from error
+                destination_linked = False
+        if guard_path is not None and not destination_linked:
+            try:
+                guard_path.unlink()
+            except OSError:
+                pass
+
+
+def _publish_database(
+        temporary_path,
+        database_path,
+        overwrite,
+        expected_destination_state=None,
+        ):
+    """Publish a generated database atomically with optional no-clobber."""
+    _require_safe_destination_sidecars(database_path)
+    if overwrite:
+        # A changed directory entry means the user's overwrite decision no
+        # longer describes the file now at this path. Reject rather than
+        # replacing an unexamined concurrent owner. The replacement helper then
+        # obtains SQLite's own exclusive lock and enforces a rollback-capable
+        # postcondition across the final filesystem operation.
+        if _destination_entry_state(database_path) != expected_destination_state:
+            raise _unsafe_publication_error(database_path)
+        if expected_destination_state is not None:
+            _replace_database_file(
+                temporary_path,
+                database_path,
+                expected_destination_state,
+            )
+            return
+
+    _link_database_file(temporary_path, database_path)
 
 
 def generate_database(
@@ -554,10 +1031,12 @@ def generate_database(
     database_path = Path(database_path)
     if database_path.suffix.lower() != ".db":
         raise SpecificationError("Database output path must end in .db")
-    if database_path.exists() and not overwrite:
+    expected_destination_state = _destination_entry_state(database_path)
+    if expected_destination_state is not None and not overwrite:
         raise SpecificationError(
             f"{database_path} already exists; use --overwrite to replace it"
         )
+    _require_safe_destination_sidecars(database_path)
 
     database_path.parent.mkdir(parents=True, exist_ok=True)
     random_generator = rng if rng is not None else np.random.default_rng()
@@ -569,6 +1048,7 @@ def generate_database(
         f"({total_runs} runs, {total_points} points)."
     )
     temporary_path = None
+    publication_completed = False
     try:
         try:
             temporary_handle = tempfile.NamedTemporaryFile(
@@ -624,13 +1104,45 @@ def generate_database(
                         f"Run stopped (completed): run_{run_number} in "
                         f"{perf_counter() - run_started:.2f} s."
                     )
+                # This marker lives in the generator-owned main before either
+                # publication path. A fresh qPlot process can therefore ignore
+                # any WAL that appears after the final sidecar check instead of
+                # trusting that it belongs to this new main.
+                connection.execute(
+                    "PRAGMA application_id = "
+                    f"{QPLOT_GENERATED_DATABASE_APPLICATION_ID}"
+                )
                 _raise_if_cancelled(cancelled_callback)
             finally:
                 connection.close()
-            _publish_database(temporary_path, database_path, overwrite)
+            # Sidecar cleanup is fallible, so complete it before the atomic
+            # publication boundary. No cleanup failure may be reported as a
+            # rejected publication after the destination has already changed.
+            _remove_owned_temporary_artifacts(
+                temporary_path,
+                include_database=False,
+            )
+            _publish_database(
+                temporary_path,
+                database_path,
+                overwrite,
+                expected_destination_state,
+            )
+            publication_completed = True
         finally:
             if temporary_path is not None:
-                _remove_owned_temporary_artifacts(temporary_path)
+                try:
+                    _remove_owned_temporary_artifacts(temporary_path)
+                except Exception:
+                    if not publication_completed:
+                        raise
+                    # Publication is committed and must still be reported as
+                    # success, but retry once so a transient unlink failure
+                    # does not strand a generator-owned hardlink/sidecar.
+                    try:
+                        _remove_owned_temporary_artifacts(temporary_path)
+                    except Exception:
+                        pass
     except GenerationCancelled:
         _timestamped_message(
             "Test database generation stopped (cancelled) after "
@@ -645,10 +1157,15 @@ def generate_database(
         )
         raise
 
-    _timestamped_message(
-        "Test database generation stopped (completed) in "
-        f"{perf_counter() - generation_started:.2f} s: {database_path}."
-    )
+    try:
+        _timestamped_message(
+            "Test database generation stopped (completed) in "
+            f"{perf_counter() - generation_started:.2f} s: {database_path}."
+        )
+    except Exception:
+        # Publication is already committed; a closed output stream must not
+        # turn success into an apparent failure after replacing the database.
+        pass
     return database_path
 
 

--- a/src/qplot/windows/_database_actions.py
+++ b/src/qplot/windows/_database_actions.py
@@ -21,6 +21,7 @@ from qplot.datahandling.file_identity import (
     DatabaseInstance,
     database_instance,
     database_instances_differ,
+    database_publication_guard_path,
     logical_database_path,
 )
 from qplot.datahandling.readonly import (
@@ -64,6 +65,17 @@ def _database_observations_differ(first, second):
     first_identity = getattr(first, "identity", first)
     second_identity = getattr(second, "identity", second)
     return _database_instances_differ(first_identity, second_identity)
+
+
+def _database_publication_is_guarded(database_path):
+    """Fail closed if publication is in flight or its guard cannot be inspected."""
+    try:
+        database_publication_guard_path(database_path).lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return True
 
 
 class DatabaseInfoDialog(qtw.QDialog):
@@ -445,14 +457,17 @@ class DatabaseActionsMixin:
             # qPlot deliberately replaces this source. Release its read-only
             # dataset handles before the worker publishes the temporary file:
             # Windows otherwise forbids replacing a database that qPlot still
-            # has open. The replacement completion path reloads the same view.
+            # has open. Publication can still be rejected, so this preparation
+            # must not mark the unchanged database as replaced or quarantine
+            # its WAL. The completion path decides which kind of reload is
+            # required after publication has either succeeded or failed.
             prepare_replacement = getattr(
                 self,
                 "_prepare_replaced_database_reload",
                 None,
             )
             if callable(prepare_replacement):
-                prepare_replacement(database_path)
+                prepare_replacement(database_path, quarantine=False)
 
         self._test_database_generation_active = True
         action = getattr(self, "generateTestDatabaseAction", None)
@@ -493,6 +508,19 @@ class DatabaseActionsMixin:
                 "Could not generate the test database.",
                 str(error),
             )
+            file_textbox = getattr(self, "fileTextbox", None)
+            current_database = file_textbox.text() if file_textbox is not None else ""
+            if (
+                    current_database
+                    and canonical_database_path(current_database)
+                    == canonical_database_path(database_path)
+                    and not _database_publication_is_guarded(database_path)
+                    ):
+                # The publication protocol preserves the old main file and all
+                # pre-existing sidecars on rejection. Restore the view whose
+                # handles were released before generation unless the publisher
+                # retained its guard after an ambiguous sidecar race.
+                self.load_file(database_path, force=True)
             return
 
         run_count = len(specifications)
@@ -510,6 +538,11 @@ class DatabaseActionsMixin:
                 and canonical_database_path(current_database)
                 == canonical_database_path(database_path)
                 ):
+            # Publication succeeded, so the identity really did change. Mark
+            # the replacement before the first reload read; this retains the
+            # read-side defence against an unpaired WAL if an external actor
+            # manages to recreate one after publication.
+            quarantine_wal_for_replaced_database(database_path)
             self.load_file(database_path, force=True)
 
 
@@ -1169,10 +1202,17 @@ class DatabaseActionsMixin:
         return True
 
 
-    def _prepare_replaced_database_reload(self, abspath):
-        """Discard every runtime object tied to a replaced file instance."""
+    def _prepare_replaced_database_reload(self, abspath, *, quarantine=True):
+        """Discard runtime objects before a database is deliberately replaced.
+
+        Test-data generation calls this with ``quarantine=False`` before its
+        worker starts. At that point publication has not happened and may be
+        rejected, so marking the existing instance as replaced would make
+        later reads incorrectly ignore its valid WAL.
+        """
         old_instance = getattr(self, "_loaded_database_instance", None)
-        quarantine_wal_for_replaced_database(abspath)
+        if quarantine:
+            quarantine_wal_for_replaced_database(abspath)
         self.monitor.stop()
         self._cancel_database_detail_load()
 

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -1318,10 +1318,11 @@ def test_post_replace_sidecar_restore_failure_retains_recovery_artifacts(
     assert restore_attempts
     backup_path = backup_paths[0]
     message = str(error_info.value)
+    normalized_message = os.path.normcase(message)
     assert "database active or SQLite sidecars present" in message
-    assert str(database_path) in message
-    assert str(guard_path) in message
-    assert str(backup_path) in message or ".backup" in message
+    assert os.path.normcase(str(database_path)) in normalized_message
+    assert os.path.normcase(str(guard_path)) in normalized_message
+    assert os.path.normcase(str(backup_path)) in normalized_message
     assert "selected path may contain the replacement" in message.lower()
 
     artifacts = artifact_bytes_and_mtimes(database_path)

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -1196,20 +1196,35 @@ def test_post_replace_wal_restores_old_main_and_retains_safety_guard(
     monkeypatch,
 ):
     database_path = tmp_path / "post-replace-wal.db"
+    wal_path = Path(f"{database_path}-wal")
     testdata_module.generate_database([small_specification()], database_path)
     old_main = artifact_bytes_and_mtimes(database_path)[""]
     original_replace = os.replace
-    replacement_writers = []
+    replacement_wals = []
 
     def replace_then_commit_new_wal(source_path, destination_path):
         result = original_replace(source_path, destination_path)
-        if Path(destination_path) == database_path and not replacement_writers:
+        if Path(destination_path) == database_path and not replacement_wals:
             writer = sqlite3.connect(database_path)
-            assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
-            writer.execute("PRAGMA wal_autocheckpoint = 0")
-            writer.execute("UPDATE runs SET name = 'NEW_WAL'")
-            writer.commit()
-            replacement_writers.append(writer)
+            try:
+                assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+                writer.execute("PRAGMA wal_autocheckpoint = 0")
+                writer.execute("UPDATE runs SET name = 'NEW_WAL'")
+                writer.commit()
+                wal_contents = wal_path.read_bytes()
+            finally:
+                writer.close()
+
+            # Windows cannot atomically restore the old main while this writer
+            # holds the replacement open. Re-create its captured WAL only after
+            # closing it: the sidecar is still genuinely from the replacement,
+            # and pairing it with the restored old main remains ambiguous.
+            wal_path.write_bytes(wal_contents)
+            controlled_mtime_ns = 1_700_000_000_000_000_000
+            os.utime(wal_path, ns=(controlled_mtime_ns, controlled_mtime_ns))
+            replacement_wals.append(
+                (wal_path.read_bytes(), wal_path.stat().st_mtime_ns)
+            )
         return result
 
     monkeypatch.setattr(
@@ -1218,31 +1233,114 @@ def test_post_replace_wal_restores_old_main_and_retains_safety_guard(
         replace_then_commit_new_wal,
     )
 
-    try:
-        with pytest.raises(
-            SpecificationError,
-            match="database active or SQLite sidecars present",
-        ) as error_info:
-            testdata_module.generate_database(
-                [small_specification()],
-                database_path,
-                overwrite=True,
-            )
-
-        guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
-        assert "cannot prove which main they belong to" in str(error_info.value)
-        assert artifact_bytes_and_mtimes(database_path)[""] == old_main
-        assert immutable_run_name(database_path) == "run_1"
-        assert guard_path.is_file()
-        with pytest.raises(ReadOnlyDatabaseAccessError):
-            qplot_run_name(database_path)
-        assert not any(
-            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
-            for path in tmp_path.iterdir()
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ) as error_info:
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
         )
-    finally:
-        for writer in replacement_writers:
-            writer.close()
+
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    assert "cannot prove which main they belong to" in str(error_info.value)
+    assert len(replacement_wals) == 1
+    artifacts = artifact_bytes_and_mtimes(database_path)
+    assert artifacts[""] == old_main
+    assert artifacts["-wal"] == replacement_wals[0]
+    assert immutable_run_name(database_path) == "run_1"
+    assert guard_path.is_file()
+    with pytest.raises(ReadOnlyDatabaseAccessError):
+        qplot_run_name(database_path)
+    assert not any(
+        path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+        for path in tmp_path.iterdir()
+    )
+
+
+def test_post_replace_sidecar_restore_failure_retains_recovery_artifacts(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "failed-restore.db"
+    sidecar_path = Path(f"{database_path}-wal")
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    testdata_module.generate_database([small_specification()], database_path)
+    old_main = artifact_bytes_and_mtimes(database_path)[""]
+    original_replace = os.replace
+    replacement_main = []
+    injected_sidecar = []
+    backup_paths = []
+    backup_states = []
+    restore_attempts = []
+
+    def install_then_fail_backup_restore(source_path, destination_path):
+        source_path = Path(source_path)
+        destination_path = Path(destination_path)
+        if destination_path == database_path and source_path.suffix == ".backup":
+            if not backup_paths:
+                backup_paths.append(source_path)
+                backup_states.append(
+                    (source_path.read_bytes(), source_path.stat().st_mtime_ns)
+                )
+            restore_attempts.append(source_path)
+            raise OSError("injected backup restore failure")
+
+        result = original_replace(source_path, destination_path)
+        if destination_path == database_path and not replacement_main:
+            replacement_main.append(artifact_bytes_and_mtimes(database_path)[""])
+            sidecar_path.write_bytes(b"ambiguous WAL from replacement main")
+            controlled_mtime_ns = 1_700_000_000_000_000_000
+            os.utime(sidecar_path, ns=(controlled_mtime_ns, controlled_mtime_ns))
+            injected_sidecar.append(
+                (sidecar_path.read_bytes(), sidecar_path.stat().st_mtime_ns)
+            )
+        return result
+
+    monkeypatch.setattr(
+        testdata_module.os,
+        "replace",
+        install_then_fail_backup_restore,
+    )
+
+    with pytest.raises(OSError) as error_info:
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
+        )
+
+    assert len(replacement_main) == 1
+    assert replacement_main[0] != old_main
+    assert len(injected_sidecar) == 1
+    assert len(backup_paths) == 1
+    assert restore_attempts
+    backup_path = backup_paths[0]
+    message = str(error_info.value)
+    assert "database active or SQLite sidecars present" in message
+    assert str(database_path) in message
+    assert str(guard_path) in message
+    assert str(backup_path) in message or ".backup" in message
+    assert "selected path may contain the replacement" in message.lower()
+
+    artifacts = artifact_bytes_and_mtimes(database_path)
+    assert artifacts[""] == replacement_main[0]
+    assert artifacts["-wal"] == injected_sidecar[0]
+    assert guard_path.is_file()
+    assert backup_path.is_file()
+    assert (backup_path.read_bytes(), backup_path.stat().st_mtime_ns) == (
+        backup_states[0]
+    )
+    assert backup_states[0] == old_main
+    with pytest.raises(ReadOnlyDatabaseAccessError):
+        qplot_run_name(database_path)
+    assert set(tmp_path.iterdir()) == {
+        database_path,
+        sidecar_path,
+        guard_path,
+        backup_path,
+    }
 
 
 def test_overwrite_succeeds_for_quiescent_database(tmp_path):

--- a/tests/test_testdata.py
+++ b/tests/test_testdata.py
@@ -1,7 +1,10 @@
 import csv
 import os
 import re
+import shutil
 import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -12,6 +15,16 @@ from qcodes.dataset.measurements import DataSaver
 from qcodes.dataset.sqlite.connection import AtomicConnection
 
 from qplot import testdata as testdata_module
+from qplot.datahandling import readonly as readonly_module
+from qplot.datahandling.file_identity import (
+    DATABASE_PUBLICATION_GUARD_SUFFIX,
+    database_has_qplot_generation_marker,
+)
+from qplot.datahandling.readonly import (
+    DatabaseInstanceChangedError,
+    ReadOnlyDatabaseAccessError,
+    qcodes_read_only_connection,
+)
 from qplot.testdata import (
     CSV_COLUMNS,
     INSTRUCTION_FILE_NAMES,
@@ -57,13 +70,78 @@ def owned_temporary_artifacts(directory):
     return sorted(
         path
         for path in directory.iterdir()
-        if path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+        if (
+            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+            or path.name.endswith(DATABASE_PUBLICATION_GUARD_SUFFIX)
+        )
     )
 
 
 def create_all_temporary_sidecars(temporary_path):
     for suffix in testdata_module._SQLITE_SIDECAR_SUFFIXES:
         Path(f"{temporary_path}{suffix}").write_bytes(suffix.encode("ascii"))
+
+
+def artifact_bytes_and_mtimes(database_path):
+    artifacts = {}
+    for suffix in ("", *testdata_module._SQLITE_SIDECAR_SUFFIXES):
+        artifact_path = Path(f"{database_path}{suffix}")
+        if artifact_path.exists():
+            contents = artifact_path.read_bytes()
+            artifacts[suffix] = (contents, artifact_path.stat().st_mtime_ns)
+    return artifacts
+
+
+def immutable_run_name(database_path):
+    connection = sqlite3.connect(
+        f"{Path(database_path).resolve().as_uri()}?mode=ro&immutable=1",
+        uri=True,
+    )
+    try:
+        return connection.execute("SELECT name FROM runs").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def qplot_run_name(database_path):
+    connection = qcodes_read_only_connection(database_path)
+    try:
+        return connection.execute("SELECT name FROM runs").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def create_hot_rollback_journal(database_path):
+    """Crash a venv subprocess after spilling an uncommitted transaction."""
+    crash_script = "\n".join(
+        (
+            "import os",
+            "import sqlite3",
+            "import sys",
+            "connection = sqlite3.connect(sys.argv[1])",
+            "connection.execute('PRAGMA journal_mode = DELETE')",
+            "connection.execute('PRAGMA synchronous = FULL')",
+            "connection.execute('PRAGMA cache_size = 1')",
+            "connection.execute('BEGIN IMMEDIATE')",
+            "connection.execute(\"UPDATE runs SET name = 'UNCOMMITTED'\")",
+            "connection.execute('CREATE TABLE hot_journal_filler(i, payload)')",
+            "for index in range(100):",
+            "    connection.execute(",
+            "        'INSERT INTO hot_journal_filler VALUES (?, ?)',",
+            "        (index, 'x' * 10000),",
+            "    )",
+            "os._exit(0)",
+        )
+    )
+    subprocess.run(
+        [sys.executable, "-c", crash_script, str(database_path)],
+        check=True,
+        timeout=30,
+    )
+    journal_path = Path(f"{database_path}-journal")
+    journal_contents = journal_path.read_bytes()
+    assert journal_contents.startswith(b"\xd9\xd5\x05\xf9 \xa1c\xd7")
+    return journal_contents
 
 
 def test_example_csv_is_ready_to_generate(tmp_path):
@@ -693,7 +771,12 @@ def test_publication_failure_removes_all_owned_temporary_sidecars(
 ):
     database_path = tmp_path / "runs.db"
 
-    def fail_publication(temporary_path, _database_path, _overwrite):
+    def fail_publication(
+        temporary_path,
+        _database_path,
+        _overwrite,
+        _expected_destination_state,
+    ):
         create_all_temporary_sidecars(temporary_path)
         raise RuntimeError("injected publication failure")
 
@@ -704,6 +787,29 @@ def test_publication_failure_removes_all_owned_temporary_sidecars(
 
     assert not database_path.exists()
     assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_publication_guard_close_failure_removes_created_guard(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "guard-close-failure.db"
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    original_close = os.close
+
+    def close_then_report_failure(descriptor):
+        original_close(descriptor)
+        raise OSError("injected close failure")
+
+    monkeypatch.setattr(testdata_module.os, "close", close_then_report_failure)
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module._create_publication_guard(database_path)
+
+    assert not guard_path.exists()
 
 
 def test_cancellation_removes_all_owned_temporary_sidecars(tmp_path):
@@ -725,7 +831,7 @@ def test_cancellation_removes_all_owned_temporary_sidecars(tmp_path):
     assert owned_temporary_artifacts(tmp_path) == []
 
 
-def test_overwrite_publish_replaces_concurrently_created_file(
+def test_overwrite_publish_rejects_concurrently_created_file(
     tmp_path,
     monkeypatch,
 ):
@@ -743,13 +849,701 @@ def test_overwrite_publish_replaces_concurrently_created_file(
         write_run_after_competitor_arrives,
     )
 
-    testdata_module.generate_database(
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
+        )
+
+    assert database_path.read_bytes() == b"concurrent owner"
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_overwrite_rejects_active_wal_without_changing_destination(tmp_path):
+    database_path = tmp_path / "active-wal.db"
+    testdata_module.generate_database([small_specification()], database_path)
+
+    writer = sqlite3.connect(database_path)
+    try:
+        assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("UPDATE runs SET name = 'OLD_WAL'")
+        writer.commit()
+
+        assert immutable_run_name(database_path) == "run_1"
+        before = artifact_bytes_and_mtimes(database_path)
+        assert set(before) == {"", "-wal", "-shm"}
+
+        with pytest.raises(
+            SpecificationError,
+            match="database active or SQLite sidecars present",
+        ):
+            testdata_module.generate_database(
+                [small_specification()],
+                database_path,
+                overwrite=True,
+            )
+
+        assert artifact_bytes_and_mtimes(database_path) == before
+        assert owned_temporary_artifacts(tmp_path) == []
+
+        # A private ordinary SQLite copy proves the preserved WAL still carries
+        # OLD_WAL. qPlot deliberately reads every generated main immutable, so
+        # its first load cannot combine that main with any unproven WAL.
+        probe_directory = tmp_path / "active-wal-probe"
+        probe_directory.mkdir()
+        probe_path = probe_directory / "probe.db"
+        shutil.copyfile(database_path, probe_path)
+        shutil.copyfile(Path(f"{database_path}-wal"), Path(f"{probe_path}-wal"))
+        probe = sqlite3.connect(probe_path)
+        try:
+            assert probe.execute("SELECT name FROM runs").fetchone()[0] == "OLD_WAL"
+        finally:
+            probe.close()
+        assert qplot_run_name(database_path) == "run_1"
+        assert artifact_bytes_and_mtimes(database_path) == before
+    finally:
+        writer.close()
+
+
+def test_overwrite_rejects_rollback_journal_without_changing_destination(tmp_path):
+    database_path = tmp_path / "active-journal.db"
+    testdata_module.generate_database([small_specification()], database_path)
+
+    writer = sqlite3.connect(database_path)
+    try:
+        assert writer.execute("PRAGMA journal_mode = DELETE").fetchone()[0] == "delete"
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute("UPDATE runs SET name = 'UNCOMMITTED'")
+        journal_path = Path(f"{database_path}-journal")
+        assert journal_path.is_file()
+        before = artifact_bytes_and_mtimes(database_path)
+        assert set(before) == {"", "-journal"}
+
+        with pytest.raises(
+            SpecificationError,
+            match="database active or SQLite sidecars present",
+        ):
+            testdata_module.generate_database(
+                [small_specification()],
+                database_path,
+                overwrite=True,
+            )
+
+        assert artifact_bytes_and_mtimes(database_path) == before
+        assert owned_temporary_artifacts(tmp_path) == []
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+def test_overwrite_does_not_recover_hot_journal_racing_during_lock(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "hot-journal-race.db"
+    journal_source_path = tmp_path / "hot-journal-source.db"
+    journal_path = Path(f"{database_path}-journal")
+    testdata_module.generate_database([small_specification()], database_path)
+    shutil.copyfile(database_path, journal_source_path)
+    parked_journal = create_hot_rollback_journal(journal_source_path)
+    main_before = artifact_bytes_and_mtimes(database_path)[""]
+    original_connect = sqlite3.connect
+    injected_journal = []
+
+    def connect_after_hot_journal_arrives(database, *args, **kwargs):
+        if ".backup?mode=rw" in str(database) and not injected_journal:
+            journal_path.write_bytes(parked_journal)
+            controlled_mtime_ns = 1_700_000_000_000_000_000
+            os.utime(
+                journal_path,
+                ns=(controlled_mtime_ns, controlled_mtime_ns),
+            )
+            injected_journal.append(
+                (journal_path.read_bytes(), journal_path.stat().st_mtime_ns)
+            )
+        return original_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(
+        testdata_module.sqlite3,
+        "connect",
+        connect_after_hot_journal_arrives,
+    )
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
+        )
+
+    assert len(injected_journal) == 1
+    after = artifact_bytes_and_mtimes(database_path)
+    assert after[""] == main_before
+    assert after["-journal"] == injected_journal[0]
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_overwrite_rejects_writer_before_rollback_journal_exists(tmp_path):
+    database_path = tmp_path / "reserved-writer.db"
+    testdata_module.generate_database([small_specification()], database_path)
+
+    writer = sqlite3.connect(database_path)
+    try:
+        writer.execute("BEGIN IMMEDIATE")
+        assert not Path(f"{database_path}-journal").exists()
+        before = artifact_bytes_and_mtimes(database_path)
+
+        with pytest.raises(
+            SpecificationError,
+            match="database active or SQLite sidecars present",
+        ):
+            testdata_module.generate_database(
+                [small_specification()],
+                database_path,
+                overwrite=True,
+            )
+
+        assert artifact_bytes_and_mtimes(database_path) == before
+        assert owned_temporary_artifacts(tmp_path) == []
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+def test_overwrite_rejects_quiescent_wal_mode_without_creating_sidecars(tmp_path):
+    database_path = tmp_path / "quiescent-wal.db"
+    testdata_module.generate_database([small_specification()], database_path)
+    connection = sqlite3.connect(database_path)
+    try:
+        assert connection.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+    finally:
+        connection.close()
+    before = artifact_bytes_and_mtimes(database_path)
+    assert set(before) == {""}
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
+        )
+
+    assert artifact_bytes_and_mtimes(database_path) == before
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+@pytest.mark.parametrize("suffix", testdata_module._SQLITE_SIDECAR_SUFFIXES)
+def test_new_database_rejects_orphaned_destination_sidecar(tmp_path, suffix):
+    database_path = tmp_path / "orphaned.db"
+    sidecar_path = Path(f"{database_path}{suffix}")
+    sidecar_path.write_bytes(f"orphaned {suffix}".encode("ascii"))
+    controlled_mtime_ns = 1_700_000_000_000_000_000
+    os.utime(sidecar_path, ns=(controlled_mtime_ns, controlled_mtime_ns))
+    before = (sidecar_path.read_bytes(), sidecar_path.stat().st_mtime_ns)
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+        )
+
+    assert not database_path.exists()
+    assert (sidecar_path.read_bytes(), sidecar_path.stat().st_mtime_ns) == before
+    assert set(tmp_path.iterdir()) == {sidecar_path}
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_new_database_rolls_back_sidecar_racing_at_atomic_link(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "link-race.db"
+    sidecar_path = Path(f"{database_path}-wal")
+    original_link = os.link
+    raced_sidecar = []
+
+    def link_after_sidecar_arrives(source_path, destination_path):
+        if Path(destination_path) == database_path and not raced_sidecar:
+            sidecar_path.write_bytes(b"orphan copied at link boundary")
+            controlled_mtime_ns = 1_700_000_000_000_000_000
+            os.utime(sidecar_path, ns=(controlled_mtime_ns, controlled_mtime_ns))
+            raced_sidecar.append(
+                (sidecar_path.read_bytes(), sidecar_path.stat().st_mtime_ns)
+            )
+        return original_link(source_path, destination_path)
+
+    monkeypatch.setattr(testdata_module.os, "link", link_after_sidecar_arrives)
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+        )
+
+    assert not database_path.exists()
+    assert (sidecar_path.read_bytes(), sidecar_path.stat().st_mtime_ns) == (
+        raced_sidecar[0]
+    )
+    assert set(tmp_path.iterdir()) == {sidecar_path}
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_cli_reports_sidecar_rejection_without_changing_destination(
+    tmp_path,
+    capsys,
+):
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "cli-active.db"
+    write_specification(
+        csv_path,
+        [("1", "current", "Current", "nA", "-1", "1", "5", "", "", "")],
+    )
+    testdata_module.generate_database([small_specification()], database_path)
+    journal_path = Path(f"{database_path}-journal")
+    journal_path.write_bytes(b"owned by another SQLite process")
+    before = artifact_bytes_and_mtimes(database_path)
+
+    with pytest.raises(SystemExit) as exit_info:
+        main([str(csv_path), str(database_path), "--overwrite"])
+
+    assert exit_info.value.code == 2
+    assert "database active or SQLite sidecars present" in capsys.readouterr().err
+    assert artifact_bytes_and_mtimes(database_path) == before
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_overwrite_rejects_when_sidecar_appears_at_final_replace(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "racing-sidecar.db"
+    sidecar_path = Path(f"{database_path}-wal")
+    testdata_module.generate_database([small_specification()], database_path)
+    old_main = artifact_bytes_and_mtimes(database_path)[""]
+    original_replace = os.replace
+    raced_sidecar = []
+    blocked_qplot_reads = []
+
+    def replace_after_sidecar_arrives(source_path, destination_path):
+        if Path(destination_path) == database_path and not raced_sidecar:
+            sidecar_path.write_bytes(b"sidecar created at final replace boundary")
+            controlled_mtime_ns = 1_700_000_000_000_000_000
+            os.utime(
+                sidecar_path,
+                ns=(controlled_mtime_ns, controlled_mtime_ns),
+            )
+            raced_sidecar.append(artifact_bytes_and_mtimes(database_path)["-wal"])
+            result = original_replace(source_path, destination_path)
+            assert database_path.read_bytes() != old_main[0]
+            with pytest.raises(ReadOnlyDatabaseAccessError):
+                qplot_run_name(database_path)
+            blocked_qplot_reads.append(True)
+            return result
+        return original_replace(source_path, destination_path)
+
+    monkeypatch.setattr(
+        testdata_module.os,
+        "replace",
+        replace_after_sidecar_arrives,
+    )
+
+    with pytest.raises(
+        SpecificationError,
+        match="database active or SQLite sidecars present",
+    ):
+        testdata_module.generate_database(
+            [small_specification()],
+            database_path,
+            overwrite=True,
+        )
+
+    assert len(raced_sidecar) == 1
+    assert blocked_qplot_reads == [True]
+    assert artifact_bytes_and_mtimes(database_path) == {
+        "": old_main,
+        "-wal": raced_sidecar[0],
+    }
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    assert guard_path.is_file()
+    with pytest.raises(ReadOnlyDatabaseAccessError):
+        qplot_run_name(database_path)
+    assert set(tmp_path.iterdir()) == {database_path, sidecar_path, guard_path}
+    assert not any(
+        path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+        for path in tmp_path.iterdir()
+    )
+
+
+def test_post_replace_wal_restores_old_main_and_retains_safety_guard(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "post-replace-wal.db"
+    testdata_module.generate_database([small_specification()], database_path)
+    old_main = artifact_bytes_and_mtimes(database_path)[""]
+    original_replace = os.replace
+    replacement_writers = []
+
+    def replace_then_commit_new_wal(source_path, destination_path):
+        result = original_replace(source_path, destination_path)
+        if Path(destination_path) == database_path and not replacement_writers:
+            writer = sqlite3.connect(database_path)
+            assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+            writer.execute("PRAGMA wal_autocheckpoint = 0")
+            writer.execute("UPDATE runs SET name = 'NEW_WAL'")
+            writer.commit()
+            replacement_writers.append(writer)
+        return result
+
+    monkeypatch.setattr(
+        testdata_module.os,
+        "replace",
+        replace_then_commit_new_wal,
+    )
+
+    try:
+        with pytest.raises(
+            SpecificationError,
+            match="database active or SQLite sidecars present",
+        ) as error_info:
+            testdata_module.generate_database(
+                [small_specification()],
+                database_path,
+                overwrite=True,
+            )
+
+        guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+        assert "cannot prove which main they belong to" in str(error_info.value)
+        assert artifact_bytes_and_mtimes(database_path)[""] == old_main
+        assert immutable_run_name(database_path) == "run_1"
+        assert guard_path.is_file()
+        with pytest.raises(ReadOnlyDatabaseAccessError):
+            qplot_run_name(database_path)
+        assert not any(
+            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+            for path in tmp_path.iterdir()
+        )
+    finally:
+        for writer in replacement_writers:
+            writer.close()
+
+
+def test_overwrite_succeeds_for_quiescent_database(tmp_path):
+    database_path = tmp_path / "quiescent.db"
+    testdata_module.generate_database([small_specification()], database_path)
+    original_contents = database_path.read_bytes()
+    assert artifact_bytes_and_mtimes(database_path).keys() == {""}
+    replacement = testdata_module.RunSpecification(
+        1,
+        "replacement",
+        "Replacement",
+        "V",
+        -2.0,
+        2.0,
+        7,
+    )
+
+    generated_path = testdata_module.generate_database(
+        [replacement],
+        database_path,
+        overwrite=True,
+    )
+
+    assert generated_path == database_path
+    assert database_path.read_bytes() != original_contents
+    assert database_has_qplot_generation_marker(database_path)
+    connection = sqlite3.connect(database_path)
+    try:
+        assert connection.execute(
+            "SELECT parameter FROM layouts ORDER BY layout_id"
+        ).fetchall() == [("V_SD",), ("replacement",)]
+    finally:
+        connection.close()
+    assert artifact_bytes_and_mtimes(database_path).keys() == {""}
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_first_load_quarantines_valid_wal_created_after_final_check(
+    tmp_path,
+    monkeypatch,
+):
+    wal_source_path = tmp_path / "wal-source.db"
+    testdata_module.generate_database([small_specification()], wal_source_path)
+    wal_source_writer = sqlite3.connect(wal_source_path)
+    try:
+        assert wal_source_writer.execute(
+            "PRAGMA journal_mode = WAL"
+        ).fetchone()[0] == "wal"
+        wal_source_writer.execute("PRAGMA wal_autocheckpoint = 0")
+        wal_source_writer.execute("UPDATE runs SET name = 'OLD_WAL'")
+        wal_source_writer.commit()
+        parked_wal = Path(f"{wal_source_path}-wal").read_bytes()
+        parked_shm = Path(f"{wal_source_path}-shm").read_bytes()
+    finally:
+        wal_source_writer.close()
+
+    database_path = tmp_path / "last-gap-sidecar.db"
+    sidecar_path = Path(f"{database_path}-wal")
+    shm_path = Path(f"{database_path}-shm")
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    testdata_module.generate_database([small_specification()], database_path)
+    original_unlink = Path.unlink
+    injected = []
+
+    def unlink_guard_after_sidecar_appears(path, *args, **kwargs):
+        if path == guard_path and not injected:
+            sidecar_path.write_bytes(parked_wal)
+            shm_path.write_bytes(parked_shm)
+            injected.append(True)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", unlink_guard_after_sidecar_appears)
+
+    generated_path = testdata_module.generate_database(
         [small_specification()],
         database_path,
         overwrite=True,
     )
 
+    assert generated_path == database_path
+    assert injected == [True]
+    assert database_has_qplot_generation_marker(database_path)
+    assert not guard_path.exists()
+    sidecars_before = artifact_bytes_and_mtimes(database_path)
+    probe_directory = tmp_path / "unsafe-probe"
+    probe_directory.mkdir()
+    probe_path = probe_directory / "probe.db"
+    shutil.copyfile(database_path, probe_path)
+    shutil.copyfile(sidecar_path, Path(f"{probe_path}-wal"))
+    probe = sqlite3.connect(probe_path)
+    try:
+        assert probe.execute("SELECT name FROM runs").fetchone()[0] == "OLD_WAL"
+    finally:
+        probe.close()
+
+    assert immutable_run_name(database_path) == "run_1"
+    assert qplot_run_name(database_path) == "run_1"
+    assert artifact_bytes_and_mtimes(database_path) == sidecars_before
+
+
+def test_new_output_first_load_quarantines_wal_after_final_link_check(
+    tmp_path,
+    monkeypatch,
+):
+    wal_source_path = tmp_path / "new-output-wal-source.db"
+    testdata_module.generate_database([small_specification()], wal_source_path)
+    wal_source_writer = sqlite3.connect(wal_source_path)
+    try:
+        assert wal_source_writer.execute(
+            "PRAGMA journal_mode = WAL"
+        ).fetchone()[0] == "wal"
+        wal_source_writer.execute("PRAGMA wal_autocheckpoint = 0")
+        wal_source_writer.execute("UPDATE runs SET name = 'OLD_WAL'")
+        wal_source_writer.commit()
+        parked_wal = Path(f"{wal_source_path}-wal").read_bytes()
+        parked_shm = Path(f"{wal_source_path}-shm").read_bytes()
+    finally:
+        wal_source_writer.close()
+
+    database_path = tmp_path / "new-output-last-gap.db"
+    wal_path = Path(f"{database_path}-wal")
+    shm_path = Path(f"{database_path}-shm")
+    guard_path = Path(f"{database_path}{DATABASE_PUBLICATION_GUARD_SUFFIX}")
+    original_unlink = Path.unlink
+    injected = []
+
+    def unlink_guard_after_sidecars_appear(path, *args, **kwargs):
+        if path == guard_path and not injected:
+            wal_path.write_bytes(parked_wal)
+            shm_path.write_bytes(parked_shm)
+            injected.append(True)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", unlink_guard_after_sidecars_appear)
+
+    generated_path = testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+    )
+
+    assert generated_path == database_path
+    assert injected == [True]
+    assert database_has_qplot_generation_marker(database_path)
+    assert immutable_run_name(database_path) == "run_1"
+    sidecars_before = artifact_bytes_and_mtimes(database_path)
+    assert qplot_run_name(database_path) == "run_1"
+    assert artifact_bytes_and_mtimes(database_path) == sidecars_before
+
+
+def test_first_load_rejects_identity_changed_during_marker_read(
+    tmp_path,
+    monkeypatch,
+):
+    wal_source_path = tmp_path / "identity-race-wal-source.db"
+    testdata_module.generate_database([small_specification()], wal_source_path)
+    wal_source_writer = sqlite3.connect(wal_source_path)
+    try:
+        assert wal_source_writer.execute(
+            "PRAGMA journal_mode = WAL"
+        ).fetchone()[0] == "wal"
+        wal_source_writer.execute("PRAGMA wal_autocheckpoint = 0")
+        wal_source_writer.execute("UPDATE runs SET name = 'OLD_WAL'")
+        wal_source_writer.commit()
+        parked_wal = Path(f"{wal_source_path}-wal").read_bytes()
+    finally:
+        wal_source_writer.close()
+
+    replacement_path = tmp_path / "marked-replacement.db"
+    testdata_module.generate_database([small_specification()], replacement_path)
+    testdata_module.generate_database(
+        [small_specification()],
+        replacement_path,
+        overwrite=True,
+    )
+    assert database_has_qplot_generation_marker(replacement_path)
+
+    database_path = tmp_path / "marker-identity-race.db"
+    wal_path = Path(f"{database_path}-wal")
+    testdata_module.generate_database([small_specification()], database_path)
+    original_marker_check = readonly_module.database_has_qplot_generation_marker
+    replacement_installed = []
+
+    def replace_during_marker_read(path):
+        if Path(path) == database_path and not replacement_installed:
+            os.replace(replacement_path, database_path)
+            wal_path.write_bytes(parked_wal)
+            replacement_installed.append(True)
+            return False
+        return original_marker_check(path)
+
+    monkeypatch.setattr(
+        readonly_module,
+        "database_has_qplot_generation_marker",
+        replace_during_marker_read,
+    )
+
+    with pytest.raises(DatabaseInstanceChangedError):
+        qplot_run_name(database_path)
+
+    assert replacement_installed == [True]
+    assert immutable_run_name(database_path) == "run_1"
+    assert qplot_run_name(database_path) == "run_1"
+
+
+def test_post_commit_cleanup_error_does_not_report_rejected_publication(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "post-commit-cleanup.db"
+    testdata_module.generate_database([small_specification()], database_path)
+    original_cleanup = testdata_module._remove_owned_temporary_artifacts
+    post_commit_failures = []
+
+    def fail_only_after_publication(temporary_path, *, include_database=True):
+        original_cleanup(
+            temporary_path,
+            include_database=include_database,
+        )
+        if (
+            include_database
+            and database_path.exists()
+            and not post_commit_failures
+        ):
+            post_commit_failures.append(Path(temporary_path))
+            raise OSError("injected post-commit cleanup failure")
+
+    monkeypatch.setattr(
+        testdata_module,
+        "_remove_owned_temporary_artifacts",
+        fail_only_after_publication,
+    )
+
+    generated_path = testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+        overwrite=True,
+    )
+
+    assert generated_path == database_path
+    assert len(post_commit_failures) == 1
     assert_generated_database(database_path)
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_successful_overwrite_retries_transient_backup_cleanup_failure(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "backup-cleanup-retry.db"
+    testdata_module.generate_database([small_specification()], database_path)
+    original_unlink = Path.unlink
+    backup_unlink_attempts = []
+
+    def fail_first_committed_backup_unlink(path, *args, **kwargs):
+        if path.name.endswith(".backup"):
+            backup_unlink_attempts.append(path)
+            if len(backup_unlink_attempts) == 2:
+                raise OSError("injected transient backup cleanup failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_first_committed_backup_unlink)
+
+    generated_path = testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+        overwrite=True,
+    )
+
+    assert generated_path == database_path
+    assert len(backup_unlink_attempts) == 3
+    assert owned_temporary_artifacts(tmp_path) == []
+
+
+def test_successful_new_output_retries_transient_temporary_cleanup_failure(
+    tmp_path,
+    monkeypatch,
+):
+    database_path = tmp_path / "temporary-cleanup-retry.db"
+    original_unlink = Path.unlink
+    temporary_unlink_attempts = []
+
+    def fail_first_published_temporary_unlink(path, *args, **kwargs):
+        if (
+            path.name.startswith(testdata_module._TEMPORARY_DATABASE_PREFIX)
+            and path.suffix == ".db"
+            and path.exists()
+        ):
+            temporary_unlink_attempts.append(path)
+            if len(temporary_unlink_attempts) == 1:
+                raise OSError("injected transient temporary cleanup failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_first_published_temporary_unlink)
+
+    generated_path = testdata_module.generate_database(
+        [small_specification()],
+        database_path,
+    )
+
+    assert generated_path == database_path
+    assert len(temporary_unlink_attempts) == 2
     assert owned_temporary_artifacts(tmp_path) == []
 
 

--- a/tests/windows/test_testdata_gui.py
+++ b/tests/windows/test_testdata_gui.py
@@ -6,6 +6,7 @@ from PyQt6 import QtGui
 from PyQt6 import QtWidgets as qtw
 
 from qplot import testdata as testdata_module
+from qplot.datahandling.file_identity import database_publication_guard_path
 from qplot.testdata import CSV_COLUMNS, INSTRUCTION_FILE_NAMES
 from qplot.windows._database_actions import (
     DatabaseActionsMixin,
@@ -170,12 +171,16 @@ def test_generation_completion_force_reloads_replaced_current_database(tmp_path)
     specification = Mock(point_count=5)
 
     try:
-        harness.test_database_generation_finished(
-            str(database_path),
-            [specification],
-            None,
-        )
+        with patch(
+            "qplot.windows._database_actions.quarantine_wal_for_replaced_database"
+        ) as quarantine:
+            harness.test_database_generation_finished(
+                str(database_path),
+                [specification],
+                None,
+            )
 
+        quarantine.assert_called_once_with(str(database_path))
         harness.load_file.assert_called_once_with(str(database_path), force=True)
     finally:
         harness.deleteLater()
@@ -187,7 +192,20 @@ def test_generation_releases_current_database_before_replacing_it(tmp_path):
     output_directory = tmp_path / "loaded # %23 測定"
     output_directory.mkdir()
     database_path = output_directory / "runs#%3f 測定.db"
-    database_path.write_bytes(b"old database")
+    testdata_module.generate_database(
+        [
+            testdata_module.RunSpecification(
+                1,
+                "old_current",
+                "Old current",
+                "nA",
+                -1.0,
+                1.0,
+                3,
+            )
+        ],
+        database_path,
+    )
     write_small_specification(csv_path)
     harness.fileTextbox = type(
         "Field",
@@ -214,12 +232,18 @@ def test_generation_releases_current_database_before_replacing_it(tmp_path):
                 "question",
                 return_value=qtw.QMessageBox.StandardButton.Yes,
             ),
+            patch(
+                "qplot.windows._database_actions."
+                "quarantine_wal_for_replaced_database"
+            ) as quarantine,
         ):
             assert harness.generate_test_database_from_csv()
 
         harness._prepare_replaced_database_reload.assert_called_once_with(
-            str(database_path)
+            str(database_path),
+            quarantine=False,
         )
+        quarantine.assert_called_once_with(str(database_path))
         harness.load_file.assert_called_once_with(str(database_path), force=True)
         connection = sqlite3.connect(database_path)
         try:
@@ -228,6 +252,109 @@ def test_generation_releases_current_database_before_replacing_it(tmp_path):
             ]
         finally:
             connection.close()
+    finally:
+        harness.deleteLater()
+
+
+def test_failed_current_database_replacement_reloads_without_quarantine(tmp_path):
+    harness = GuiHarness(tmp_path)
+    csv_path = tmp_path / "runs.csv"
+    database_path = tmp_path / "runs.db"
+    database_path.write_bytes(b"unchanged database")
+    write_small_specification(csv_path)
+    harness.fileTextbox = type(
+        "Field",
+        (),
+        {"text": lambda _self: str(database_path)},
+    )()
+    harness._prepare_replaced_database_reload = Mock()
+
+    def reload_after_error(*args, **kwargs):
+        assert harness.errors
+        return True
+
+    harness.load_file = Mock(side_effect=reload_after_error)
+    publication_error = RuntimeError(
+        "database active or SQLite sidecars present; close database users and retry"
+    )
+
+    try:
+        with (
+            patch.object(
+                qtw.QFileDialog,
+                "getOpenFileName",
+                return_value=(str(csv_path), "CSV Files (*.csv)"),
+            ),
+            patch.object(
+                qtw.QFileDialog,
+                "getSaveFileName",
+                return_value=(str(database_path), "QCoDeS Database (*.db)"),
+            ),
+            patch.object(
+                qtw.QMessageBox,
+                "question",
+                return_value=qtw.QMessageBox.StandardButton.Yes,
+            ),
+            patch(
+                "qplot.windows._database_actions.generate_database",
+                side_effect=publication_error,
+            ),
+            patch(
+                "qplot.windows._database_actions."
+                "quarantine_wal_for_replaced_database"
+            ) as quarantine,
+        ):
+            assert harness.generate_test_database_from_csv()
+
+        harness._prepare_replaced_database_reload.assert_called_once_with(
+            str(database_path),
+            quarantine=False,
+        )
+        quarantine.assert_not_called()
+        harness.load_file.assert_called_once_with(str(database_path), force=True)
+        assert harness.errors == [
+            (
+                "Test Database Generation Failed",
+                "Could not generate the test database.",
+                str(publication_error),
+            )
+        ]
+        assert database_path.read_bytes() == b"unchanged database"
+    finally:
+        harness.deleteLater()
+
+
+def test_ambiguous_sidecar_failure_keeps_guarded_database_unloaded(tmp_path):
+    harness = GuiHarness(tmp_path)
+    database_path = tmp_path / "guarded.db"
+    database_path.write_bytes(b"restored database")
+    database_publication_guard_path(database_path).write_text(
+        "ambiguous sidecar race",
+        encoding="utf-8",
+    )
+    harness.fileTextbox = type(
+        "Field",
+        (),
+        {"text": lambda _self: str(database_path)},
+    )()
+    harness.load_file = Mock(return_value=True)
+    publication_error = RuntimeError(
+        "database active or SQLite sidecars present; safety guard retained"
+    )
+
+    try:
+        with patch(
+            "qplot.windows._database_actions.quarantine_wal_for_replaced_database"
+        ) as quarantine:
+            harness.test_database_generation_finished(
+                str(database_path),
+                [Mock(point_count=5)],
+                publication_error,
+            )
+
+        quarantine.assert_not_called()
+        harness.load_file.assert_not_called()
+        assert harness.errors[-1][2] == str(publication_error)
     finally:
         harness.deleteLater()
 


### PR DESCRIPTION
## Summary

- reject database publication when an existing destination is active or has `-wal`, `-shm`, or `-journal` sidecars
- guard and validate atomic publication, preserve the prior main and all sidecar contents on rejection, and retain a recovery guard after ambiguous post-swap races
- mark generated databases so the first qPlot read cannot combine a replacement main with an unpaired WAL, including across CLI/API process boundaries
- preserve the loaded-database GUI lifecycle on both successful publication and fail-closed rejection
- add regression coverage for active/orphaned sidecars, publication races, hot journals, artifact cleanup, quiescent overwrite, CLI behavior, and GUI reload behavior

## Root cause

`_publish_database` replaced only the SQLite main file. Existing WAL, SHM, or rollback-journal files survived and could then be interpreted alongside the unrelated replacement main. In the reproduced failure, the replacement main contained `run_1`, while the first qPlot read returned `OLD_WAL`.

## Validation

- focused publication/read-only/GUI tests: 100 passed, 3 existing QCoDeS warnings
- Ruff: all checks passed
- mypy: no issues in 63 source files
- full suite: 715 passed, 24 subtests passed, 3 existing QCoDeS warnings
- offscreen qPlot smoke start and normal close: exit status 0
- `git diff --check`: clean
