### PR TITLE
Prepare qPlot 1.5.1 beta 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ installation commands and release validation, see `docs/distribution.md`.
 
 ## Unreleased
 
+## 1.5.1-b2 - 2026-08-13
+
+### Changed
+
+- Show percentage progress and clearer per-run status while generating test
+  databases, including interrupted and failed runs.
+- Preserve the selected run and its details while database refreshes are
+  staged, updating the view only after the refreshed state is ready.
+- Validate source distributions by running their full test suite in an
+  isolated environment, and smoke-test installed wheels during package CI.
+
+### Fixed
+
+- Keep every input QCoDeS database strictly read-only, including when reading
+  live WAL-backed data, so viewing cannot create, modify, publish, or remove
+  SQLite `-wal`, `-shm`, or `-journal` sidecar files.
+- Publish generated test databases atomically without exposing stale SQLite
+  sidecars, and restore the original database and sidecars if replacement
+  fails.
+- Safely replace a generated database that is already loaded, including
+  through a symlink, while preserving unrelated open datasets and refreshing
+  plots against the replacement.
+- Prevent preview CSV exports and overwrite confirmations from acting on a
+  database that was replaced while the export was being prepared.
+- Prevent database reads from racing with same-path test-database generation.
+- Synchronize completion across plots sharing a live run, including runs that
+  finish without appending another data row.
+- Treat zero-row datasets as valid selections and avoid showing stale selected
+  run details after refreshes.
+- Resolve generated-database URI paths consistently and close temporary QCoDeS
+  loader connections without taking ownership of shared connections.
+- Save GUI configuration changes transactionally so a failed write does not
+  leave partial settings behind.
+
 ## 1.5.1-b1 - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ part of the GUI test or support matrix.
 
 Install qPlot inside a Python 3.11 or newer virtual environment:
 The commands below install the latest full release, `1.5.0`. The current beta
-is `1.5.1-b1`; it is documented below but is not used for the default install.
+is `1.5.1-b2`; it is documented below but is not used for the default install.
 
 Windows:
 
@@ -39,7 +39,7 @@ To test the current beta instead, install its explicit tag in the same virtual
 environment:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.1-b1
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.1-b2
 ```
 
 macOS:

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -26,13 +26,13 @@ Both commands expose the `qplot` and `qplot-cfg` entry points.
 
 ## Current Beta
 
-The current beta is `1.5.1-b1`. The package metadata uses the PEP 440 normal
-form `1.5.1b1`; the GitHub release tag should be `v1.5.1-b1`.
+The current beta is `1.5.1-b2`. The package metadata uses the PEP 440 normal
+form `1.5.1b2`; the GitHub release tag should be `v1.5.1-b2`.
 
 Beta test install:
 
 ```console
-python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.1-b1
+python -m pip install git+https://github.com/lairdgrouplancaster/QCoDeS-Plotter.git@v1.5.1-b2
 ```
 
 ## Current Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qplot"
-version = "1.5.1b1"
+version = "1.5.1b2"
 description = "PyQt-based viewer for completed and running QCoDeS database experiments"
 readme = "README.md"
 authors = [{name="Ben Wordsworth", email="b.wordsworth@lancaster.ac.uk"},{name="Edward Laird", email="e.a.laird@lancaster.ac.uk"}]


### PR DESCRIPTION
## What changed

- bump the package version to `1.5.1b2`
- update README and distribution guidance to use tag `v1.5.1-b2`
- add the 2026-08-13 beta 2 changelog covering database read-only safety, atomic test-database replacement, live-run synchronization, export race fixes, generator status improvements, transactional configuration, and package validation

## Why

This packages the fixes merged since `v1.5.1-b1` as the next beta candidate and makes the documented install path and release metadata consistent.

## Validation

- `python -m ruff check .`
- `python -m mypy`
- `python -m pytest` — 716 passed
- clean-tree distribution check
- source and wheel build
- extracted-sdist test suite — 716 passed
- wheel import/resource/entry-point and generator CLI smoke checks
- `twine check` on both artifacts
- qPlot GUI startup smoke check on macOS